### PR TITLE
fix: connection state

### DIFF
--- a/registry/api/v1/mcp/connection_router.py
+++ b/registry/api/v1/mcp/connection_router.py
@@ -65,7 +65,6 @@ async def reinitialize_server(
                 details={"reinitialized": True, "has_oauth": True}
             )
             logger.info(f"[Reinitialize] Created connection for {server_id}")
-
         return JSONResponse(
             status_code=status.HTTP_200_OK,
             content=response_data

--- a/registry/services/oauth/oauth_service.py
+++ b/registry/services/oauth/oauth_service.py
@@ -568,7 +568,7 @@ class MCPOAuthService:
         """
         Helper method: Build response indicating OAuth is required
         
-        Does NOT initiate OAuth flow - frontend should call /{server_id}/oauth/initiate
+        Does NOT initiate OAuth flow - frontend should call /api/v1/mcp/{server_id}/oauth/initiate
         This ensures connection status remains DISCONNECTED until frontend starts OAuth
         
         Args:

--- a/registry/services/oauth/status_resolver.py
+++ b/registry/services/oauth/status_resolver.py
@@ -146,9 +146,9 @@ class ConnectionStatusResolver:
                 if oauth_state == "failed":
                     logger.debug(f"OAuth flow failed for: {server_id}")
                     return ConnectionState.ERROR.value
-                # elif oauth_state == "active":
-                #     logger.debug(f"OAuth flow active for: {server_id}")
-                #     return ConnectionState.CONNECTING.value
+                elif oauth_state == "active": # ps: Once OAuth begins, it is considered ConnectionState.CONNECTING!
+                    logger.debug(f"OAuth flow active for: {server_id}")
+                    return ConnectionState.CONNECTING.value
 
         except Exception as e:
             logger.error(

--- a/registry/tests/unit/services/test_oauth_service.py
+++ b/registry/tests/unit/services/test_oauth_service.py
@@ -180,7 +180,8 @@ class TestMCPOAuthService:
 
     @pytest.mark.asyncio
     async def test_handle_reinitialize_auth_oauth_config_missing(self, oauth_service):
-        """Test handle_reinitialize_auth when OAuth configuration is missing"""
+        """Test handle_reinitialize_auth when OAuth configuration is missing
+        """
         user_id = "test_user"
         mock_server = Mock(spec=MCPServerDocument)
         mock_server.id = ObjectId("507f1f77bcf86cd799439011")
@@ -195,9 +196,8 @@ class TestMCPOAuthService:
         )
 
         assert needs_connection == False
-        assert response_data["success"] == False
-        # The error message from initiate_oauth_flow when oauth config is missing
-        assert "authentication configuration not found" in response_data["message"]
+        assert response_data["success"] == True
+        assert "OAuth authorization required" in response_data["message"]
 
     @pytest.mark.asyncio
     async def test_handle_reinitialize_auth_refresh_failure(self, oauth_service, mock_server):

--- a/registry/tests/unit/services/test_oauth_service.py
+++ b/registry/tests/unit/services/test_oauth_service.py
@@ -122,7 +122,7 @@ class TestMCPOAuthService:
                                  refresh_exists=True, refresh_valid=False)
 
         # Mock OAuth flow initiation
-        with patch.object(oauth_service, '_initiate_oauth_flow_response', AsyncMock(
+        with patch.object(oauth_service, '_build_oauth_required_response', AsyncMock(
                 return_value=(False, {
                     "success": True,
                     "authorization_url": "https://example.com/auth",
@@ -163,7 +163,7 @@ class TestMCPOAuthService:
                                  refresh_exists=False, refresh_valid=False)
 
         # Mock OAuth flow initiation
-        with patch.object(oauth_service, '_initiate_oauth_flow_response', AsyncMock(
+        with patch.object(oauth_service, '_build_oauth_required_response', AsyncMock(
                 return_value=(False, {
                     "success": True,
                     "authorization_url": "https://example.com/auth",


### PR DESCRIPTION
1. /reinitialize 接口不做任何 /initiate的逻辑，这样status为disconnected，前使用/initiate 进行oauth流程;
2. /initiate 开始oauth时，状态为连接中

@ryohang 周五晚上我们沟通的，我改的过程中，还是觉得让前端调initiate 就好了，逻辑清晰点；跟您说的一致； 