### PR TITLE
Login Page should only use Providers

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,10 +1,9 @@
-import { ExclamationTriangleIcon, EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
 import type React from 'react';
 import { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { getBasePath } from '../config';
-import { useAuth } from '../contexts/AuthContext';
 
 interface OAuthProvider {
   name: string;
@@ -13,22 +12,14 @@ interface OAuthProvider {
 }
 
 const Login: React.FC = () => {
-  const [credentials, setCredentials] = useState({ username: '', password: '' });
-  const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const [fieldErrors, setFieldErrors] = useState<{ username?: string; password?: string }>({});
   const [oauthProviders, setOauthProviders] = useState<OAuthProvider[]>([]);
-  const [showPassword, setShowPassword] = useState(false);
-  const [capsLockOn, setCapsLockOn] = useState(false);
-  const [rememberMe, setRememberMe] = useState(false);
-  const [setAuthServerUrl] = useState<string>('');
-  const { login } = useAuth();
-  const navigate = useNavigate();
+  const [loadingProviders, setLoadingProviders] = useState(true);
+  const [loginInProgress, setLoginInProgress] = useState<string | null>(null);
   const [searchParams] = useSearchParams();
 
   useEffect(() => {
     console.log('[Login] Component mounted, fetching OAuth providers...');
-    fetchAuthConfig();
     fetchOAuthProviders();
 
     // Check for error parameter from URL (e.g., from OAuth callback)
@@ -36,24 +27,7 @@ const Login: React.FC = () => {
     if (urlError) {
       setError(decodeURIComponent(urlError));
     }
-
-    // Check if user preferences exist
-    const savedRememberMe = localStorage.getItem('rememberMe') === 'true';
-    const savedUsername = localStorage.getItem('savedUsername');
-    setRememberMe(savedRememberMe);
-    if (savedRememberMe && savedUsername) {
-      setCredentials(prev => ({ ...prev, username: savedUsername }));
-    }
   }, [searchParams]);
-
-  const fetchAuthConfig = async () => {
-    try {
-      const response = await axios.get('/api/auth/config');
-      setAuthServerUrl(response.data.auth_server_url || '');
-    } catch (error) {
-      console.error('Failed to fetch auth config:', error);
-    }
-  };
 
   // Log when oauthProviders state changes
   useEffect(() => {
@@ -61,9 +35,9 @@ const Login: React.FC = () => {
   }, [oauthProviders]);
 
   const fetchOAuthProviders = async () => {
+    setLoadingProviders(true);
     try {
       console.log('[Login] Fetching OAuth providers from /api/auth/providers');
-      // Call the registry auth providers endpoint
       const response = await axios.get('/api/auth/providers');
       console.log('[Login] Response received:', response.data);
       console.log('[Login] Providers:', response.data.providers);
@@ -71,98 +45,32 @@ const Login: React.FC = () => {
       console.log('[Login] State updated with', response.data.providers?.length || 0, 'providers');
     } catch (error) {
       console.error('[Login] Failed to fetch OAuth providers:', error);
-      // Don't show error for missing OAuth providers, just continue with basic auth
-    }
-  };
-
-  const handleKeyPress = (e: React.KeyboardEvent) => {
-    setCapsLockOn(e.getModifierState('CapsLock'));
-  };
-
-  const validateField = (field: string, value: string) => {
-    const errors: { username?: string; password?: string } = {};
-
-    if (field === 'username' && value.trim().length === 0) {
-      errors.username = 'Username is required';
-    } else if (field === 'username' && value.length < 2) {
-      errors.username = 'Username must be at least 2 characters';
-    }
-
-    if (field === 'password' && value.length === 0) {
-      errors.password = 'Password is required';
-    } else if (field === 'password' && value.length < 3) {
-      errors.password = 'Password must be at least 3 characters';
-    }
-
-    setFieldErrors(prev => ({ ...prev, ...errors }));
-    return Object.keys(errors).length === 0;
-  };
-
-  const handleInputChange = (field: string, value: string) => {
-    setCredentials(prev => ({ ...prev, [field]: value }));
-    // Clear field-specific errors when user starts typing
-    if (fieldErrors[field as keyof typeof fieldErrors]) {
-      setFieldErrors(prev => ({ ...prev, [field]: undefined }));
-    }
-    // Clear general error
-    if (error) {
-      setError('');
-    }
-  };
-
-  const handleInputBlur = (field: string, value: string) => {
-    validateField(field, value);
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-    setError('');
-    setFieldErrors({});
-
-    // Validate all fields
-    const usernameValid = validateField('username', credentials.username);
-    const passwordValid = validateField('password', credentials.password);
-
-    if (!usernameValid || !passwordValid) {
-      setLoading(false);
-      return;
-    }
-
-    try {
-      await login(credentials.username, credentials.password);
-
-      // Handle remember me
-      if (rememberMe) {
-        localStorage.setItem('rememberMe', 'true');
-        localStorage.setItem('savedUsername', credentials.username);
-      } else {
-        localStorage.removeItem('rememberMe');
-        localStorage.removeItem('savedUsername');
-      }
-
-      navigate('/');
-    } catch (error: any) {
-      const errorMessage = error.response?.data?.detail || 'Login failed';
-
-      // Provide more specific error messages
-      if (errorMessage.toLowerCase().includes('credential') || errorMessage.toLowerCase().includes('password')) {
-        setError('Invalid username or password. Please check your credentials and try again.');
-      } else if (errorMessage.toLowerCase().includes('user') && errorMessage.toLowerCase().includes('not found')) {
-        setError('User not found. Please check your username or contact support.');
-      } else if (errorMessage.toLowerCase().includes('disabled') || errorMessage.toLowerCase().includes('blocked')) {
-        setError('Account is disabled. Please contact support for assistance.');
-      } else {
-        setError(errorMessage);
-      }
+      setError('Failed to load authentication providers. Please refresh the page.');
     } finally {
-      setLoading(false);
+      setLoadingProviders(false);
     }
   };
 
   const handleOAuthLogin = (provider: string) => {
+    setLoginInProgress(provider);
     window.location.href = `${getBasePath()}/redirect/${provider}`;
   };
+
+  const LoadingSpinner = () => (
+    <svg
+      className='animate-spin h-5 w-5'
+      xmlns='http://www.w3.org/2000/svg'
+      fill='none'
+      viewBox='0 0 24 24'
+    >
+      <circle className='opacity-25' cx='12' cy='12' r='10' stroke='currentColor' strokeWidth='4'></circle>
+      <path
+        className='opacity-75'
+        fill='currentColor'
+        d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
+      ></path>
+    </svg>
+  );
 
   return (
     <div className='min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col justify-center py-12 sm:px-6 lg:px-8'>
@@ -177,152 +85,45 @@ const Login: React.FC = () => {
 
       <div className='mt-8 sm:mx-auto sm:w-full sm:max-w-md'>
         <div className='card p-8'>
-          {/* OAuth Providers */}
-          {oauthProviders.length > 0 && (
-            <div className='space-y-3 mb-6'>
+          {error && (
+            <div className='mb-6 p-4 text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg dark:bg-red-900/30 dark:text-red-400 dark:border-red-800 flex items-start space-x-2'>
+              <ExclamationTriangleIcon className='h-5 w-5 flex-shrink-0 mt-0.5' />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {loadingProviders ? (
+            <div className='flex flex-col items-center justify-center py-8 space-y-4'>
+              <LoadingSpinner />
+              <p className='text-sm text-gray-500 dark:text-gray-400'>Loading authentication providers...</p>
+            </div>
+          ) : oauthProviders.length > 0 ? (
+            <div className='space-y-3'>
               {oauthProviders.map(provider => (
                 <button
                   key={provider.name}
                   onClick={() => handleOAuthLogin(provider.name)}
-                  className='w-full flex items-center justify-center px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 transition-all duration-200 hover:shadow-md'
+                  disabled={loginInProgress !== null}
+                  className='w-full flex items-center justify-center px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 transition-all duration-200 hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed'
                 >
-                  <span>Continue with {provider.display_name}</span>
-                </button>
-              ))}
-
-              <div className='relative my-6'>
-                <div className='absolute inset-0 flex items-center'>
-                  <div className='w-full border-t border-gray-300 dark:border-gray-600' />
-                </div>
-                <div className='relative flex justify-center text-sm'>
-                  <span className='px-4 bg-gray-50 dark:bg-gray-900 text-gray-500 dark:text-gray-400'>
-                    Or continue with username
-                  </span>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Traditional Login Form */}
-          <form onSubmit={handleSubmit} className='space-y-6'>
-            {error && (
-              <div className='p-4 text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg dark:bg-red-900/30 dark:text-red-400 dark:border-red-800 flex items-start space-x-2'>
-                <ExclamationTriangleIcon className='h-5 w-5 flex-shrink-0 mt-0.5' />
-                <span>{error}</span>
-              </div>
-            )}
-
-            <div>
-              <label htmlFor='username' className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
-                Username
-              </label>
-              <input
-                id='username'
-                type='text'
-                required
-                autoComplete='username'
-                className={`input mt-1 ${fieldErrors.username ? 'border-red-300 dark:border-red-600 focus:ring-red-500 focus:border-red-500' : ''}`}
-                value={credentials.username}
-                onChange={e => handleInputChange('username', e.target.value)}
-                onBlur={e => handleInputBlur('username', e.target.value)}
-                onKeyDown={handleKeyPress}
-                placeholder='Enter your username'
-              />
-              {fieldErrors.username && (
-                <p className='mt-1 text-sm text-red-600 dark:text-red-400'>{fieldErrors.username}</p>
-              )}
-            </div>
-
-            <div>
-              <label htmlFor='password' className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
-                Password
-              </label>
-              <div className='relative'>
-                <input
-                  id='password'
-                  type={showPassword ? 'text' : 'password'}
-                  required
-                  autoComplete='current-password'
-                  className={`input mt-1 pr-12 ${fieldErrors.password ? 'border-red-300 dark:border-red-600 focus:ring-red-500 focus:border-red-500' : ''}`}
-                  value={credentials.password}
-                  onChange={e => handleInputChange('password', e.target.value)}
-                  onBlur={e => handleInputBlur('password', e.target.value)}
-                  onKeyDown={handleKeyPress}
-                  placeholder='Enter your password'
-                />
-                <button
-                  className='absolute inset-y-0 right-0 pr-3 flex items-center'
-                  onClick={() => setShowPassword(!showPassword)}
-                  tabIndex={-1}
-                >
-                  {showPassword ? (
-                    <EyeSlashIcon className='h-5 w-5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300' />
+                  {loginInProgress === provider.name ? (
+                    <>
+                      <LoadingSpinner />
+                      <span className='ml-2'>Redirecting...</span>
+                    </>
                   ) : (
-                    <EyeIcon className='h-5 w-5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300' />
+                    <span>Continue with {provider.display_name}</span>
                   )}
                 </button>
-              </div>
-              {fieldErrors.password && (
-                <p className='mt-1 text-sm text-red-600 dark:text-red-400'>{fieldErrors.password}</p>
-              )}
-              {capsLockOn && (
-                <p className='mt-1 text-sm text-yellow-600 dark:text-yellow-400 flex items-center space-x-1'>
-                  <ExclamationTriangleIcon className='h-4 w-4' />
-                  <span>Caps Lock is on</span>
-                </p>
-              )}
+              ))}
             </div>
-
-            <div className='flex items-center justify-between'>
-              <div className='flex items-center'>
-                <input
-                  id='remember-me'
-                  name='remember-me'
-                  type='checkbox'
-                  checked={rememberMe}
-                  onChange={e => setRememberMe(e.target.checked)}
-                  className='h-4 w-4 text-purple-600 focus:ring-purple-500 border-gray-300 dark:border-gray-600 rounded dark:bg-gray-700'
-                />
-                <label htmlFor='remember-me' className='ml-2 block text-sm text-gray-700 dark:text-gray-300'>
-                  Remember me
-                </label>
-              </div>
+          ) : (
+            <div className='text-center py-8'>
+              <p className='text-sm text-gray-500 dark:text-gray-400'>
+                No authentication providers available. Please contact your administrator.
+              </p>
             </div>
-
-            <button
-              type='submit'
-              disabled={loading}
-              className='w-full btn-primary disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 flex items-center justify-center space-x-2'
-            >
-              {loading ? (
-                <>
-                  <svg
-                    className='animate-spin -ml-1 mr-2 h-4 w-4 text-white'
-                    xmlns='http://www.w3.org/2000/svg'
-                    fill='none'
-                    viewBox='0 0 24 24'
-                  >
-                    <circle
-                      className='opacity-25'
-                      cx='12'
-                      cy='12'
-                      r='10'
-                      stroke='currentColor'
-                      strokeWidth='4'
-                    ></circle>
-                    <path
-                      className='opacity-75'
-                      fill='currentColor'
-                      d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-                    ></path>
-                  </svg>
-                  <span>Signing in...</span>
-                </>
-              ) : (
-                <span>Sign in</span>
-              )}
-            </button>
-          </form>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Summary                                                                                                                                                                                                  
  - Removed username/password sign-in from the login page                                              
  - Login now exclusively uses OAuth provider authentication                                           
<img width="505" height="369" alt="image" src="https://github.com/user-attachments/assets/4d99113d-007e-40c9-9469-d687e4aa6cb7" />
<img width="500" height="335" alt="image" src="https://github.com/user-attachments/assets/b2f3a001-d889-484b-924b-3dd3232d9de7" />
 
# Motivation                                                                                                                                                                                     
We will never support username/password authentication for this application. Having the form present alongside OAuth providers created unnecessary confusion for users about which method to use. This change simplifies the login experience by presenting only the supported authentication method.       
                                                                                                       
# Changes
  - Removed username/password form, validation logic, and related state                                
  - Added loading indicator while fetching available OAuth providers                                   
  - Added loading state on provider buttons during redirect                                            
  - Added fallback message when no providers are configured   