### PR TITLE
Add ACL APIs

### DIFF
--- a/docs/acl-connector-service.md
+++ b/docs/acl-connector-service.md
@@ -227,6 +227,23 @@ class ACLService:
 
 The following REST API endpoints are exposed for ACL management:
 
+- **GET /permissions/search-principals**
+    - **Purpose:** Search for principals (users, groups, public) by query string for ACL sharing UI and permission assignment.
+    - **Query Parameters:**
+        - `query` (string, required): The search string for principal name, email, or username.
+        - `limit` (int, optional): Maximum number of results to return (default: 30).
+        - `principal_types` (list of string, optional): Filter by principal type (e.g., `user`, `group`). 
+    - **Response:**
+        ```json
+        [
+          {
+            "principal_type": "<user | group >",
+            "principal_id": "<id>",
+            "display_name": "...",
+          }
+        ]
+        ```
+
 - **GET /permissions/servers/{server_id}**
     - **Purpose:** Get the current user's permissions for a specific server resource.
     - **Response:**

--- a/docs/acl-connector-service.md
+++ b/docs/acl-connector-service.md
@@ -10,7 +10,7 @@
     - [Compatibility and Gaps with Current Requirements](#compatibility-and-gaps-with-current-requirements)
     - [Solution: Bridging the Gaps](#solution-bridging-the-gaps)
 3. [ACL Service Design](#acl-service-design)
-    - [High-Level Data Flow Diagram](#high-level-data-flow-diagram)
+    - [High-Level Authentication & Authorization Sequence Flow](#high-level-authentication--authorization-sequence-flow)
     - [Data Models](#data-models)
     - [Service Design](#service-design)
 4. [Jarvis Integration](#jarvis-integration)
@@ -49,7 +49,7 @@ This ACL service will be foundational for enforcing secure access and will be co
 An ACLService is already implemented in the Jarvis project. Prior to defining the registry-specific approach, it is essential to review this existing design and assess its compatibility with the updated requirements for sharing connectors (MCP servers and agents) across user, group, and public scopes.
 
 ### Terminology
-- **Principals**: Entities that can be granted permissions (individual users, groups, public, and roles)
+- **Principals**: Entities that can be granted permissions (individual users, groups, public)
 - **Roles**: Predefined sets of permissions. Each role is associated with a resource type  and maps to permission bits (permBits) 
 - **Resources**: Items that require access control (mcp servers, agents), identified by resourceType and resourceId.
 - **Permissions**: Numeric bitmasks that define allowed actions (view, edit).
@@ -60,7 +60,7 @@ The existing [ACLService](https://github.com/ascending-llc/jarvis-api/blob/deplo
 - `grantPermission`: Grants permissions to a principal for specific resources using a permission set optionally defined in a role
 - `findAccessibleResources`: Finds all resources of a specific type that a user has access to with specific permission bits
 - ~~`findPubliclyAccessibleResources`: Find all publicly accessible resources of a specific type~~
-- ~~`getResourcePermissionsMap`: Get effective permissions for multiple resources in a batch operation~~
+- `getResourcePermissionsMap`: Get effective permissions for multiple resources in a batch operation
 - `removeAllPermissions`: Removes all permissions for a resource
 - `checkPermission`: Checks if a specific user has permissions on a resource
 - ~~`validateResourceType`: Validates a resource types and manages permission schemas.~~
@@ -79,90 +79,39 @@ The existing [ACLService](https://github.com/ascending-llc/jarvis-api/blob/deplo
 
 2. Implement automated synchronization of enums and constants (such as roles and permission bits) between Jarvis and the registry project to maintain schema consistency and prevent drift.
 
-3. Establish a secure mechanism for passing authenticated user context (e.g., JWT tokens) from Jarvis to the registry service, enabling accurate permission checks and resource filtering based on user identity.
-
+3. Use session cookie authentication (`mcp-gateway-session`) for browser/UI users.
 
 ## ACL Service Design
 
-### High-Level Data Flow Diagram 
+### High-Level Authentication & Authorization Sequence Flow
+
+**Note:** Jarvis users authenticate to the registry using a session cookie named `mcp-gateway-session`. This cookie is set after successful login and is included in all subsequent requests to the registry for authentication and permission checks.
 
 ```mermaid
-flowchart LR
-  %% ========= Jarvis Side =========
-  JarvisAuth["`
-AuthService
-*AuthServer.js*
-Issues JWT (JWS) via HS256/RS256
-`"]
+sequenceDiagram
+    participant U as User Browser
+    participant R as Registry Backend (FastAPI)
+    participant A as Auth Server (OAuth2)
+    participant DB as MongoDB
 
-  JarvisServerRegistry["`
-Server/Agent Registry Client
-*MCPServersRegistry.ts*
-Forwards Authorization: Bearer <JWT>
-`"]
-
-  subgraph Jarvis
-    direction TB
-    JarvisAuth -- "JWT issued (JWS: signed token)" --> JarvisServerRegistry
-  end
-
-  %% ========= Registry Side =========
-  subgraph MCPRegistry
-    direction TB
-
-    AuthMiddleware["`
-JWTAuthMiddleware
-- Extract Bearer token from Authorization header
-- Verify signature (JWS) + validate exp/nbf/iat
-- Decode claims -> request.state.user_context
-`"]
-
-    APIRouter["`
-API Router
-*registry/main.py*
-Routes use request.state.user_context
-`"]
-
-    ServerService["`
-Server/Agent Service
-(List + read server/agent resources)
-`"]
-
-    ACLService["`
-ACLService (internal)
-- check_permission(...)
-- list_accessible_resources(...)
-- grant_permission(...)
-- remove_all_permissions(...)
-`"]
-
-    AuthMiddleware -- "attach user_context (user_id, email, ...)" --> APIRouter
-    APIRouter --> ServerService
-    ServerService -- "permission checks + resource filtering" --> ACLService
-  end
-
-  %% ========= Cross-service request flow (JWT forwarding) =========
-  JarvisServerRegistry -- "HTTP request
-Authorization: Bearer <JWT (JWS)>" --> AuthMiddleware
-
-  %% Explicit “back” arrow to satisfy “AuthMiddle -> JarvisServerRegistry”
-  AuthMiddleware -- "401/403 on invalid/expired JWT
-(or proceeds if valid)" --> JarvisServerRegistry
-
-  %% ========= Persistence =========
-  subgraph MongoDB
-    ServerCollection["Server Collection"]
-    AgentCollection["Agent Collection"]
-    ACLCollection["ACLEntry Collection"]
-  end
-
-  ServerService --> ServerCollection
-  ServerService --> AgentCollection
-  ACLService --> ACLCollection
-
+    U->>R: Request login page
+    R->>A: Fetch available OAuth2 providers
+    R-->>U: Render login page with providers
+    U->>R: Select provider, request /redirect/{provider}
+    R->>A: Redirect to Auth Server for OAuth2 login
+    U->>A: Authenticate (OAuth2 flow)
+    A->>U: Redirect with signed user info (JWT or payload)
+    U->>R: Callback to /redirect with signed user info
+    R->>DB: Lookup or create user in MongoDB
+    DB-->>R: User record
+    R->>U: Set session cookie `mcp-gateway-session`, redirect to dashboard
+    U->>R: Subsequent API requests with `mcp-gateway-session` cookie
+    R->>DB: (If needed) Load user/ACL data for permissions
+    DB-->>R: User/ACL data
+    R-->>U: Serve protected resources based on permissions
 ```
 
-### Data Models
+### ACL Implementation
 
 #### Field Definitions
 
@@ -221,163 +170,94 @@ The ACL service needs to facilitate the following operations:
 4. Admin/Owner can remove all permissions from resource (in the case of resource deletion)
 
 ```python
-from datetime import datetime
-from packages.models._generated.aclEntry import IAclEntry
-from packages.models._generated.accessRole import IAccessRole
-from packages.models._generated.user import IUser
+from datetime import datetime, timezone
+from typing import Optional, Union
+from packages.models._generated import IAccessRole
+from packages.models.extended_acl_entry import ExtendedAclEntry as IAclEntry
+from beanie import PydanticObjectId
+from registry.core.acl_constants import ResourceType, PermissionBits, PrincipalType
 
-class ACLService: 
-    def grant_permission(
+class ACLService:
+    async def grant_permission(
         self,
         principal_type: str,
-        principal_id: Optional[str] = None,
+        principal_id: Optional[Union[PydanticObjectId, str]],
         resource_type: str,
-        resource_id: str,
-        granted_by: str,
-        role_id: Optional[str] = None,
+        resource_id: PydanticObjectId,
+        role_id: Optional[PydanticObjectId] = None,
         perm_bits: Optional[int] = None,
-    ):
+    ) -> IAclEntry:
         """
-        Assigns permission bits to a specified principal (user, group, or public) for a given resource.
-
-        Returns the created or updated ACL entry
-        """
-        # Validate input parameters 
-        if principal_type in ["user", "group"] and not principal_id:
-            raise ValueError("principal_id must be set for user/group principal_type")
-
-        if not role_id and not perm_bits: 
-            raise ValueError("Permission bits must set via perm_bits or role_id")
-
-        if role_id: 
-            perm_bits = await IAccessRole.find_one({"accessRoleId": role_id}).perm_bits
-
-        # Check that the granting user is either an admin or has owner permission bits for the specified resource
-        granting_user = await IUser.find_one({"email": granted_by}) # get email from middleware
-        is_admin = granting_user.role == "ADMIN"
-        has_owner_perm = self.check_permission(
-            principal_type=PrincipalType.USER,
-            principal_id=granting_user._id,
-            resource_type=resource_type,
-            resource_id=resource_id,
-            required_permission=RoleBits.OWNER
-        )
-        if not (is_admin or has_owner_perm):
-            raise PermissionError("User must be admin or owner to grant ACL permission")
-
-        # Check if an ACL entry already exists for this principal/resource
-        acl_entry = await IAclEntry.find_one({
-            "principalType": principal_type,
-            "principalId": principal_id,
-            "resourceType": resource_type,
-            "resourceId": resource_id
-        })
-
-        # Create or update entry permissions and metadata
-        if acl_entry:
-            acl_entry.permBits = perm_bits
-            acl_entry.roleId = role_id
-            acl_entry.grantedBy = granting_user._id
-            acl_entry.grantedAt = datetime.utcnow().isoformat()
-            acl_entry.updatedAt = datetime.utcnow().isoformat()
-            await acl_entry.save()
-            return acl_entry
-        else:
-            new_entry = IAclEntry(
-                principalType=principal_type,
-                principalId=principal_id,
-                resourceType=resource_type,
-                resourceId=resource_id,
-                permBits=perm_bits,
-                roleId=role_id,
-                grantedBy=granting_user._id,
-                grantedAt=datetime.utcnow().isoformat(),
-                createdAt=datetime.utcnow().isoformat(),
-                updatedAt=datetime.utcnow().isoformat()
-            )
-            await new_entry.insert()
-            return new_entry
-
-    def check_permission(
-        self,
-        principal_type: str,
-        principal_id: str,
-        resource_type: str,
-        resource_id: str,
-        required_permission: int,
-        role: str = None
-    ) -> bool:
-        """
-        Check if a principal (user, group, public) has specific permission bits on a resource.
-        Returns True if the permission is present, otherwise False.
+        Grant ACL permission to a principal (user or group) for a specific resource.
         """
 
-    def list_accessible_resources(
-        self,
-        principal_type: str,
-        principal_id: str,
-        resource_type: str,
-        required_permissions: int,
-        role: str = None
-    ) -> List[str]:
-        """
-        List all resources a principal (user, group, public) has access to with specific permission bits.
-        Returns a list of resource IDs (as strings).
-        """
-
-    def remove_all_permissions(
+    async def delete_acl_entries_for_resource(
         self,
         resource_type: str,
-        resource_id: str
+        resource_id: PydanticObjectId,
+        perm_bits_to_delete: Optional[int] = None
     ) -> int:
         """
-        Remove all permissions for a resource (cleanup).
-        Returns the number of ACL entries removed.
-        """           
+        Bulk delete ACL entries for a given resource, optionally deleting all entries with permBits less than or equal to the specified value.
+        """
+
+    async def get_permissions_map_for_user_id(
+        self,
+        principal_type: str,
+        principal_id: PydanticObjectId,
+    ) -> dict:
+        """
+        Return a permissions map for a user, showing access rights for each resource type and resource ID.
+        """
+
+    async def delete_permission(
+        self,
+        resource_type: str,
+        resource_id: PydanticObjectId,
+        principal_type: str,
+        principal_id: Optional[Union[PydanticObjectId, str]]
+    ) -> int:
+        """
+        Remove a single ACL entry for a given resource, principal type, and principal ID.
+        """
 ```
 
-**Note**: The ACL Service will primarily be consumed by internal registry services. For that reason, it does not need to expose an API. 
 
-## Jarvis Integration
+### Exposed API Endpoints
 
-### Authentication Middleware
+The following REST API endpoints are exposed for ACL management:
 
-To ensure robust enforcement of ACL permissions, the registry service must reliably obtain authenticated user context from incoming requests, regardless of whether the call originates from Jarvis or the registry project. The current approach, which relies on FastAPI's dependency injection, is insufficient for cross-service integration.
+- **GET /permissions/servers/{server_id}**
+    - **Purpose:** Get the current user's permissions for a specific server resource.
+    - **Response:**
+        ```json
+        {
+            "server_id": "<id>",
+            "permissions": {"VIEW": true, "EDIT": false, ...}
+        }
+        ```
 
-Instead, a dedicated authentication middleware should be implemented to extract and validate user information from JWT tokens provided in the Authorization header. This enables consistent permission checks and resource filtering based on user identity across all entry points.
-
-#### Example: FastAPI JWT Authentication Middleware
-```python
-from fastapi import Request
-from fastapi.responses import JSONResponse
-from starlette.middleware.base import BaseHTTPMiddleware
-import jwt 
-
-class JWTAuthMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next):
-        auth_header = request.headers.get("Authorization")
-        user_context = None
-        if auth_header and auth_header.startswith("Bearer "):
-            token = auth_header.split(" ", 1)[1]
-            try:
-                payload = jwt.decode(token, os.getenv("JWT_SECRET"), algorithms=["HS256"])
-                user_context = {
-                    "user_id": payload.get("_id"),
-                    "email": payload.get("email")
-                    # ...other fields as needed
-                }
-                request.state.user_context = user_context
-            except jwt.PyJWTError:
-                return JSONResponse(status_code=401, content={"detail": "Invalid or expired token"})
-        # Optionally, handle anonymous or missing user context
-        response = await call_next(request)
-        return response
-```
+- **PUT /permissions/servers/{server_id}**
+    - **Purpose:** Update ACL permissions for a specific server.
+    - **Request:**
+        ```json
+        {
+            "public": true,
+            "removed": [ ... ],
+            "updated": [ ... ]
+        }
+        ```
+    - **Response:**
+        ```json
+        {
+            "message": "Updated <count> and deleted <count> permissions",
+            "results": {"server_id": "<id>"}
+        }
+        ```
  
-## Additional Considerations
+This pattern can be extended to include APIs for agent, prompt groups, and other resource types.
 
-### Server Registration Form Updates 
-The Server registration form should be updated to include a field that specifies who all can access the server 
+## Additional Considerations
 
 ### ACL Service Cache
 TBD after evaulating performance of initial service implementation

--- a/docs/acl-connector-service.md
+++ b/docs/acl-connector-service.md
@@ -49,7 +49,7 @@ This ACL service will be foundational for enforcing secure access and will be co
 An ACLService is already implemented in the Jarvis project. Prior to defining the registry-specific approach, it is essential to review this existing design and assess its compatibility with the updated requirements for sharing connectors (MCP servers and agents) across user, group, and public scopes.
 
 ### Terminology
-- **Principals**: Entities that can be granted permissions (individual users, groups, public)
+- **Principals**: Entities that can be granted permissions (individual users, groups, public, and roles)
 - **Roles**: Predefined sets of permissions. Each role is associated with a resource type  and maps to permission bits (permBits) 
 - **Resources**: Items that require access control (mcp servers, agents), identified by resourceType and resourceId.
 - **Permissions**: Numeric bitmasks that define allowed actions (view, edit).
@@ -180,7 +180,7 @@ class ACLService:
     async def delete_acl_entries_for_resource(self, resource_type: str, resource_id: PydanticObjectId, perm_bits_to_delete: Optional[int] = None) -> int: ...
     async def delete_permission(self, resource_type: str, resource_id: PydanticObjectId, principal_type: str, principal_id: Optional[Union[PydanticObjectId, str]]) -> int: ...
     async def get_permissions_map_for_user_id(self, principal_type: str, principal_id: PydanticObjectId) -> dict: ...
-    async def search_principals(self, query: str, limit: int = 30, principal_types: Optional[List[str]] = None) -> List[dict]: ...
+    async def search_principals(self, query: str, limit: int = 30, principal_types: Optional[List[str]] = None) -> List[PermissionPrincipalOut]: ...
     async def get_resource_permissions(self, resource_type: str, resource_id: PydanticObjectId) -> Dict[str, Any]: ...
 ```
 
@@ -195,14 +195,16 @@ The following REST API endpoints are exposed for ACL management:
     - **Query Parameters:**
         - `query` (string, required): The search string for principal name, email, or username.
         - `limit` (int, optional): Maximum number of results to return (default: 30).
-        - `principal_types` (list of string, optional): Filter by principal type (e.g., `user`, `group`).
+        - `principal_types` (list of string, optional): Filter by principal type (e.g., `user`, `group`, etc).
     - **Response:**
         ```json
         [
             {
-                "principal_type": "user",
-                "principal_id": "<id>",
-                "display_name": "..."
+                "principal_type": "user | group | role",
+                "principal_id": str,
+                "name": Optional[str] = None,
+                "email": Optional[str] = None,
+                "accessRoleId": str,
             },
         ]
         ```

--- a/docs/acl-connector-service.md
+++ b/docs/acl-connector-service.md
@@ -191,7 +191,7 @@ These methods are implemented in `registry/services/access_control_service.py` a
 The following REST API endpoints are exposed for ACL management:
 
 - **GET `/permissions/search-principals`**
-    - **Purpose:** Search for principals (users, groups) by query string for ACL sharing UI and permission assignment.
+    - **Purpose:** Search for principals (users, groups) by query string. Enables the ACL management UI to look up principals for permission assignment
     - **Query Parameters:**
         - `query` (string, required): The search string for principal name, email, or username.
         - `limit` (int, optional): Maximum number of results to return (default: 30).
@@ -208,7 +208,7 @@ The following REST API endpoints are exposed for ACL management:
         ```
 
 - **GET `/permissions/{resource_type}/{resource_id}`**
-    - **Purpose:** Get all ACL permissions for a specific resource.
+    - **Purpose:** Get all ACL permissions for a specific resource. Allows the ACL management UI to display which principals have access and whether the resource is public
     - **Response:**
         ```json
         {

--- a/registry/api/v1/acl_routes.py
+++ b/registry/api/v1/acl_routes.py
@@ -40,7 +40,7 @@ async def search_principals(
     query: str,
     limit: Optional[int] = None,
     principal_types: Optional[List[str]] = Query(None),
-) -> List:
+) -> List[Dict[str, Any]]:
     """
     Search for principals (users, groups, public) matching the query string.
     Returns a paginated response with metadata.
@@ -89,7 +89,7 @@ async def update_resource_permissions(
                 resource_id=PydanticObjectId(resource_id),
                 perm_bits_to_delete=PermissionBits.VIEW
             )
-            logger.info(f"Deleted {deleted_count} VIEW ACL entries for server {resource_id}")
+            logger.info(f"Deleted {deleted_count} VIEW ACL entries for resource {resource_id}")
 
             # Create 1 public acl entry
             acl_entry = await acl_service.grant_permission(
@@ -99,7 +99,7 @@ async def update_resource_permissions(
                 resource_id=PydanticObjectId(resource_id),
                 perm_bits=PermissionBits.VIEW
             )
-            logger.info(f"Created public ACL entry: {acl_entry.id} for server {resource_id}")
+            logger.info(f"Created public ACL entry: {acl_entry.id} for resource {resource_id}")
             updated_count = 1 if acl_entry else 0
         else:
             # Delete the public ACL entry
@@ -110,7 +110,7 @@ async def update_resource_permissions(
                 principal_id=None
             )
             deleted_count += deleted_public_entry
-            logger.info(f"Deleted public ACL entry for server {resource_id}")
+            logger.info(f"Deleted public ACL entry for resource {resource_id}")
 
         if data.removed:
             delete_results = await asyncio.gather(*[
@@ -135,14 +135,14 @@ async def update_resource_permissions(
             ])
             updated_count += len(update_results)
 
-        logger.info(f"Updated permissions for server {resource_id}: {updated_count} updated, {deleted_count} deleted")
+        logger.info(f"Updated permissions for resource {resource_id}: {updated_count} updated, {deleted_count} deleted")
         return UpdateResourcePermissionsResponse(
             message=f"Updated {updated_count} and deleted {deleted_count} permissions",
             results={"resource_id": resource_id}
         )
     
     except Exception as e: 
-        logger.error(f"Error updating permissions for server {resource_id}: {e}")
+        logger.error(f"Error updating permissions for resource {resource_id}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={
@@ -154,7 +154,7 @@ async def update_resource_permissions(
 @router.get(
    f"/permissions/{{resource_type}}/{{resource_id}}",
     summary="Get all permissions for a specific resource",
-    description="Search for principals by query string. Used for ACL sharing UI.",
+    description="Get ACL permissions for a specific resource.",
 )
 async def get_resource_permissions(
     resource_type: str,

--- a/registry/api/v1/acl_routes.py
+++ b/registry/api/v1/acl_routes.py
@@ -13,11 +13,12 @@ from registry.auth.dependencies import CurrentUserWithACLMap
 from registry.services.access_control_service import acl_service
 from registry.core.acl_constants import PrincipalType, ResourceType, PermissionBits
 from registry.schemas.permissions_schema import (
-    UpdateServerPermissionsRequest,
-    UpdateServerPermissionsResponse,
+    UpdateResourcePermissionsResponse,
+    UpdateResourcePermissionsRequest,
 )
 from registry.services.permissions_utils import (
     check_required_permission,
+    validate_resource_type
 )
 
 from typing import Dict, Any, List, Optional
@@ -30,31 +31,6 @@ def get_user_context(user_context: CurrentUserWithACLMap):
     """Extract user context from authentication dependency"""
     return user_context
 
-
-@router.get(
-    "/permissions/servers/{server_id}",
-    summary="Get ACL permissions for a specific server (for UI controls)",
-    description="Returns the current user's permissions for a specific server resource. Used by frontend to show/hide edit/delete buttons.",
-)
-async def get_server_permissions(
-    server_id: str,
-    user_context: dict = Depends(get_user_context),
-) -> Dict[str, Any]:
-    """
-    Returns the current user's permissions for the given server resource.
-    Example response:
-    {
-        "server_id": "...",
-        "permissions": ["VIEW", "EDIT", "DELETE", ...]
-    }
-    """
-    acl_permission_map = user_context.get("acl_permission_map", {})
-    perms = acl_permission_map.get(ResourceType.MCPSERVER, {}).get(server_id, [])
-    return {
-        "server_id": server_id,
-        "permissions": perms
-    }
-
 @router.get(
     "/permissions/search-principals",
     summary="Search for principals",
@@ -62,11 +38,9 @@ async def get_server_permissions(
 )
 async def search_principals(
     query: str,
-    page: int = 1,
-    per_page: int = 30,
+    limit: Optional[int] = None,
     principal_types: Optional[List[str]] = Query(None),
-    user_context: dict = Depends(get_user_context),
-) -> Dict[str, Any]:
+) -> List:
     """
     Search for principals (users, groups, public) matching the query string.
     Returns a paginated response with metadata.
@@ -74,10 +48,8 @@ async def search_principals(
     try:
         response = await acl_service.search_principals(
             query=query,
-            page=page,
-            per_page=per_page,
-            principal_types=principal_types,
-            current_user=user_context
+            limit=limit,
+            principal_types=principal_types
         )
         return response
     except Exception as e:
@@ -90,21 +62,22 @@ async def search_principals(
             }
         )
 
-
 @router.put(
-    f"/permissions/servers/{{server_id}}",
-    summary="Update ACL permissions for a specific server",
-    description="Update ACL permissions for a specific server",
-    response_model=UpdateServerPermissionsResponse,
+    f"/permissions/{{resource_type}}/{{resource_id}}",
+    summary="Update ACL permissions for a specific resource",
+    description="Update ACL permissions for a specific resource",
+    response_model=UpdateResourcePermissionsResponse,
 )
-async def update_server_permissions(
-    server_id: str,
-    data: UpdateServerPermissionsRequest,
+async def update_resource_permissions(
+    resource_id: str,
+    resource_type: str,
+    data: UpdateResourcePermissionsRequest,
     user_context: dict = Depends(get_user_context),
-) -> dict:
-    # Check if user has SHARE permissions
+) -> UpdateResourcePermissionsResponse:
+    validate_resource_type(resource_type)
+
     acl_permission_map = user_context.get("acl_permission_map", {})
-    check_required_permission(acl_permission_map, ResourceType.MCPSERVER.value, server_id, "SHARE")
+    check_required_permission(acl_permission_map, resource_type, resource_id, "SHARE")
     
     try:
         deleted_count = 0
@@ -112,38 +85,38 @@ async def update_server_permissions(
         if data.public:
             # Delete all the ACL entries granting VIEW access
             deleted_count = await acl_service.delete_acl_entries_for_resource(
-                resource_type=ResourceType.MCPSERVER.value,
-                resource_id=PydanticObjectId(server_id),
+                resource_type=resource_type,
+                resource_id=PydanticObjectId(resource_id),
                 perm_bits_to_delete=PermissionBits.VIEW
             )
-            logger.info(f"Deleted {deleted_count} VIEW ACL entries for server {server_id}")
+            logger.info(f"Deleted {deleted_count} VIEW ACL entries for server {resource_id}")
 
             # Create 1 public acl entry
             acl_entry = await acl_service.grant_permission(
                 principal_type=PrincipalType.PUBLIC.value,
                 principal_id=None,
                 resource_type=ResourceType.MCPSERVER.value,
-                resource_id=PydanticObjectId(server_id),
+                resource_id=PydanticObjectId(resource_id),
                 perm_bits=PermissionBits.VIEW
             )
-            logger.info(f"Created public ACL entry: {acl_entry.id} for server {server_id}")
+            logger.info(f"Created public ACL entry: {acl_entry.id} for server {resource_id}")
             updated_count = 1 if acl_entry else 0
         else:
             # Delete the public ACL entry
             deleted_public_entry = await acl_service.delete_permission(
-                resource_type=ResourceType.MCPSERVER.value,
-                resource_id=PydanticObjectId(server_id),
+                resource_type=resource_type,
+                resource_id=PydanticObjectId(resource_id),
                 principal_type=PrincipalType.PUBLIC.value,
                 principal_id=None
             )
             deleted_count += deleted_public_entry
-            logger.info(f"Deleted public ACL entry for server {server_id}")
+            logger.info(f"Deleted public ACL entry for server {resource_id}")
 
         if data.removed:
             delete_results = await asyncio.gather(*[
                 acl_service.delete_permission(
                     resource_type=ResourceType.MCPSERVER.value,
-                    resource_id=PydanticObjectId(server_id),
+                    resource_id=PydanticObjectId(resource_id),
                     principal_type=principal.principal_type,
                     principal_id=PydanticObjectId(principal.principal_id)
                 ) for principal in data.removed
@@ -156,20 +129,20 @@ async def update_server_permissions(
                     principal_type=principal.principal_type,
                     principal_id=PydanticObjectId(principal.principal_id),
                     resource_type=ResourceType.MCPSERVER.value,
-                    resource_id=PydanticObjectId(server_id),
+                    resource_id=PydanticObjectId(resource_id),
                     perm_bits=principal.perm_bits,
                 ) for principal in data.updated
             ])
             updated_count += len(update_results)
 
-        logger.info(f"Updated permissions for server {server_id}: {updated_count} updated, {deleted_count} deleted")
-        return UpdateServerPermissionsResponse(
+        logger.info(f"Updated permissions for server {resource_id}: {updated_count} updated, {deleted_count} deleted")
+        return UpdateResourcePermissionsResponse(
             message=f"Updated {updated_count} and deleted {deleted_count} permissions",
-            results={"server_id": server_id}
+            results={"resource_id": resource_id}
         )
     
     except Exception as e: 
-        logger.error(f"Error updating permissions for server {server_id}: {e}")
+        logger.error(f"Error updating permissions for server {resource_id}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={
@@ -178,3 +151,36 @@ async def update_server_permissions(
             }
         )
 
+@router.get(
+   f"/permissions/{{resource_type}}/{{resource_id}}",
+    summary="Get all permissions for a specific resource",
+    description="Search for principals by query string. Used for ACL sharing UI.",
+)
+async def get_resource_permissions(
+    resource_type: str,
+    resource_id: str,
+    user_context: dict = Depends(get_user_context),
+) -> Dict[str, Any]:
+    """
+    Get ACL permissions for a specific resource.
+    """
+    validate_resource_type(resource_type)
+
+    acl_permission_map = user_context.get("acl_permission_map", {})
+    check_required_permission(acl_permission_map, resource_type, resource_id, "VIEW")
+
+    try:
+        result = await acl_service.get_resource_permissions(
+            resource_type=resource_type,
+            resource_id=PydanticObjectId(resource_id),
+        )
+        return result
+    except Exception as e:
+        logger.error(f"Error fetching resource permissions for {resource_type} {resource_id}: {e}")
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "error": "internal_server_error",
+                "message": "An error occurred while fetching resource permissions."
+            }
+        )

--- a/registry/api/v1/acl_routes.py
+++ b/registry/api/v1/acl_routes.py
@@ -15,6 +15,7 @@ from registry.core.acl_constants import PrincipalType, PermissionBits
 from registry.schemas.permissions_schema import (
     UpdateResourcePermissionsResponse,
     UpdateResourcePermissionsRequest,
+    PermissionPrincipalOut
 )
 from registry.services.permissions_utils import (
     check_required_permission,
@@ -40,7 +41,7 @@ async def search_principals(
     query: str,
     limit: Optional[int] = None,
     principal_types: Optional[List[str]] = Query(None),
-) -> List[Dict[str, Any]]:
+) -> List[PermissionPrincipalOut]:
     """
     Search for principals (users, groups, public) matching the query string.
     Returns a paginated response with metadata.

--- a/registry/api/v1/acl_routes.py
+++ b/registry/api/v1/acl_routes.py
@@ -1,5 +1,5 @@
 """
-Permission Management API Routes V1
+ACL Management API Routes V1
 
 RESTful API endpoints for managing ACL permissions using MongoDB.
 """
@@ -11,7 +11,7 @@ from beanie import PydanticObjectId
 
 from registry.auth.dependencies import CurrentUserWithACLMap
 from registry.services.access_control_service import acl_service
-from registry.core.acl_constants import PrincipalType, ResourceType, PermissionBits
+from registry.core.acl_constants import PrincipalType, PermissionBits
 from registry.schemas.permissions_schema import (
     UpdateResourcePermissionsResponse,
     UpdateResourcePermissionsRequest,
@@ -95,7 +95,7 @@ async def update_resource_permissions(
             acl_entry = await acl_service.grant_permission(
                 principal_type=PrincipalType.PUBLIC.value,
                 principal_id=None,
-                resource_type=ResourceType.MCPSERVER.value,
+                resource_type=resource_type,
                 resource_id=PydanticObjectId(resource_id),
                 perm_bits=PermissionBits.VIEW
             )
@@ -115,7 +115,7 @@ async def update_resource_permissions(
         if data.removed:
             delete_results = await asyncio.gather(*[
                 acl_service.delete_permission(
-                    resource_type=ResourceType.MCPSERVER.value,
+                    resource_type=resource_type,
                     resource_id=PydanticObjectId(resource_id),
                     principal_type=principal.principal_type,
                     principal_id=PydanticObjectId(principal.principal_id)
@@ -128,7 +128,7 @@ async def update_resource_permissions(
                 acl_service.grant_permission(
                     principal_type=principal.principal_type,
                     principal_id=PydanticObjectId(principal.principal_id),
-                    resource_type=ResourceType.MCPSERVER.value,
+                    resource_type=resource_type,
                     resource_id=PydanticObjectId(resource_id),
                     perm_bits=principal.perm_bits,
                 ) for principal in data.updated

--- a/registry/api/v1/permissions_routes.py
+++ b/registry/api/v1/permissions_routes.py
@@ -20,6 +20,8 @@ from registry.services.permissions_utils import (
     check_required_permission,
 )
 
+from typing import Dict, Any
+
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
@@ -27,6 +29,31 @@ router = APIRouter()
 def get_user_context(user_context: CurrentUserWithACLMap):
     """Extract user context from authentication dependency"""
     return user_context
+
+
+@router.get(
+    "/permissions/servers/{server_id}",
+    summary="Get ACL permissions for a specific server (for UI controls)",
+    description="Returns the current user's permissions for a specific server resource. Used by frontend to show/hide edit/delete buttons.",
+)
+async def get_server_permissions(
+    server_id: str,
+    user_context: dict = Depends(get_user_context),
+) -> Dict[str, Any]:
+    """
+    Returns the current user's permissions for the given server resource.
+    Example response:
+    {
+        "server_id": "...",
+        "permissions": ["VIEW", "EDIT", "DELETE", ...]
+    }
+    """
+    acl_permission_map = user_context.get("acl_permission_map", {})
+    perms = acl_permission_map.get(ResourceType.MCPSERVER, {}).get(server_id, [])
+    return {
+        "server_id": server_id,
+        "permissions": perms
+    }
 
 @router.put(
     f"/permissions/servers/{{server_id}}",

--- a/registry/main.py
+++ b/registry/main.py
@@ -197,7 +197,7 @@ app.include_router(search_router, prefix=f"/api/{settings.API_VERSION}", tags=["
 app.include_router(health_router, prefix="/api/health", tags=["Health Monitoring"])
 app.include_router(oauth_router, prefix=f"/api/{settings.API_VERSION}", tags=["MCP  Oauth Management"])
 app.include_router(connection_router, prefix=f"/api/{settings.API_VERSION}", tags=["MCP  Connection Management"])
-app.include_router(acl_router, prefix=f"/api/{settings.API_VERSION}", tags=["Permission Management"])
+app.include_router(acl_router, prefix=f"/api/{settings.API_VERSION}", tags=["ACL Management"])
 app.include_router(auth_provider_router, tags=["Authentication"])
 
 # Register Anthropic MCP Registry API (public API for MCP servers only)

--- a/registry/schemas/permissions_schema.py
+++ b/registry/schemas/permissions_schema.py
@@ -1,8 +1,8 @@
 """
-Pydantic Schemas for Permission Management API v1
+Pydantic Schemas for ACL Management API v1
 
 These schemas define the request and response models for the
-Permission Management endpoints based on the API documentation.
+ACL Management endpoints based on the API documentation.
 """
 
 from typing import List, Optional

--- a/registry/schemas/permissions_schema.py
+++ b/registry/schemas/permissions_schema.py
@@ -15,7 +15,7 @@ class PermissionPrincipalIn(BaseModel):
     perm_bits: Optional[int] = 0
     accessRoleId: Optional[str] = None
 
-class UpdateServerPermissionsRequest(BaseModel):
+class UpdateResourcePermissionsRequest(BaseModel):
     updated: List[PermissionPrincipalIn] = Field(default_factory=list)
     removed: List[PermissionPrincipalIn] = Field(default_factory=list)
     public: bool = False
@@ -31,6 +31,6 @@ class PermissionPrincipalOut(BaseModel):
     accessRoleId: str
 
 
-class UpdateServerPermissionsResponse(BaseModel):
+class UpdateResourcePermissionsResponse(BaseModel):
     message: str
     results: dict

--- a/registry/schemas/permissions_schema.py
+++ b/registry/schemas/permissions_schema.py
@@ -26,8 +26,6 @@ class PermissionPrincipalOut(BaseModel):
     principal_id: str
     name: Optional[str] = None
     email: Optional[str] = None
-    source: Optional[str] = None
-    idOnTheSource: Optional[str] = None
     accessRoleId: str
 
 

--- a/registry/services/access_control_service.py
+++ b/registry/services/access_control_service.py
@@ -220,7 +220,6 @@ class ACLService:
 	) -> List:
 		"""
 		Search for principals (users, groups, agents) matching the query string.
-		Returns paginated results and metadata.
 		"""
 		query = (query or "").strip()
 		if not query or len(query) < 2:
@@ -266,7 +265,6 @@ class ACLService:
 	) -> Dict[str, Any]:
 		"""
 		Get all ACL permissions for a specific resource.
-		Returns a list of principals with their permission bits.
 		"""
 		try:
 			acl_entries = await IAclEntry.find({

--- a/registry/services/group_service.py
+++ b/registry/services/group_service.py
@@ -1,0 +1,25 @@
+from typing import List, Dict, Any
+from packages.models._generated import IGroup  
+from registry.utils.log import logger
+
+class GroupService:
+	async def search_groups(self, query: str) -> List[IGroup]:
+		"""
+		Search groups by name or email (case-insensitive substring match).
+		Returns a list of dicts with keys: id, name, email
+		"""
+		try:
+			query =  {
+                "$or": [
+					{"name": {"$regex": query, "$options": "i"}},
+                    {"email": {"$regex": query, "$options": "i"}},
+                ]
+            }
+			results = await IGroup.find(query).to_list()
+			return results
+		except Exception as e:
+			logger.error(f"Error searching groups with query '{query}': {e}")
+			return []
+
+
+group_service = GroupService()

--- a/registry/services/group_service.py
+++ b/registry/services/group_service.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import List
 from packages.models._generated import IGroup  
 from registry.utils.log import logger
 
@@ -6,19 +6,19 @@ class GroupService:
 	async def search_groups(self, query: str) -> List[IGroup]:
 		"""
 		Search groups by name or email (case-insensitive substring match).
-		Returns a list of dicts with keys: id, name, email
+		Returns a list of IGroup instances representing matching groups (e.g., with id, name, email fields).
 		"""
 		try:
-			query =  {
+			search_query =  {
                 "$or": [
 					{"name": {"$regex": query, "$options": "i"}},
                     {"email": {"$regex": query, "$options": "i"}},
                 ]
             }
-			results = await IGroup.find(query).to_list()
+			results = await IGroup.find(search_query).to_list()
 			return results
 		except Exception as e:
-			logger.error(f"Error searching groups with query '{query}': {e}")
+			logger.error(f"Error searching groups with query '{search_query}': {e}")
 			return []
 
 

--- a/registry/services/permissions_utils.py
+++ b/registry/services/permissions_utils.py
@@ -3,6 +3,7 @@ Permission utility functions for ACL checks.
 """
 
 from fastapi import HTTPException, status as http_status
+from registry.core.acl_constants import ResourceType
 
 def check_required_permission(acl_permission_map: dict, resource_type: str, resource_id: str, required_permission: str) -> None:
     """
@@ -27,4 +28,13 @@ def check_required_permission(acl_permission_map: dict, resource_type: str, reso
             }
         )
 
-    
+def validate_resource_type(resource_type: str) -> None: 
+    if resource_type not in [rt.value for rt in ResourceType]:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "invalid_resource_type",
+                "message": f"Resource type '{resource_type}' is not valid."
+            }
+        )
+            

--- a/registry/services/user_service.py
+++ b/registry/services/user_service.py
@@ -58,22 +58,22 @@ class UserService:
             user = await IUser.find_one({"email": email})
         return user
 
-    async def search_users(self, query: str, limit: int = 30, skip: int = 0) -> List[IUser]:
+    async def search_users(self, query: str) -> List[IUser]:
         """
         Search users by name, email, or username. Returns IUser model objects.
         """
         try:
-            query =  {
+            search_query =  {
                 "$or": [
                     {"email": {"$regex": query, "$options": "i"}},
                     {"name": {"$regex": query, "$options": "i"}},
                     {"username": {"$regex": query, "$options": "i"}}
                 ]
             }
-            results = await IUser.find(query).to_list()
+            results = await IUser.find(search_query).to_list()
             return results
         except Exception as e:
-            logger.error(f"Error searching users with query '{query}': {e}")
+            logger.error(f"Error searching users with query '{search_query}': {e}")
             return []
 
 user_service = UserService()

--- a/registry/services/user_service.py
+++ b/registry/services/user_service.py
@@ -1,5 +1,5 @@
 from datetime import timezone, datetime
-from typing import Optional
+from typing import Optional, List
 from beanie import PydanticObjectId
 from packages.models import IUser
 from registry.utils.log import logger
@@ -58,5 +58,22 @@ class UserService:
             user = await IUser.find_one({"email": email})
         return user
 
+    async def search_users(self, query: str, limit: int = 30, skip: int = 0) -> List[IUser]:
+        """
+        Search users by name, email, or username. Returns IUser model objects.
+        """
+        try:
+            query =  {
+                "$or": [
+                    {"email": {"$regex": query, "$options": "i"}},
+                    {"name": {"$regex": query, "$options": "i"}},
+                    {"username": {"$regex": query, "$options": "i"}}
+                ]
+            }
+            results = await IUser.find(query).to_list()
+            return results
+        except Exception as e:
+            logger.error(f"Error searching users with query '{query}': {e}")
+            return []
 
 user_service = UserService()


### PR DESCRIPTION
# PR Summary 

Adds the ACL APIs needed to build an ACL Management UI. See example UI from Jarvis below

- `GET /permissions/search-principals`: Search for principals (users, groups) by query string. Enables the ACL management UI to look up principals for permission assignment
- `GET /permissions/{resource_type}/{resource_id}`: Get all ACL permissions for a specific resource. Allows the ACL management UI to display which principals have access and whether the resource is public
- `PUT /permissions/{resource_type}/{resource_id}`: Update ACL permissions for a specific resource.
- Adds `acl_permissions_map` to `/auth/me` for showing/hiding UI features
<img width="750" height="459" alt="ACL UI Example" src="https://github.com/user-attachments/assets/eefd0fb9-5ed8-4137-b6bc-b8ec4b82ef5e" />
