### PR TITLE
add ReconnectionLockService ..

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,14 @@ function App() {
           <Router basename={getBasePath() || '/'}>
             <Routes>
               <Route path='/login' element={<Login />} />
-              <Route path='/oauth/callback' element={<OAuthCallback />} />
+              <Route
+                path='/oauth-callback'
+                element={
+                  <ProtectedRoute>
+                    <OAuthCallback />
+                  </ProtectedRoute>
+                }
+              />
               <Route
                 path='/'
                 element={

--- a/frontend/src/components/AgentCard.tsx
+++ b/frontend/src/components/AgentCard.tsx
@@ -14,7 +14,6 @@ import type React from 'react';
 import { useCallback, useState } from 'react';
 import HELPER from '@/helper';
 import AgentDetailsModal from './AgentDetailsModal';
-import StarRatingWidget from './StarRatingWidget';
 
 /**
  * Agent interface representing an A2A agent.
@@ -32,7 +31,6 @@ export interface Agent {
   last_checked_time?: string;
   usersCount?: number;
   rating?: number;
-  rating_details?: Array<{ user: string; rating: number }>;
   status?: 'healthy' | 'healthy-auth-expired' | 'unhealthy' | 'unknown';
 }
 
@@ -282,20 +280,6 @@ const AgentCard: React.FC<AgentCardProps> = ({
         {/* Stats */}
         <div className='px-5 pb-4'>
           <div className='grid grid-cols-2 gap-4'>
-            <StarRatingWidget
-              resourceType='agents'
-              path={agent.path}
-              initialRating={agent.rating || 0}
-              initialCount={agent.rating_details?.length || 0}
-              authToken={authToken}
-              onShowToast={onShowToast}
-              onRatingUpdate={newRating => {
-                // Update local agent rating when user submits rating
-                if (onAgentUpdate) {
-                  onAgentUpdate(agent.path, { rating: newRating });
-                }
-              }}
-            />
             <div className='flex items-center gap-2'>
               <div className='p-1.5 bg-cyan-50 dark:bg-cyan-900/30 rounded'>
                 <CpuChipIcon className='h-4 w-4 text-cyan-600 dark:text-cyan-400' />

--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -17,12 +17,10 @@ import type { Tool } from '@/services/server/type';
 import UTILS from '@/utils';
 import ServerAuthorizationModal from './ServerAuthorizationModal';
 import ServerConfigModal from './ServerConfigModal';
-import StarRatingWidget from './StarRatingWidget';
 
 interface ServerCardProps {
   server: ServerInfo;
   canModify?: boolean;
-  authToken?: string | null;
   onEdit?: (server: ServerInfo) => void;
   onShowToast: (message: string, type: 'success' | 'error') => void;
   onServerUpdate: (id: string, updates: Partial<ServerInfo>) => void;
@@ -32,7 +30,6 @@ interface ServerCardProps {
 const ServerCard: React.FC<ServerCardProps> = ({
   server,
   canModify,
-  authToken,
   onEdit,
   onShowToast,
   onServerUpdate,
@@ -89,8 +86,8 @@ const ServerCard: React.FC<ServerCardProps> = ({
       if (onServerUpdate && result) {
         const updates: Partial<ServerInfo> = {
           status: result.status,
-          last_checked_time: result.last_checked,
-          num_tools: result.num_tools,
+          last_checked_time: result.lastConnected,
+          num_tools: result.numTools,
         };
         onServerUpdate(server.id, updates);
       } else if (onRefreshSuccess) {
@@ -238,20 +235,6 @@ const ServerCard: React.FC<ServerCardProps> = ({
         {/* Stats */}
         <div className='px-4 pb-3'>
           <div className='grid grid-cols-2 gap-2'>
-            <StarRatingWidget
-              resourceType='servers'
-              path={server.path}
-              initialRating={server.num_stars || 0}
-              initialCount={server.rating_details?.length || 0}
-              authToken={authToken}
-              onShowToast={onShowToast}
-              onRatingUpdate={newRating => {
-                // Update local server rating when user submits rating
-                if (onServerUpdate) {
-                  onServerUpdate(server.id, { num_stars: newRating });
-                }
-              }}
-            />
             <div className='flex items-center gap-1.5'>
               {(server.num_tools || 0) > 0 ? (
                 <button

--- a/frontend/src/components/ServerFormDialog/ServerCreationSuccessDialog.tsx
+++ b/frontend/src/components/ServerFormDialog/ServerCreationSuccessDialog.tsx
@@ -12,7 +12,7 @@ interface ServerCreationSuccessDialogProps {
 
 const ServerCreationSuccessDialog: React.FC<ServerCreationSuccessDialogProps> = ({ isOpen, serverData, onClose }) => {
   const [copied, setCopied] = useState(false);
-  const redirectUri = `${window.location.protocol}//${window.location.host}${getBasePath()}/api/mcp/v1/${serverData.serverName}/oauth/callback`;
+  const redirectUri = `${window.location.protocol}//${window.location.host}${getBasePath()}/api/mcp/v1/${serverData.serverName}/oauth-callback`;
 
   const handleCopy = () => {
     navigator.clipboard.writeText(redirectUri);

--- a/frontend/src/components/ServerFormDialog/ServerFormDialog.tsx
+++ b/frontend/src/components/ServerFormDialog/ServerFormDialog.tsx
@@ -189,7 +189,6 @@ const ServerFormDialog: React.FC<ServerFormDialogProps> = ({
       path: data.path,
       url: data.url,
       tags: data.tags,
-      enabled: true,
       type: data.type,
     };
     switch (data.authConfig.type) {
@@ -200,9 +199,7 @@ const ServerFormDialog: React.FC<ServerFormDialogProps> = ({
           ...baseData,
           apiKey: {
             source: data.authConfig.source,
-            ...(data.authConfig.source !== 'user' && data.authConfig.key
-              ? { key: data.authConfig.key }
-              : {}),
+            ...(data.authConfig.source !== 'user' && data.authConfig.key ? { key: data.authConfig.key } : {}),
             authorization_type: data.authConfig.authorization_type,
             ...(data.authConfig.authorization_type === 'custom' && data.authConfig.custom_header
               ? { custom_header: data.authConfig.custom_header }

--- a/frontend/src/contexts/ServerContext.tsx
+++ b/frontend/src/contexts/ServerContext.tsx
@@ -24,7 +24,6 @@ export interface ServerInfo {
   is_python?: boolean;
   connection_state: SERVER_CONNECTION;
   requires_oauth: boolean;
-  rating_details?: [];
 }
 
 interface Agent {
@@ -158,7 +157,7 @@ export const ServerProvider: React.FC<ServerProviderProps> = ({ children }) => {
         official: serverInfo.is_official || false,
         enabled: serverInfo.enabled !== undefined ? serverInfo.enabled : false,
         tags: serverInfo.tags || [],
-        last_checked_time: serverInfo.updatedAt,
+        last_checked_time: serverInfo.lastConnected,
         usersCount: 0,
         rating: serverInfo.numStars || 0,
         status: serverInfo.status || 'unknown', // undefined

--- a/frontend/src/contexts/ServerContext.tsx
+++ b/frontend/src/contexts/ServerContext.tsx
@@ -166,7 +166,7 @@ export const ServerProvider: React.FC<ServerProviderProps> = ({ children }) => {
         num_stars: serverInfo.numStars || 0,
         is_python: serverInfo.is_python || false,
         requires_oauth: serverInfo.requiresOAuth,
-        connection_state: serverInfo.connection_state,
+        connection_state: serverInfo.connectionState,
       };
     });
   };

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -412,7 +412,6 @@ const Dashboard: React.FC = () => {
                       key={server.id}
                       server={server}
                       canModify={user?.can_modify_servers || false}
-                      authToken={agentApiToken}
                       onEdit={handleEditServer}
                       onShowToast={showToast}
                       onServerUpdate={handleServerUpdate}
@@ -518,7 +517,6 @@ const Dashboard: React.FC = () => {
                           key={server.id}
                           server={server}
                           canModify={user?.can_modify_servers || false}
-                          authToken={agentApiToken}
                           onEdit={handleEditServer}
                           onShowToast={showToast}
                           onServerUpdate={handleServerUpdate}

--- a/frontend/src/pages/OAuthCallback.tsx
+++ b/frontend/src/pages/OAuthCallback.tsx
@@ -1,7 +1,7 @@
 import { CheckCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 
 import logo from '@/assets/logo.svg';
 
@@ -25,26 +25,22 @@ const Footer: React.FC = () => (
 const OAuthCallback: React.FC = () => {
   const [searchParams] = useSearchParams();
   const [countdown, setCountdown] = useState(5);
+  const navigate = useNavigate();
 
   // Get URL parameters with memoization
   const type = useMemo(() => searchParams.get('type') || 'success', [searchParams]);
   const serverName = useMemo(() => searchParams.get('serverName') || 'Connectors', [searchParams]);
   const error = useMemo(() => searchParams.get('error') || 'Unknown error occurred', [searchParams]);
 
-  const closeWindow = useCallback(() => {
-    try {
-      if (window.opener) window.opener.focus();
-      window.close();
-    } catch {
-      console.log('Could not close window automatically');
-    }
+  const goToDashboard = useCallback(() => {
+    navigate('/');
   }, []);
 
   useEffect(() => {
     const timer = setInterval(() => {
       setCountdown(prev => {
         if (prev <= 1) {
-          closeWindow();
+          goToDashboard();
           return 0;
         }
         return prev - 1;
@@ -55,7 +51,7 @@ const OAuthCallback: React.FC = () => {
     const handleVisibilityChange = () => {
       if (document.hidden) {
         if (timerCloseWindow) clearTimeout(timerCloseWindow);
-        timerCloseWindow = setTimeout(closeWindow, 1000);
+        timerCloseWindow = setTimeout(goToDashboard, 1000);
       }
     };
 
@@ -66,7 +62,7 @@ const OAuthCallback: React.FC = () => {
       if (timerCloseWindow) clearTimeout(timerCloseWindow);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [closeWindow]);
+  }, [goToDashboard]);
 
   // Render error state
   if (type === 'error') {
@@ -94,10 +90,10 @@ const OAuthCallback: React.FC = () => {
               Retry Authorization
             </Link>
             <button
-              onClick={closeWindow}
+              onClick={goToDashboard}
               className='bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-6 py-3 rounded-lg font-semibold hover:bg-gray-200 dark:hover:bg-gray-600 transition-all duration-200'
             >
-              Close Window
+              Go to the Dashboard page
             </button>
           </div>
 
@@ -134,10 +130,10 @@ const OAuthCallback: React.FC = () => {
         </p>
 
         <button
-          onClick={closeWindow}
+          onClick={goToDashboard}
           className='btn-primary w-full mt-6 hover:transform hover:-translate-y-0.5 transition-all duration-200 shadow-md hover:shadow-lg'
         >
-          Close Window
+          Go to the Dashboard page
         </button>
 
         <div className='text-xs text-gray-500 dark:text-gray-400 mt-6 opacity-80'>

--- a/frontend/src/services/server/type.ts
+++ b/frontend/src/services/server/type.ts
@@ -35,7 +35,7 @@ export type Server = {
   url: string;
   enabled: boolean;
   requiresOAuth: boolean;
-  connection_state: SERVER_CONNECTION;
+  connectionState: SERVER_CONNECTION;
   capabilities: string;
   tools: string;
   author: string;

--- a/registry/api/v1/mcp/oauth_router.py
+++ b/registry/api/v1/mcp/oauth_router.py
@@ -396,8 +396,8 @@ def _redirect_to_page(request: Request,
                       error_msg: str = None) -> RedirectResponse:
     """
     Generate a response that redirects to frontend OAuth callback page.
-        /oauth/callback?type=success&serverName=value
-        /oauth/callback?type=error&serverName=value&error=value
+        /oauth-callback?type=success&serverName=value
+        /oauth-callback?type=error&serverName=value&error=value
     """
     base_path = REGISTRY_CONSTANTS.NGINX_BASE_PATH.strip("/")
     encoded_server = quote(str(server_name))
@@ -405,7 +405,7 @@ def _redirect_to_page(request: Request,
     # Build full URL with host if request is provided
     host = request.headers.get("host", "localhost:7860")
     proto = request.headers.get("x-forwarded-proto", request.url.scheme)
-    redirect_url = f"{proto}://{host}/{base_path}/oauth/callback?type={flag}&serverName={encoded_server}"
+    redirect_url = f"{proto}://{host}/{base_path}/oauth-callback?type={flag}&serverName={encoded_server}"
 
     if error_msg and flag == "error":
         encoded_error = quote(str(error_msg))

--- a/registry/api/v1/server_routes.py
+++ b/registry/api/v1/server_routes.py
@@ -88,7 +88,7 @@ def apply_connection_status_to_server(
     """
     if status:
         server_item.connectionState = status.get("connection_state")
-        server_item.requiresOAuth = status.get("requiresOAuth", False)
+        server_item.requiresOAuth = status.get("requires_oauth", False)
         server_item.error = status.get("error")
     else:
         # Fallback if status not found

--- a/registry/api/v1/server_routes.py
+++ b/registry/api/v1/server_routes.py
@@ -87,13 +87,13 @@ def apply_connection_status_to_server(
     Apply connection status to a server response object.
     """
     if status:
-        server_item.connection_state = status.get("connection_state")
-        server_item.requires_oauth = status.get("requires_oauth", False)
+        server_item.connectionState = status.get("connection_state")
+        server_item.requiresOAuth = status.get("requiresOAuth", False)
         server_item.error = status.get("error")
     else:
         # Fallback if status not found
-        server_item.connection_state = ConnectionState.ERROR.value
-        server_item.requires_oauth = fallback_requires_oauth
+        server_item.connectionState = ConnectionState.ERROR.value
+        server_item.requiresOAuth = fallback_requires_oauth
         server_item.error = "Connection status not available"
 
 

--- a/registry/auth/oauth/__init__.py
+++ b/registry/auth/oauth/__init__.py
@@ -1,10 +1,13 @@
 from .flow_state_manager import FlowStateManager, get_flow_state_manager
 from .oauth_http_client import OAuthHttpClient
 from .token_manager import OAuthTokenManager
+from .oauth_utils import parse_scope, scope_to_string
 
 __all__ = [
     "FlowStateManager",
     "get_flow_state_manager",
     "OAuthHttpClient",
     "OAuthTokenManager",
+    "parse_scope",
+    "scope_to_string",
 ]

--- a/registry/auth/oauth/flow_state_manager.py
+++ b/registry/auth/oauth/flow_state_manager.py
@@ -337,11 +337,9 @@ class FlowStateManager:
         redirect_uris = [redirect_uri] if redirect_uri else []
 
         # Get scopes from config (can be list or string)
-        scopes = oauth_config.get("scopes", [])
+        scopes = oauth_config.get("scope", [])
         if isinstance(scopes, list):
             scope_string = " ".join(scopes)
-        else:
-            scope_string = scopes
         logger.debug(f"Client info - redirect_uris: {redirect_uris}, scopes: {scope_string}")
         return OAuthClientInformation(
             client_id=oauth_config.get("client_id", ""),
@@ -355,11 +353,10 @@ class FlowStateManager:
         """
         Build OAuth metadata from server configuration
         """
-        auth_url = oauth_config.get("authorize_url") or oauth_config.get("auth_url", "")
-        token_url = oauth_config.get("token_url", "")
+        auth_url = oauth_config.get("authorization_url")
+        token_url = oauth_config.get("token_url")
 
-        # Get scopes (ensure it's a list)
-        scopes = oauth_config.get("scopes", [])
+        scopes = oauth_config.get("scope", [])
         if isinstance(scopes, str):
             scopes = [s.strip() for s in scopes.split()]
 

--- a/registry/auth/oauth/flow_state_manager.py
+++ b/registry/auth/oauth/flow_state_manager.py
@@ -351,8 +351,8 @@ class FlowStateManager:
         """
         Build OAuth metadata from server configuration
         """
-        auth_url = oauth_config.get("authorization_url")
-        token_url = oauth_config.get("token_url")
+        auth_url = oauth_config.get("authorization_url", "")
+        token_url = oauth_config.get("token_url", "")
 
         scopes = parse_scope(oauth_config.get("scope"), default=[])
 

--- a/registry/auth/oauth/oauth_http_client.py
+++ b/registry/auth/oauth/oauth_http_client.py
@@ -168,7 +168,7 @@ class OAuthHttpClient:
                 data["client_secret"] = oauth_config["client_secret"]
 
             # Add scope if exists (handle both list and string formats)
-            scopes = oauth_config.get("scopes")
+            scopes = oauth_config.get("scope")
             if scopes:
                 if isinstance(scopes, list):
                     data["scope"] = " ".join(scopes)

--- a/registry/auth/oauth/oauth_utils.py
+++ b/registry/auth/oauth/oauth_utils.py
@@ -24,6 +24,8 @@ def parse_scope(scope: Union[str, List[str], None], default: List[str] = None) -
         else:
             return [s.strip() for s in scope.split() if s.strip()]
 
+    return []
+
 
 def scope_to_string(scope: Union[str, List[str], None]) -> str:
     """

--- a/registry/auth/oauth/oauth_utils.py
+++ b/registry/auth/oauth/oauth_utils.py
@@ -1,0 +1,47 @@
+from typing import List, Union
+
+
+def parse_scope(scope: Union[str, List[str], None], default: List[str] = None) -> List[str]:
+    """
+    Parse OAuth scope field into a list of scopes.
+    
+    Args:
+        scope: Can be a string (space or comma separated), a list of strings, or None
+        default: Default value to return if scope is None
+        
+    Returns:
+        List of scope strings
+    """
+    if scope is None:
+        return default if default is not None else []
+
+    if isinstance(scope, list):
+        return scope
+
+    if isinstance(scope, str):
+        if ',' in scope:
+            return [s.strip() for s in scope.split(',') if s.strip()]
+        else:
+            return [s.strip() for s in scope.split() if s.strip()]
+
+
+def scope_to_string(scope: Union[str, List[str], None]) -> str:
+    """
+    Convert scope to a space-separated string.
+    
+    Args:
+        scope: Can be a string, a list of strings, or None
+        
+    Returns:
+        Space-separated string of scopes
+    """
+    if scope is None:
+        return ""
+
+    if isinstance(scope, list):
+        return " ".join(scope)
+
+    if isinstance(scope, str):
+        return scope
+
+    return ""

--- a/registry/models/oauth_models.py
+++ b/registry/models/oauth_models.py
@@ -93,7 +93,7 @@ class MCPOAuthFlowMetadata(BaseModel):
     """MCP OAuth flow metadata"""
     server_name: str = Field(..., description="Server name")
     user_id: str = Field(..., description="User ID")
-    authorize_url: str = Field(..., description="Authorize URL")
+    authorization_url: str = Field(..., description="Authorization URL")
     state: str = Field(..., description="State parameter")
     code_verifier: str = Field(..., description="PKCE code_verifier")
     client_info: OAuthClientInformation = Field(..., description="Client information")

--- a/registry/schemas/server_api_schemas.py
+++ b/registry/schemas/server_api_schemas.py
@@ -172,8 +172,7 @@ class ServerListItemResponse(BaseModel):
     createdAt: datetime
     updatedAt: datetime
     # Connection status fields
-    connection_state: Optional[str] = Field(default=None, description="Connection state")
-    requires_oauth: Optional[bool] = Field(default=None, description="Whether server requires OAuth")
+    connectionState: Optional[str] = Field(default=None, description="Connection state")
     error: Optional[str] = Field(default=None, description="Error message if connection failed")
     
     class ConfigDict:
@@ -230,8 +229,7 @@ class ServerDetailResponse(BaseModel):
     createdAt: datetime
     updatedAt: datetime
 
-    connection_state: Optional[str] = Field(default=None, description="Connection state")
-    requires_oauth: Optional[bool] = Field(default=None, description="Whether server requires OAuth")
+    connectionState: Optional[str] = Field(default=None, description="Connection state")
     error: Optional[str] = Field(default=None, description="Error message if connection failed")
     
     class ConfigDict:

--- a/registry/services/oauth/connection_service.py
+++ b/registry/services/oauth/connection_service.py
@@ -61,14 +61,14 @@ class MCPConnectionService:
                 # 为不需要 OAuth 的服务器创建应用级连接
                 for server in servers:
                     # 检查服务器是否需要 OAuth
-                    if not server.config.requiresOAuth:
+                    if not server.config.get("requiresOAuth"):
                         self.app_connections[server.serverName] = MCPConnection(
                             server_name=server.serverName,
                             connection_state=ConnectionState.CONNECTED,
                             details={
                                 "type": "app_connection",
                                 "server_id": str(server.id),
-                                "url": server.url,
+                                "url": server.config.get("url"),
                                 "config": server.config,
                                 "created_at": time.time(),
                                 "last_health_check": time.time()

--- a/registry/services/oauth/connection_service.py
+++ b/registry/services/oauth/connection_service.py
@@ -61,7 +61,7 @@ class MCPConnectionService:
                 # 为不需要 OAuth 的服务器创建应用级连接
                 for server in servers:
                     # 检查服务器是否需要 OAuth
-                    if not server.config.requires_oauth:
+                    if not server.config.requiresOAuth:
                         self.app_connections[server.serverName] = MCPConnection(
                             server_name=server.serverName,
                             connection_state=ConnectionState.CONNECTED,

--- a/registry/services/oauth/connection_status_service.py
+++ b/registry/services/oauth/connection_status_service.py
@@ -37,7 +37,7 @@ async def get_servers_connection_status(
             "config": server.config,
             "updated_at": server.updatedAt.timestamp() if server.updatedAt else None,
         }
-        if server.config.get("requires_oauth", False):
+        if server.config.get("requiresOAuth", False):
             oauth_servers.add(server_name)
     
     # Get status for each server

--- a/registry/services/oauth/oauth_service.py
+++ b/registry/services/oauth/oauth_service.py
@@ -1,5 +1,5 @@
 from typing import Dict, Optional, Any, Tuple
-from registry.auth.oauth import OAuthHttpClient, get_flow_state_manager, FlowStateManager
+from registry.auth.oauth import OAuthHttpClient, get_flow_state_manager, FlowStateManager, parse_scope
 from registry.models.oauth_models import OAuthTokens
 from registry.schemas.enums import OAuthFlowStatus
 from registry.utils.utils import generate_code_verifier, generate_code_challenge
@@ -63,11 +63,11 @@ class MCPOAuthService:
             flow_id = self.flow_manager.generate_flow_id(user_id, server_name)
 
             # Create OAuth flow metadata (using flow_id as state)
-            authorize_url = oauth_config.get("authorization_url")
+            authorization_url = oauth_config.get("authorization_url")
             flow_metadata = self.flow_manager.create_flow_metadata(
                 server_name=server_name,
                 user_id=user_id,
-                authorize_url=authorize_url,
+                authorization_url=authorization_url,
                 code_verifier=code_verifier,
                 oauth_config=oauth_config,
                 flow_id=flow_id
@@ -279,9 +279,7 @@ class MCPOAuthService:
 
             # Persist refreshed tokens to database with metadata
             auth_url = oauth_config.get("authorization_url")
-            scopes = oauth_config.get("scope", [])
-            if isinstance(scopes, str):
-                scopes = [s.strip() for s in scopes.split()]
+            scopes = parse_scope(oauth_config.get("scope"), default=[])
             
             metadata = {
                 "authorization_endpoint": auth_url,

--- a/registry/services/oauth/oauth_service.py
+++ b/registry/services/oauth/oauth_service.py
@@ -39,11 +39,11 @@ class MCPOAuthService:
                 return None, None, "Server not found"
 
             # Check if server requires OAuth
-            if not mcp_server.config.get("requires_oauth"):
+            if not mcp_server.config.get("requiresOAuth"):
                 return None, None, f"Server '{server_name}' does not require OAuth"
 
             # Get OAuth config from authentication
-            authentication = mcp_server.config.get("authentication")
+            authentication = mcp_server.config.get("oauth")
             if not authentication:
                 return None, None, f"Server '{server_name}' authentication configuration not found"
             
@@ -52,10 +52,10 @@ class MCPOAuthService:
             
             # Debug logs: verify OAuth configuration
             logger.debug(f"OAuth config keys: {list(oauth_config.keys())}")
-            logger.debug(f"authorize_url: {oauth_config.get('authorize_url')}")
+            logger.debug(f"authorization_url: {oauth_config.get('authorization_url')}")
             logger.debug(f"token_url: {oauth_config.get('token_url')}")
             logger.debug(f"client_id: {oauth_config.get('client_id')}")
-            logger.debug(f"scopes: {oauth_config.get('scopes')}")
+            logger.debug(f"scope: {oauth_config.get('scope')}")
 
             # Generate PKCE parameters
             code_verifier = generate_code_verifier()
@@ -63,10 +63,11 @@ class MCPOAuthService:
             flow_id = self.flow_manager.generate_flow_id(user_id, server_name)
 
             # Create OAuth flow metadata (using flow_id as state)
+            authorize_url = oauth_config.get("authorization_url")
             flow_metadata = self.flow_manager.create_flow_metadata(
                 server_name=server_name,
                 user_id=user_id,
-                authorize_url=oauth_config.get("authorize_url", ""),
+                authorize_url=authorize_url,
                 code_verifier=code_verifier,
                 oauth_config=oauth_config,
                 flow_id=flow_id
@@ -259,12 +260,12 @@ class MCPOAuthService:
             if not mcp_server:
                 return False, f"Server '{server_name}' not found"
             
-            # Get OAuth config from authentication
-            authentication = mcp_server.config.get("authentication")
+            # Get OAuth config from oauth
+            authentication = mcp_server.config.get("oauth")
             if not authentication:
-                return False, f"Server '{server_name}' authentication configuration not found"
+                return False, f"Server '{server_name}' OAuth configuration not found"
             
-            # OAuth configuration is directly under authentication
+            # OAuth configuration is directly under oauth
             oauth_config = authentication
 
             # Refresh tokens
@@ -277,11 +278,16 @@ class MCPOAuthService:
                 return False, "Failed to refresh tokens"
 
             # Persist refreshed tokens to database with metadata
+            auth_url = oauth_config.get("authorization_url")
+            scopes = oauth_config.get("scope", [])
+            if isinstance(scopes, str):
+                scopes = [s.strip() for s in scopes.split()]
+            
             metadata = {
-                "authorization_endpoint": oauth_config.get("authorize_url"),
+                "authorization_endpoint": auth_url,
                 "token_endpoint": oauth_config.get("token_url"),
                 "issuer": oauth_config.get("issuer"),
-                "scopes_supported": oauth_config.get("scopes", []),
+                "scopes_supported": scopes,
                 "grant_types_supported": ["authorization_code", "refresh_token"],
                 "response_types_supported": ["code"],
             }

--- a/registry/services/oauth/reconnection_lock_service.py
+++ b/registry/services/oauth/reconnection_lock_service.py
@@ -1,0 +1,365 @@
+import time
+from typing import Optional, List, Dict, Any
+from redis import Redis
+from contextlib import asynccontextmanager
+from registry.config.redis_config import init_redis_connection
+from registry.constants import REGISTRY_CONSTANTS
+from registry.utils.log import logger
+
+
+class ReconnectionLockService:
+    """
+    Distributed lock service for server reconnection using Redis.
+    
+    Uses Redis SET with NX (not exists) and EX (expiry) options to implement
+    distributed locks that prevent concurrent reconnection attempts.
+    """
+
+    LOCK_KEY_PREFIX = f"{REGISTRY_CONSTANTS.REDIS_KEY_PREFIX}:reconnection:lock"
+
+    # Redis key prefix for reconnection status tracking
+    STATUS_KEY_PREFIX = f"{REGISTRY_CONSTANTS.REDIS_KEY_PREFIX}:reconnection:status"
+
+    # Default lock timeout: 30 seconds
+    # This should be longer than expected reconnection time but short enough
+    # to not block too long if the process crashes
+    DEFAULT_LOCK_TTL = 30
+
+    # Default cooldown period: 60 seconds
+    # Minimum time between reconnection attempts for the same server
+    DEFAULT_COOLDOWN_PERIOD = 60
+
+    def __init__(self, redis_client: Optional[Redis] = None):
+        """
+        Initialize reconnection lock service.
+        
+        Args:
+            redis_client: Redis client instance. If None, creates a new one.
+        """
+        self.redis = redis_client or init_redis_connection()
+        logger.info("ReconnectionLockService initialized")
+
+    def _make_lock_key(self, user_id: str, server_name: str) -> str:
+        """Generate Redis lock key for user:server combination."""
+        return f"{self.LOCK_KEY_PREFIX}:{user_id}:{server_name}"
+
+    def _make_status_key(self, user_id: str, server_name: str) -> str:
+        """Generate Redis status key for user:server combination."""
+        return f"{self.STATUS_KEY_PREFIX}:{user_id}:{server_name}"
+
+    def acquire_lock(
+            self,
+            user_id: str,
+            server_name: str,
+            ttl: int = DEFAULT_LOCK_TTL
+    ) -> bool:
+        """
+        Try to acquire a distributed lock for server reconnection.
+        
+        Args:
+            user_id: User ID
+            server_name: Server name
+            ttl: Lock time-to-live in seconds
+            
+        Returns:
+            True if lock was acquired, False if already locked
+        """
+        lock_key = self._make_lock_key(user_id, server_name)
+        lock_value = str(time.time())
+
+        try:
+            # SET key value NX EX ttl
+            # NX: Only set if key doesn't exist
+            # EX: Set expiry time
+            acquired = self.redis.set(
+                lock_key,
+                lock_value,
+                nx=True,  # Only set if not exists
+                ex=ttl  # Expire after ttl seconds
+            )
+
+            if acquired:
+                logger.debug(f"Acquired reconnection lock: {user_id}:{server_name} "
+                             f"(TTL: {ttl}s)")
+            else:
+                logger.debug(f"Failed to acquire lock (already locked): "
+                             f"{user_id}:{server_name}")
+
+            return bool(acquired)
+
+        except Exception as e:
+            logger.error(f"Error acquiring reconnection lock for {user_id}:{server_name}: {e}",
+                         exc_info=True)
+            # Fail open: allow reconnection attempt on Redis error
+            return True
+
+    def release_lock(self, user_id: str, server_name: str) -> bool:
+        """
+        Release a reconnection lock.
+        
+        Args:
+            user_id: User ID
+            server_name: Server name
+            
+        Returns:
+            True if lock was released, False if lock didn't exist
+        """
+        lock_key = self._make_lock_key(user_id, server_name)
+
+        try:
+            deleted = self.redis.delete(lock_key)
+
+            if deleted:
+                logger.debug(f"Released reconnection lock: {user_id}:{server_name}")
+
+            return bool(deleted)
+
+        except Exception as e:
+            logger.error(f"Error releasing reconnection lock for {user_id}:{server_name}: {e}",
+                         exc_info=True)
+            return False
+
+    def is_locked(self, user_id: str, server_name: str) -> bool:
+        """
+        Check if a server is currently locked for reconnection.
+        
+        Args:
+            user_id: User ID
+            server_name: Server name
+            
+        Returns:
+            True if locked, False otherwise
+        """
+        lock_key = self._make_lock_key(user_id, server_name)
+
+        try:
+            return bool(self.redis.exists(lock_key))
+        except Exception as e:
+            logger.error(f"Error checking reconnection lock for {user_id}:{server_name}: {e}",
+                         exc_info=True)
+            return False
+
+    def set_reconnection_status(
+            self,
+            user_id: str,
+            server_name: str,
+            status: str,
+            details: Optional[Dict[str, Any]] = None,
+            ttl: int = DEFAULT_COOLDOWN_PERIOD
+    ) -> bool:
+        """
+        Set reconnection status for a server.
+        
+        Args:
+            user_id: User ID
+            server_name: Server name
+            status: Status string (e.g., "success", "failed", "in_progress")
+            details: Optional additional details
+            ttl: Time-to-live for status in seconds
+            
+        Returns:
+            True if status was set successfully
+        """
+        status_key = self._make_status_key(user_id, server_name)
+
+        try:
+            data = {
+                "status": status,
+                "timestamp": str(time.time()),
+                "user_id": user_id,
+                "server_name": server_name
+            }
+
+            if details:
+                data["details"] = str(details)
+
+            # Use pipeline for atomic operation
+            pipe = self.redis.pipeline()
+            pipe.hmset(status_key, data)
+            pipe.expire(status_key, ttl)
+            pipe.execute()
+
+            logger.debug(
+                f"Set reconnection status for {user_id}:{server_name}: "
+                f"{status} (TTL: {ttl}s)"
+            )
+            return True
+
+        except Exception as e:
+            logger.error(f"Error setting reconnection status for {user_id}:{server_name}: {e}",
+                         exc_info=True)
+            return False
+
+    def get_reconnection_status(
+            self,
+            user_id: str,
+            server_name: str
+    ) -> Optional[Dict[str, str]]:
+        """
+        Get reconnection status for a server.
+        
+        Args:
+            user_id: User ID
+            server_name: Server name
+            
+        Returns:
+            Status dictionary or None if no status exists
+        """
+        status_key = self._make_status_key(user_id, server_name)
+
+        try:
+            data = self.redis.hgetall(status_key)
+            return data if data else None
+
+        except Exception as e:
+            logger.error(f"Error getting reconnection status for {user_id}:{server_name}: {e}",
+                         exc_info=True)
+            return None
+
+    def can_attempt_reconnection(
+            self,
+            user_id: str,
+            server_name: str,
+            cooldown_period: int = DEFAULT_COOLDOWN_PERIOD
+    ) -> bool:
+        """
+        Check if reconnection can be attempted (not locked and cooldown expired).
+        
+        Args:
+            user_id: User ID
+            server_name: Server name
+            cooldown_period: Minimum seconds between reconnection attempts
+            
+        Returns:
+            True if reconnection can be attempted
+        """
+        # Check if currently locked
+        if self.is_locked(user_id, server_name):
+            logger.debug(f"Cannot attempt reconnection (locked): {user_id}:{server_name}")
+            return False
+
+        # Check cooldown period
+        status = self.get_reconnection_status(user_id, server_name)
+        if status:
+            try:
+                last_attempt = float(status.get("timestamp", 0))
+                elapsed = time.time() - last_attempt
+
+                if elapsed < cooldown_period:
+                    logger.debug(f"Cannot attempt reconnection (cooldown): "
+                                 f"{user_id}:{server_name} "
+                                 f"(elapsed: {elapsed:.1f}s, required: {cooldown_period}s)")
+                    return False
+            except (ValueError, TypeError) as e:
+                logger.warning(f"Invalid timestamp in reconnection status: {e}")
+        return True
+
+    @asynccontextmanager
+    async def reconnection_lock(
+            self,
+            user_id: str,
+            server_name: str,
+            ttl: int = DEFAULT_LOCK_TTL
+    ):
+        """
+        Async context manager for reconnection lock.
+        
+        Usage:
+            async with lock_service.reconnection_lock(user_id, server_name):
+                # Perform reconnection
+                pass
+        
+        Args:
+            user_id: User ID
+            server_name: Server name
+            ttl: Lock time-to-live in seconds
+            
+        Yields:
+            True if lock was acquired, raises exception if not
+        """
+        acquired = self.acquire_lock(user_id, server_name, ttl)
+
+        if not acquired:
+            raise RuntimeError(f"Failed to acquire reconnection lock for "
+                               f"{user_id}:{server_name}")
+
+        try:
+            yield True
+        finally:
+            self.release_lock(user_id, server_name)
+
+    def cleanup_expired_locks(self) -> int:
+        """
+        Cleanup expired locks (Redis handles this automatically via TTL).
+        
+        This method is provided for manual cleanup if needed.
+        
+        Returns:
+            Number of locks cleaned up (always 0 as Redis auto-expires)
+        """
+        # Redis automatically handles expiry, but we can scan for orphaned keys
+        # This is a safety measure in case TTL wasn't set properly
+        pattern = f"{self.LOCK_KEY_PREFIX}:*"
+        cleaned = 0
+
+        try:
+            for key in self.redis.scan_iter(match=pattern, count=100):
+                # Check if key has no TTL (should not happen)
+                ttl = self.redis.ttl(key)
+                if ttl == -1:  # No expiry set
+                    self.redis.delete(key)
+                    cleaned += 1
+                    logger.warning(f"Cleaned up lock without TTL: {key}")
+
+            if cleaned > 0:
+                logger.info(f"Cleaned up {cleaned} locks without TTL")
+
+            return cleaned
+
+        except Exception as e:
+            logger.error(f"Error during lock cleanup: {e}", exc_info=True)
+            return 0
+
+    def get_all_locked_servers(self, user_id: Optional[str] = None) -> List[str]:
+        """
+        Get all currently locked servers (optionally filtered by user).
+        
+        Args:
+            user_id: Optional user ID to filter by
+            
+        Returns:
+            List of server names currently locked
+        """
+        if user_id:
+            pattern = f"{self.LOCK_KEY_PREFIX}:{user_id}:*"
+        else:
+            pattern = f"{self.LOCK_KEY_PREFIX}:*"
+
+        locked_servers = []
+
+        try:
+            for key in self.redis.scan_iter(match=pattern, count=100):
+                # Extract server name from key
+                # Key format: prefix:user_id:server_name
+                key_str = key if isinstance(key, str) else key.decode('utf-8')
+                parts = key_str.split(":")
+                if len(parts) >= 4:  # prefix has colons too
+                    server_name = ":".join(parts[3:])
+                    locked_servers.append(server_name)
+
+            return locked_servers
+
+        except Exception as e:
+            logger.error(f"Error getting locked servers: {e}", exc_info=True)
+            return []
+
+
+_reconnection_lock_service: Optional[ReconnectionLockService] = None
+
+
+def get_reconnection_lock_service() -> ReconnectionLockService:
+    global _reconnection_lock_service
+    if _reconnection_lock_service is None:
+        _reconnection_lock_service = ReconnectionLockService()
+        logger.info("Initialized global ReconnectionLockService")
+    return _reconnection_lock_service

--- a/tests/unit/oauth/test_flow_manager.py
+++ b/tests/unit/oauth/test_flow_manager.py
@@ -69,24 +69,24 @@ class TestFlowStateManager:
         manager = FlowStateManager()
         server_name = "test-server"
         user_id = "test-user"
-        authorize_url = "https://example.com/oauth/authorize"
+        authorization_url = "https://example.com/oauth/authorize"
         code_verifier = "test-verifier"
         flow_id = "test-flow-id"
         oauth_config = {
             "client_id": "test-client-id",
             "client_secret": "test-secret",
-            "scopes": ["read", "write"],
-            "authorize_url": authorize_url,
+            "scope": ["read", "write"],
+            "authorization_url": authorization_url,
             "token_url": "https://example.com/oauth/token"
         }
         
         metadata = manager.create_flow_metadata(
-            server_name, user_id, authorize_url, code_verifier, oauth_config, flow_id
+            server_name, user_id, authorization_url, code_verifier, oauth_config, flow_id
         )
         
         assert metadata.server_name == server_name
         assert metadata.user_id == user_id
-        assert metadata.authorize_url == authorize_url
+        assert metadata.authorization_url == authorization_url
         assert metadata.code_verifier == code_verifier
         assert metadata.client_info.client_id == "test-client-id"
 
@@ -101,8 +101,8 @@ class TestFlowStateManager:
         # Create minimal metadata
         oauth_config = {
             "client_id": "test-client",
-            "scopes": ["read"],
-            "authorize_url": "https://example.com/auth",
+            "scope": ["read"],
+            "authorization_url": "https://example.com/auth",
             "token_url": "https://example.com/token"
         }
         metadata = manager.create_flow_metadata(
@@ -128,8 +128,8 @@ class TestFlowStateManager:
         # Create flow
         oauth_config = {
             "client_id": "test-client",
-            "scopes": ["read"],
-            "authorize_url": "https://example.com/auth",
+            "scope": ["read"],
+            "authorization_url": "https://example.com/auth",
             "token_url": "https://example.com/token"
         }
         metadata = manager.create_flow_metadata(
@@ -165,8 +165,8 @@ class TestFlowStateManager:
         # Create flow
         oauth_config = {
             "client_id": "test-client",
-            "scopes": ["read"],
-            "authorize_url": "https://example.com/auth",
+            "scope": ["read"],
+            "authorization_url": "https://example.com/auth",
             "token_url": "https://example.com/token"
         }
         metadata = manager.create_flow_metadata(
@@ -193,8 +193,8 @@ class TestFlowStateManager:
         # Create flow
         oauth_config = {
             "client_id": "test-client",
-            "scopes": ["read"],
-            "authorize_url": "https://example.com/auth",
+            "scope": ["read"],
+            "authorization_url": "https://example.com/auth",
             "token_url": "https://example.com/token"
         }
         metadata = manager.create_flow_metadata(
@@ -245,8 +245,8 @@ class TestFlowStateManager:
         # Create flow
         oauth_config = {
             "client_id": "test-client",
-            "scopes": ["read"],
-            "authorize_url": "https://example.com/auth",
+            "scope": ["read"],
+            "authorization_url": "https://example.com/auth",
             "token_url": "https://example.com/token"
         }
         metadata = manager.create_flow_metadata(
@@ -284,8 +284,8 @@ class TestFlowStateManager:
         # Create flow
         oauth_config = {
             "client_id": "test-client",
-            "scopes": ["read"],
-            "authorize_url": "https://example.com/auth",
+            "scope": ["read"],
+            "authorization_url": "https://example.com/auth",
             "token_url": "https://example.com/token"
         }
         metadata = manager.create_flow_metadata(
@@ -314,8 +314,8 @@ class TestFlowStateManager:
         # Create flow
         oauth_config = {
             "client_id": "test-client",
-            "scopes": ["read"],
-            "authorize_url": "https://example.com/auth",
+            "scope": ["read"],
+            "authorization_url": "https://example.com/auth",
             "token_url": "https://example.com/token"
         }
         metadata = manager.create_flow_metadata(
@@ -343,8 +343,8 @@ class TestFlowStateManager:
         # Create multiple flows for same user/server
         oauth_config = {
             "client_id": "test-client",
-            "scopes": ["read"],
-            "authorize_url": "https://example.com/auth",
+            "scope": ["read"],
+            "authorization_url": "https://example.com/auth",
             "token_url": "https://example.com/token"
         }
         
@@ -433,8 +433,8 @@ class TestFlowStateManagerIntegration:
         code_verifier = "test-verifier"
         oauth_config = {
             "client_id": "test-client",
-            "scopes": ["read"],
-            "authorize_url": "https://example.com/auth",
+            "scope": ["read"],
+            "authorization_url": "https://example.com/auth",
             "token_url": "https://example.com/token"
         }
         metadata = manager.create_flow_metadata(


### PR DESCRIPTION

### **1. Improve reconnection logic**

1. User refreshes /v1/servers page
   ↓
2. list_servers() queries database
   query: “notion”, status: “active”, page: 1, per_page: 20
   → Returns 20 servers
   ↓
3. Retrieve connection status
   → 5 DISCONNECTED, 10 CONNECTED, 5 ERROR
   ↓
4. Return response to frontend (display immediately)
   ↓
5. Trigger reconnect_servers(user_id, servers, connection_status) in the background
   ↓
6. _get_servers_to_reconnect filter:
   - 20 servers
   - Filter out 15 non-OAuth / disabled / connected
   - Remaining 5 require inspection
   ↓
7. can_reconnect checks these 5:
   - 2 pass all checks
   - 3 skipped due to expired/missing tokens
↓
8. Acquires Redis lock for these 2 servers:
   - 1 lock acquired successfully
   - 1 locked by another instance (skipped)
   ↓
9. Execute try_reconnect_server:
   - Check tokens
   - Refresh expired tokens (if needed)
   - Update connection status to CONNECTED
   - Set Redis status to success (5-minute cooldown)
   ↓
10. Release lock
    ↓
11. Done! Frontend will see new status on next poll


### **2、Refresh the access token using the refresh token.**

1. Initial Authorization (Manual User Action)
   ↓
   Save:
   - access_token (valid for 1 hour)
   - refresh_token (valid for 30 days)
   ↓
2. Access token expires (after 59 minutes)
   ↓
   Auto-refresh:
   - Exchange refresh_token for new access_token
   - May obtain new refresh_token
   ↓
   Save:
   - new access_token (valid for 1 hour)
   - new refresh_token (valid for 30 days)
   ↓
3. Repeat step 2 (up to 30 days)
   ↓
4. Refresh token expires (after 30 days)
   ↓
   Requires user reauthorization