### PR TITLE
Fix/permissions map

### DIFF
--- a/registry/services/access_control_service.py
+++ b/registry/services/access_control_service.py
@@ -164,13 +164,14 @@ class ACLService:
 			for entry in specific + public:
 				rtype = entry.resourceType
 				rid = str(entry.resourceId)
-				if rid not in result[rtype]:
-					result[rtype][rid] = {
-						"VIEW": entry.permBits >= PermissionBits.VIEW,
-						"EDIT": entry.permBits >= PermissionBits.EDIT,
-						"DELETE": entry.permBits >= PermissionBits.DELETE,
-						"SHARE": entry.permBits >= PermissionBits.SHARE,
-					}
+				if rid in result[rtype]:
+					continue
+				result[rtype][rid] = {
+					"VIEW": entry.permBits >= PermissionBits.VIEW,
+					"EDIT": entry.permBits >= PermissionBits.EDIT,
+					"DELETE": entry.permBits >= PermissionBits.DELETE,
+					"SHARE": entry.permBits >= PermissionBits.SHARE,
+				}
 			return result
 		except Exception as e: 
 			logger.error(f"Error fetching ACL permissions map for user id: {principal_id}: {e}")

--- a/registry/services/access_control_service.py
+++ b/registry/services/access_control_service.py
@@ -159,31 +159,18 @@ class ACLService:
 			}
 			acl_entries = await IAclEntry.find(query).to_list()
 			result = {rt.value: {} for rt in ResourceType}
-			processed_entry = set()
-			# First, process user/group-specific entries
-			for entry in acl_entries:
-				if entry.principalType != PrincipalType.PUBLIC.value and entry.principalId is not None:
-					rtype = entry.resourceType
-					rid = str(entry.resourceId)
+			specific = [e for e in acl_entries if e.principalType != PrincipalType.PUBLIC.value and e.principalId is not None]
+			public = [e for e in acl_entries if e.principalType == PrincipalType.PUBLIC.value]
+			for entry in specific + public:
+				rtype = entry.resourceType
+				rid = str(entry.resourceId)
+				if rid not in result[rtype]:
 					result[rtype][rid] = {
 						"VIEW": entry.permBits >= PermissionBits.VIEW,
 						"EDIT": entry.permBits >= PermissionBits.EDIT,
 						"DELETE": entry.permBits >= PermissionBits.DELETE,
 						"SHARE": entry.permBits >= PermissionBits.SHARE,
 					}
-					processed_entry.add((rtype, rid))
-			# Then, process public entries only if not already set
-			for entry in acl_entries:
-				if entry.principalType == PrincipalType.PUBLIC.value:
-					rtype = entry.resourceType
-					rid = str(entry.resourceId)
-					if (rtype, rid) not in processed_entry:
-						result[rtype][rid] = {
-							"VIEW": entry.permBits >= PermissionBits.VIEW,
-							"EDIT": entry.permBits >= PermissionBits.EDIT,
-							"DELETE": entry.permBits >= PermissionBits.DELETE,
-							"SHARE": entry.permBits >= PermissionBits.SHARE,
-						}
 			return result
 		except Exception as e: 
 			logger.error(f"Error fetching ACL permissions map for user id: {principal_id}: {e}")


### PR DESCRIPTION
Fixes a bug where public ACL entry could be applied before a principal-specific entry, causing the code to keep the weaker/incorrect permission