### PR TITLE
Fix/delete oauth tokens

### DIFF
--- a/registry/api/v1/mcp/oauth_router.py
+++ b/registry/api/v1/mcp/oauth_router.py
@@ -424,9 +424,9 @@ async def delete_oauth_tokens(
             user_id, server_id
         )
         if disconnected:
-            logger.info(f"[Delete Oauth Tokens] Disconnected {server_id} for user {user_id}")
+            logger.info(f"[Delete OAuth Tokens] Disconnected {server_id} for user {user_id}")
         results = await token_service.delete_oauth_tokens(user_id, server.serverName)
-        logger.info(f"[Delete Oauth Tokens] Deleted OAuth tokens for {server_id}, results: {results}")
+        logger.info(f"[Delete OAuth Tokens] Deleted OAuth tokens for {server_id}, results: {results}")
         message = "successfully" if results else "failed"
         return {
             "success": results,

--- a/registry/api/v1/mcp/oauth_router.py
+++ b/registry/api/v1/mcp/oauth_router.py
@@ -424,9 +424,9 @@ async def delete_oauth_tokens(
             user_id, server_id
         )
         if disconnected:
-            logger.info(f"[Reinitialize] Disconnected {server_id} for user {user_id}")
+            logger.info(f"[Delete Oauth Tokens] Disconnected {server_id} for user {user_id}")
         results = await token_service.delete_oauth_tokens(user_id, server.serverName)
-        logger.info(f"[OAuth Refresh] Deleted OAuth tokens for {server_id}, results: {results}")
+        logger.info(f"[Delete Oauth Tokens] Deleted OAuth tokens for {server_id}, results: {results}")
         message = "successfully" if results else "failed"
         return {
             "success": results,


### PR DESCRIPTION
1. When deleting an OAuth token, disconnect the user's connection to this server.
2. fix test_oauth_router.py