### PR TITLE
Registry needs REGISTRY_CLIENT_URL localhost:5173.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ AUTH_SERVER_URL=http://auth-server:8888
 # For custom HTTPS domain: https://mcpgateway.mycorp.com
 AUTH_SERVER_EXTERNAL_URL=https://your-domain.com
 
+# Frontend client URL (for browser access to the registry frontend)
+REGISTRY_CLIENT_URL=http://registry-frontend
+
 # =============================================================================
 # MONGODB CONFIGURATION
 # =============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,6 +197,7 @@ services:
       - ENTRA_EMAIL_CLAIM=${ENTRA_EMAIL_CLAIM:-upn}
       - ENTRA_NAME_CLAIM=${ENTRA_NAME_CLAIM:-name}
       - ENTRA_ROLE_TOKEN_KIND=${ENTRA_ROLE_TOKEN_KIND:-id}
+      - REGISTRY_CLIENT_URL=${REGISTRY_CLIENT_URL:-http://registry-frontend}
     ports:
       - "8888:8888"
     volumes:


### PR DESCRIPTION
When running the application with docker compose, it will fail as the settings, by default, send a user to `localhost:5173`, this change will correctly send the user to the frontend.