### PR TITLE
Control Log Level by .env if wanted

### DIFF
--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -13,6 +13,7 @@ the get-m2m-token.sh script.
 
 import json
 import logging
+import os
 import subprocess
 from typing import Optional, List, Dict, Any, Union
 from enum import Enum
@@ -24,9 +25,10 @@ from pydantic import BaseModel, Field, HttpUrl, ConfigDict
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
+
 logger = logging.getLogger(__name__)
 
 

--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel, Field, HttpUrl, ConfigDict
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -22,10 +22,11 @@ from urllib.parse import quote
 
 import requests
 from pydantic import BaseModel, Field, HttpUrl, ConfigDict
+from registry.core.config import settings
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -13,8 +13,6 @@ the get-m2m-token.sh script.
 
 import json
 import logging
-import os
-import subprocess
 from typing import Optional, List, Dict, Any, Union
 from enum import Enum
 from datetime import datetime
@@ -26,8 +24,8 @@ from registry.core.config import settings
 
 # Configure logging
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -203,7 +203,7 @@ from registry_client import (
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -204,8 +204,8 @@ from registry_client import (
 
 # Configure logging
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -203,9 +203,10 @@ from registry_client import (
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
+
 logger = logging.getLogger(__name__)
 
 

--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -169,6 +169,7 @@ import sys
 from pathlib import Path
 from typing import Optional, List, Dict, Any
 
+from registry.core.config import settings
 from registry_client import (
     RegistryClient,
     InternalServiceRegistration,
@@ -203,7 +204,7 @@ from registry_client import (
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/auth_server/core/config.py
+++ b/auth_server/core/config.py
@@ -99,6 +99,7 @@ class AuthSettings(BaseSettings):
     
     # ==================== Logging Settings ====================
     log_level: int = logging.INFO  # Default to INFO (20), can be overridden by LOG_LEVEL env var
+    log_format: str = "%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s"
     
     # ==================== Metrics Settings ====================
     metrics_service_url: str = "http://localhost:8890"

--- a/auth_server/core/config.py
+++ b/auth_server/core/config.py
@@ -5,6 +5,8 @@ Centralized configuration management using Pydantic Settings.
 All environment variables are loaded here and accessed through the global `settings` instance.
 """
 
+import logging
+import os
 import secrets
 import yaml
 from pathlib import Path
@@ -94,6 +96,9 @@ class AuthSettings(BaseSettings):
     entra_client_id: Optional[str] = None
     entra_client_secret: Optional[str] = None
     entra_token_kind: str = "id"  # "id" or "access"
+    
+    # ==================== Logging Settings ====================
+    log_level: int = logging.INFO  # Default to INFO (20), can be overridden by LOG_LEVEL env var
     
     # ==================== Metrics Settings ====================
     metrics_service_url: str = "http://localhost:8890"

--- a/auth_server/providers/base.py
+++ b/auth_server/providers/base.py
@@ -6,7 +6,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/auth_server/providers/base.py
+++ b/auth_server/providers/base.py
@@ -2,11 +2,12 @@
 
 import logging
 from abc import ABC, abstractmethod
-import os
 from typing import Any, Dict, List, Optional
 
+from ..core.config import settings
+
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.log_level,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/auth_server/providers/base.py
+++ b/auth_server/providers/base.py
@@ -2,11 +2,12 @@
 
 import logging
 from abc import ABC, abstractmethod
+import os
 from typing import Any, Dict, List, Optional
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/auth_server/providers/base.py
+++ b/auth_server/providers/base.py
@@ -8,7 +8,7 @@ from ..core.config import settings
 
 logging.basicConfig(
     level=settings.log_level,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/auth_server/providers/cognito.py
+++ b/auth_server/providers/cognito.py
@@ -14,7 +14,7 @@ import requests
 from .base import AuthProvider
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/auth_server/providers/cognito.py
+++ b/auth_server/providers/cognito.py
@@ -15,7 +15,7 @@ from ..core.config import settings
 
 logging.basicConfig(
     level=settings.log_level,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/auth_server/providers/cognito.py
+++ b/auth_server/providers/cognito.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import os
 import time
 from functools import lru_cache
 from typing import Any, Dict, List, Optional
@@ -12,9 +11,10 @@ import jwt
 import requests
 
 from .base import AuthProvider
+from ..core.config import settings
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.log_level,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/auth_server/providers/cognito.py
+++ b/auth_server/providers/cognito.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import time
 from functools import lru_cache
 from typing import Any, Dict, List, Optional
@@ -13,8 +14,8 @@ import requests
 from .base import AuthProvider
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/auth_server/providers/entra.py
+++ b/auth_server/providers/entra.py
@@ -7,9 +7,10 @@ from typing import Any, Dict, Optional
 from urllib.parse import urlencode
 from .base import AuthProvider
 from ..utils.config_loader import get_provider_config
+from ..core.config import settings
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.log_level,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/auth_server/providers/entra.py
+++ b/auth_server/providers/entra.py
@@ -9,8 +9,8 @@ from .base import AuthProvider
 from ..utils.config_loader import get_provider_config
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/auth_server/providers/entra.py
+++ b/auth_server/providers/entra.py
@@ -11,7 +11,7 @@ from ..core.config import settings
 
 logging.basicConfig(
     level=settings.log_level,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/auth_server/providers/entra.py
+++ b/auth_server/providers/entra.py
@@ -9,7 +9,7 @@ from .base import AuthProvider
 from ..utils.config_loader import get_provider_config
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/auth_server/providers/factory.py
+++ b/auth_server/providers/factory.py
@@ -11,8 +11,8 @@ from ..utils.config_loader import get_provider_config
 from ..core.config import settings
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/auth_server/providers/factory.py
+++ b/auth_server/providers/factory.py
@@ -11,7 +11,7 @@ from ..utils.config_loader import get_provider_config
 from ..core.config import settings
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.log_level,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/auth_server/providers/factory.py
+++ b/auth_server/providers/factory.py
@@ -11,7 +11,7 @@ from ..utils.config_loader import get_provider_config
 from ..core.config import settings
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/auth_server/providers/factory.py
+++ b/auth_server/providers/factory.py
@@ -12,7 +12,7 @@ from ..core.config import settings
 
 logging.basicConfig(
     level=settings.log_level,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/auth_server/providers/keycloak.py
+++ b/auth_server/providers/keycloak.py
@@ -14,7 +14,7 @@ import requests
 from .base import AuthProvider
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/auth_server/providers/keycloak.py
+++ b/auth_server/providers/keycloak.py
@@ -15,7 +15,7 @@ from ..core.config import settings
 
 logging.basicConfig(
     level=settings.log_level,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/auth_server/providers/keycloak.py
+++ b/auth_server/providers/keycloak.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import os
 import time
 from functools import lru_cache
 from typing import Any, Dict, List, Optional
@@ -12,9 +11,10 @@ import jwt
 import requests
 
 from .base import AuthProvider
+from ..core.config import settings
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.log_level,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/auth_server/providers/keycloak.py
+++ b/auth_server/providers/keycloak.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import time
 from functools import lru_cache
 from typing import Any, Dict, List, Optional
@@ -13,8 +14,8 @@ import requests
 from .base import AuthProvider
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -6,7 +6,6 @@ Configuration is passed via headers instead of environment variables.
 import argparse
 import logging
 from contextlib import asynccontextmanager
-import os
 from fastapi import FastAPI
 import jwt
 import time
@@ -46,7 +45,7 @@ validator = SimplifiedCognitoValidator()
 # Configure logging
 logging.basicConfig(
     level=settings.log_level,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -6,6 +6,7 @@ Configuration is passed via headers instead of environment variables.
 import argparse
 import logging
 from contextlib import asynccontextmanager
+import os
 from fastapi import FastAPI
 import jwt
 import time
@@ -44,10 +45,10 @@ validator = SimplifiedCognitoValidator()
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,  # Set the log level to INFO
-    # Define log message format
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
+
 logger = logging.getLogger(__name__)
 
 

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -45,7 +45,7 @@ validator = SimplifiedCognitoValidator()
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.log_level,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -45,7 +45,7 @@ validator = SimplifiedCognitoValidator()
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/credentials-provider/add_noauth_services.py
+++ b/credentials-provider/add_noauth_services.py
@@ -17,8 +17,8 @@ from typing import Dict, List, Any, Optional
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/credentials-provider/add_noauth_services.py
+++ b/credentials-provider/add_noauth_services.py
@@ -18,8 +18,8 @@ from registry.core.config import settings
 
 # Configure logging
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/credentials-provider/add_noauth_services.py
+++ b/credentials-provider/add_noauth_services.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Any, Optional
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/credentials-provider/add_noauth_services.py
+++ b/credentials-provider/add_noauth_services.py
@@ -14,10 +14,11 @@ import os
 import sys
 from pathlib import Path
 from typing import Dict, List, Any, Optional
+from registry.core.config import settings
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/credentials-provider/oauth/egress_oauth.py
+++ b/credentials-provider/oauth/egress_oauth.py
@@ -39,7 +39,7 @@ from typing import Dict, Any, Optional, List
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/credentials-provider/oauth/egress_oauth.py
+++ b/credentials-provider/oauth/egress_oauth.py
@@ -40,8 +40,8 @@ from registry.core.config import settings
 
 # Configure logging
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/credentials-provider/oauth/egress_oauth.py
+++ b/credentials-provider/oauth/egress_oauth.py
@@ -39,9 +39,10 @@ from typing import Dict, Any, Optional, List
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
+
 logger = logging.getLogger(__name__)
 
 # Try to load .env file if python-dotenv is available

--- a/credentials-provider/oauth/egress_oauth.py
+++ b/credentials-provider/oauth/egress_oauth.py
@@ -36,10 +36,11 @@ import sys
 import time
 from pathlib import Path
 from typing import Dict, Any, Optional, List
+from registry.core.config import settings
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/credentials-provider/oauth/generic_oauth_flow.py
+++ b/credentials-provider/oauth/generic_oauth_flow.py
@@ -61,7 +61,7 @@ import yaml
 
 # Configure logging first
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/credentials-provider/oauth/generic_oauth_flow.py
+++ b/credentials-provider/oauth/generic_oauth_flow.py
@@ -63,8 +63,8 @@ from registry.core.config import settings
 
 # Configure logging first
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger("generic-oauth")

--- a/credentials-provider/oauth/generic_oauth_flow.py
+++ b/credentials-provider/oauth/generic_oauth_flow.py
@@ -61,9 +61,10 @@ import yaml
 
 # Configure logging first
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
+
 logger = logging.getLogger("generic-oauth")
 
 # Try to load .env file if python-dotenv is available

--- a/credentials-provider/oauth/generic_oauth_flow.py
+++ b/credentials-provider/oauth/generic_oauth_flow.py
@@ -59,9 +59,11 @@ from typing import Any, Dict, List, Optional, Union
 import requests
 import yaml
 
+from registry.core.config import settings
+
 # Configure logging first
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/credentials-provider/oauth/ingress_oauth.py
+++ b/credentials-provider/oauth/ingress_oauth.py
@@ -50,8 +50,8 @@ from registry.core.config import settings
 
 # Configure logging
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/credentials-provider/oauth/ingress_oauth.py
+++ b/credentials-provider/oauth/ingress_oauth.py
@@ -48,7 +48,7 @@ import requests
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/credentials-provider/oauth/ingress_oauth.py
+++ b/credentials-provider/oauth/ingress_oauth.py
@@ -48,9 +48,10 @@ import requests
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
+
 logger = logging.getLogger(__name__)
 
 # Try to load .env file if python-dotenv is available

--- a/credentials-provider/oauth/ingress_oauth.py
+++ b/credentials-provider/oauth/ingress_oauth.py
@@ -46,9 +46,11 @@ from typing import Dict, Any, Optional
 
 import requests
 
+from registry.core.config import settings
+
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/credentials-provider/token_refresher.py
+++ b/credentials-provider/token_refresher.py
@@ -29,9 +29,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from registry.core.config import settings
+
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/credentials-provider/token_refresher.py
+++ b/credentials-provider/token_refresher.py
@@ -33,8 +33,8 @@ from registry.core.config import settings
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/credentials-provider/token_refresher.py
+++ b/credentials-provider/token_refresher.py
@@ -31,7 +31,7 @@ from typing import Dict, List, Optional, Tuple
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/credentials-provider/token_refresher.py
+++ b/credentials-provider/token_refresher.py
@@ -31,9 +31,10 @@ from typing import Dict, List, Optional, Tuple
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
+
 logger = logging.getLogger(__name__)
 
 

--- a/metrics-service/app/config.py
+++ b/metrics-service/app/config.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Optional
 
@@ -13,6 +14,18 @@ class Settings:
     # Service settings
     METRICS_SERVICE_PORT: int = int(os.getenv("METRICS_SERVICE_PORT", "8890"))
     METRICS_SERVICE_HOST: str = os.getenv("METRICS_SERVICE_HOST", "0.0.0.0")
+    
+    # Logging settings
+    log_level: int = logging.INFO
+    
+    def __init__(self):
+        # Handle LOG_LEVEL environment variable (supports both int and string formats)
+        if os.getenv("LOG_LEVEL"):
+            try:
+                self.log_level = int(os.getenv("LOG_LEVEL"))
+            except ValueError:
+                # If it's a string like "DEBUG", convert to logging constant
+                self.log_level = getattr(logging, os.getenv("LOG_LEVEL").upper(), logging.INFO)
     
     # OpenTelemetry settings
     OTEL_SERVICE_NAME: str = os.getenv("OTEL_SERVICE_NAME", "mcp-metrics-service")

--- a/metrics-service/app/config.py
+++ b/metrics-service/app/config.py
@@ -17,6 +17,7 @@ class Settings:
     
     # Logging settings
     log_level: int = logging.INFO
+    log_format: str = "%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s"
     
     def __init__(self):
         # Handle LOG_LEVEL environment variable (supports both int and string formats)

--- a/metrics-service/app/main.py
+++ b/metrics-service/app/main.py
@@ -8,11 +8,10 @@ from .storage.database import init_database, wait_for_database, MetricsStorage
 from .core.rate_limiter import rate_limiter
 from .core.retention import retention_manager
 from .utils.helpers import hash_api_key
-import os
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.log_level,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/metrics-service/app/main.py
+++ b/metrics-service/app/main.py
@@ -12,7 +12,7 @@ from .utils.helpers import hash_api_key
 # Configure logging
 logging.basicConfig(
     level=settings.log_level,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/metrics-service/app/main.py
+++ b/metrics-service/app/main.py
@@ -12,9 +12,10 @@ import os
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
+
 logger = logging.getLogger(__name__)
 
 

--- a/metrics-service/app/main.py
+++ b/metrics-service/app/main.py
@@ -12,7 +12,7 @@ import os
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -36,7 +36,7 @@ from registry.services.agent_scanner import agent_scanner_service
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -9,7 +9,6 @@ Based on: docs/design/a2a-protocol-integration.md
 
 import logging
 from datetime import datetime, timezone
-import os
 from typing import Annotated, Dict, List, Optional, Any
 
 from fastapi import (
@@ -36,8 +35,8 @@ from registry.services.agent_scanner import agent_scanner_service
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -36,7 +36,7 @@ from registry.services.agent_scanner import agent_scanner_service
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -9,6 +9,7 @@ Based on: docs/design/a2a-protocol-integration.md
 
 import logging
 from datetime import datetime, timezone
+import os
 from typing import Annotated, Dict, List, Optional, Any
 
 from fastapi import (
@@ -35,8 +36,8 @@ from registry.services.agent_scanner import agent_scanner_service
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import secrets
 from pathlib import Path
@@ -112,7 +113,7 @@ class Settings(BaseSettings):
     JWT_AUDIENCE: str = "jarvis-services"
     JWT_SELF_SIGNED_KID: str = "self-signed-key-v1"
     API_VERSION: str = "v1"
-    LOG_LEVEL: str = "INFO"
+    LOG_LEVEL: int = logging.INFO  # Default to INFO (20), can be overridden by LOG_LEVEL env var
 
     # Local development mode detection
     @property
@@ -122,6 +123,7 @@ class Settings(BaseSettings):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        
         # Generate secret key if not provided
         if not self.secret_key:
             self.secret_key = secrets.token_hex(32)

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -113,7 +113,8 @@ class Settings(BaseSettings):
     JWT_AUDIENCE: str = "jarvis-services"
     JWT_SELF_SIGNED_KID: str = "self-signed-key-v1"
     API_VERSION: str = "v1"
-    LOG_LEVEL: int = logging.INFO  # Default to INFO (20), can be overridden by LOG_LEVEL env var
+    log_level: int = logging.INFO  # Default to INFO (20), can be overridden by LOG_LEVEL env var
+    log_format: str = "%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s"
 
     # Local development mode detection
     @property

--- a/registry/schemas/agent_models.py
+++ b/registry/schemas/agent_models.py
@@ -9,8 +9,8 @@ Based on: docs/design/a2a-protocol-integration.md
 
 import logging
 from datetime import datetime
-import os
 from typing import Any, Dict, List, Optional, Union
+from ..core.config import settings
 
 from pydantic import (
     BaseModel,
@@ -23,8 +23,8 @@ from pydantic import (
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/schemas/agent_models.py
+++ b/registry/schemas/agent_models.py
@@ -23,7 +23,7 @@ from pydantic import (
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/schemas/agent_models.py
+++ b/registry/schemas/agent_models.py
@@ -23,7 +23,7 @@ from pydantic import (
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/schemas/agent_models.py
+++ b/registry/schemas/agent_models.py
@@ -9,6 +9,7 @@ Based on: docs/design/a2a-protocol-integration.md
 
 import logging
 from datetime import datetime
+import os
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import (
@@ -22,8 +23,8 @@ from pydantic import (
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/schemas/anthropic_schema.py
+++ b/registry/schemas/anthropic_schema.py
@@ -5,14 +5,14 @@ Based on: https://raw.githubusercontent.com/modelcontextprotocol/registry/refs/h
 """
 
 import logging
-import os
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
+from ..core.config import settings
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/schemas/anthropic_schema.py
+++ b/registry/schemas/anthropic_schema.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/schemas/anthropic_schema.py
+++ b/registry/schemas/anthropic_schema.py
@@ -5,15 +5,17 @@ Based on: https://raw.githubusercontent.com/modelcontextprotocol/registry/refs/h
 """
 
 import logging
+import os
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
+
 
 logger = logging.getLogger(__name__)
 

--- a/registry/schemas/anthropic_schema.py
+++ b/registry/schemas/anthropic_schema.py
@@ -12,8 +12,8 @@ from ..core.config import settings
 
 
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 

--- a/registry/services/agent_service.py
+++ b/registry/services/agent_service.py
@@ -10,7 +10,6 @@ Based on: registry/services/server_service.py
 import json
 import logging
 from datetime import datetime, timezone
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -20,8 +19,8 @@ from ..schemas.agent_models import AgentCard, AgentInfo
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/agent_service.py
+++ b/registry/services/agent_service.py
@@ -20,7 +20,7 @@ from ..schemas.agent_models import AgentCard, AgentInfo
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/agent_service.py
+++ b/registry/services/agent_service.py
@@ -10,6 +10,7 @@ Based on: registry/services/server_service.py
 import json
 import logging
 from datetime import datetime, timezone
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -19,8 +20,8 @@ from ..schemas.agent_models import AgentCard, AgentInfo
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/agent_service.py
+++ b/registry/services/agent_service.py
@@ -20,7 +20,7 @@ from ..schemas.agent_models import AgentCard, AgentInfo
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/agent_transform_service.py
+++ b/registry/services/agent_transform_service.py
@@ -6,6 +6,7 @@ following the same pattern as the server transform service.
 """
 
 import logging
+import os
 from typing import Any, Dict, List, Optional
 
 from ..constants import REGISTRY_CONSTANTS
@@ -19,8 +20,8 @@ from ..schemas.anthropic_schema import (
 
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/agent_transform_service.py
+++ b/registry/services/agent_transform_service.py
@@ -20,8 +20,8 @@ from ..schemas.anthropic_schema import (
 
 
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/agent_transform_service.py
+++ b/registry/services/agent_transform_service.py
@@ -20,7 +20,7 @@ from ..schemas.anthropic_schema import (
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/agent_transform_service.py
+++ b/registry/services/agent_transform_service.py
@@ -6,10 +6,10 @@ following the same pattern as the server transform service.
 """
 
 import logging
-import os
 from typing import Any, Dict, List, Optional
 
 from ..constants import REGISTRY_CONSTANTS
+from ..core.config import settings
 from ..schemas.anthropic_schema import (
     Package,
     PaginationMetadata,
@@ -20,7 +20,7 @@ from ..schemas.anthropic_schema import (
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/federation/anthropic_client.py
+++ b/registry/services/federation/anthropic_client.py
@@ -16,8 +16,8 @@ from ...schemas.federation_schema import AnthropicServerConfig
 
 
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/federation/anthropic_client.py
+++ b/registry/services/federation/anthropic_client.py
@@ -16,7 +16,7 @@ from ...schemas.federation_schema import AnthropicServerConfig
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/federation/anthropic_client.py
+++ b/registry/services/federation/anthropic_client.py
@@ -6,17 +6,17 @@ and transforms them to the gateway's internal format.
 """
 
 import logging
-import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
 from .base_client import BaseFederationClient
+from ...core.config import settings
 from ...schemas.federation_schema import AnthropicServerConfig
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/federation/anthropic_client.py
+++ b/registry/services/federation/anthropic_client.py
@@ -16,8 +16,8 @@ from ...schemas.federation_schema import AnthropicServerConfig
 
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/federation/asor_client.py
+++ b/registry/services/federation/asor_client.py
@@ -16,8 +16,8 @@ from ...schemas.federation_schema import AsorAgentConfig
 
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/federation/asor_client.py
+++ b/registry/services/federation/asor_client.py
@@ -17,8 +17,8 @@ from ...schemas.federation_schema import AsorAgentConfig
 
 
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/federation/asor_client.py
+++ b/registry/services/federation/asor_client.py
@@ -12,11 +12,12 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
 from .base_client import BaseFederationClient
+from ...core.config import settings
 from ...schemas.federation_schema import AsorAgentConfig
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/federation/asor_client.py
+++ b/registry/services/federation/asor_client.py
@@ -16,7 +16,7 @@ from ...schemas.federation_schema import AsorAgentConfig
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/federation/base_client.py
+++ b/registry/services/federation/base_client.py
@@ -13,7 +13,7 @@ import httpx
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/federation/base_client.py
+++ b/registry/services/federation/base_client.py
@@ -13,8 +13,8 @@ from ...core.config import settings
 
 
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/federation/base_client.py
+++ b/registry/services/federation/base_client.py
@@ -6,14 +6,15 @@ Provides common functionality for all federation clients.
 
 import logging
 from abc import ABC, abstractmethod
+import os
 from typing import Any, Dict, List, Optional
 
 import httpx
 
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/federation/base_client.py
+++ b/registry/services/federation/base_client.py
@@ -6,14 +6,14 @@ Provides common functionality for all federation clients.
 
 import logging
 from abc import ABC, abstractmethod
-import os
 from typing import Any, Dict, List, Optional
 
 import httpx
+from ...core.config import settings
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/federation_service.py
+++ b/registry/services/federation_service.py
@@ -25,7 +25,7 @@ from .federation.asor_client import AsorFederationClient
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/federation_service.py
+++ b/registry/services/federation_service.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ..core.config import settings
 from ..schemas.federation_schema import (
     AnthropicFederationConfig,
     FederatedServer,
@@ -25,7 +26,7 @@ from .federation.asor_client import AsorFederationClient
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/federation_service.py
+++ b/registry/services/federation_service.py
@@ -26,8 +26,8 @@ from .federation.asor_client import AsorFederationClient
 
 
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/federation_service.py
+++ b/registry/services/federation_service.py
@@ -25,8 +25,8 @@ from .federation.asor_client import AsorFederationClient
 
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/search/service.py
+++ b/registry/services/search/service.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from .embedded_service import EmbeddedFaissService
     from .external_service import ExternalVectorSearchService
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/search/service.py
+++ b/registry/services/search/service.py
@@ -8,7 +8,6 @@ Depending on the configuration (discovery_mode), it will either use:
 """
 
 import logging
-import os
 from typing import TYPE_CHECKING
 
 from registry.core.config import settings
@@ -18,7 +17,7 @@ if TYPE_CHECKING:
     from .embedded_service import EmbeddedFaissService
     from .external_service import ExternalVectorSearchService
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/search/service.py
+++ b/registry/services/search/service.py
@@ -8,6 +8,7 @@ Depending on the configuration (discovery_mode), it will either use:
 """
 
 import logging
+import os
 from typing import TYPE_CHECKING
 
 from registry.core.config import settings
@@ -17,9 +18,10 @@ if TYPE_CHECKING:
     from .embedded_service import EmbeddedFaissService
     from .external_service import ExternalVectorSearchService
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
+
 
 logger = logging.getLogger(__name__)
 

--- a/registry/services/search/service.py
+++ b/registry/services/search/service.py
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
     from .embedded_service import EmbeddedFaissService
     from .external_service import ExternalVectorSearchService
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 

--- a/registry/services/transform_service.py
+++ b/registry/services/transform_service.py
@@ -20,8 +20,8 @@ from ..schemas.anthropic_schema import (
 
 
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/transform_service.py
+++ b/registry/services/transform_service.py
@@ -5,6 +5,7 @@ This bridges our internal data model with the external Anthropic API format.
 """
 
 import logging
+import os
 from typing import Any, Dict, List, Optional
 
 from ..constants import REGISTRY_CONSTANTS
@@ -19,8 +20,8 @@ from ..schemas.anthropic_schema import (
 
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/services/transform_service.py
+++ b/registry/services/transform_service.py
@@ -20,7 +20,7 @@ from ..schemas.anthropic_schema import (
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/services/transform_service.py
+++ b/registry/services/transform_service.py
@@ -5,10 +5,10 @@ This bridges our internal data model with the external Anthropic API format.
 """
 
 import logging
-import os
 from typing import Any, Dict, List, Optional
 
 from ..constants import REGISTRY_CONSTANTS
+from ..core.config import settings
 from ..schemas.anthropic_schema import (
     Package,
     PaginationMetadata,
@@ -20,7 +20,7 @@ from ..schemas.anthropic_schema import (
 
 
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/utils/agent_validator.py
+++ b/registry/utils/agent_validator.py
@@ -30,8 +30,8 @@ from registry.schemas.agent_models import (
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/utils/agent_validator.py
+++ b/registry/utils/agent_validator.py
@@ -30,7 +30,7 @@ from registry.schemas.agent_models import (
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/utils/agent_validator.py
+++ b/registry/utils/agent_validator.py
@@ -9,6 +9,7 @@ Based on: docs/design/a2a-protocol-integration.md
 """
 
 import logging
+import os
 import re
 from typing import (
     Dict,
@@ -29,8 +30,8 @@ from registry.schemas.agent_models import (
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+    level=os.environ.get("LOGLEVEL", "INFO"),
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 
 logger = logging.getLogger(__name__)

--- a/registry/utils/agent_validator.py
+++ b/registry/utils/agent_validator.py
@@ -9,7 +9,6 @@ Based on: docs/design/a2a-protocol-integration.md
 """
 
 import logging
-import os
 import re
 from typing import (
     Dict,
@@ -21,6 +20,7 @@ from typing import (
 import httpx
 from pydantic import BaseModel
 
+from registry.core.config import settings
 from registry.schemas.agent_models import (
     AgentCard,
     SecurityScheme,
@@ -30,7 +30,7 @@ from registry.schemas.agent_models import (
 
 # Configure logging with basicConfig
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/registry/utils/log.py
+++ b/registry/utils/log.py
@@ -14,8 +14,7 @@ def setup_logging():
     log_file = log_dir / "registry.log"
 
     # Get log level from settings
-    log_level_str = settings.LOG_LEVEL.upper()
-    log_level = getattr(logging, log_level_str, logging.INFO)
+    log_level = settings.log_level
 
     # Create formatters
     file_formatter = logging.Formatter(

--- a/servers/currenttime/server.py
+++ b/servers/currenttime/server.py
@@ -11,9 +11,10 @@ from typing import Annotated
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
+    level=os.environ.get("LOGLEVEL", "INFO"),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
+
 logger = logging.getLogger(__name__)
 
 def parse_arguments():

--- a/servers/currenttime/server.py
+++ b/servers/currenttime/server.py
@@ -12,8 +12,8 @@ from registry.core.config import settings
 
 # Configure logging
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
 
 logger = logging.getLogger(__name__)

--- a/servers/currenttime/server.py
+++ b/servers/currenttime/server.py
@@ -8,10 +8,11 @@ import logging
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 from typing import Annotated
+from registry.core.config import settings
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
+    level=settings.LOG_LEVEL,
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/servers/currenttime/server.py
+++ b/servers/currenttime/server.py
@@ -11,7 +11,7 @@ from typing import Annotated
 
 # Configure logging
 logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
+    level=os.environ.get("LOGLEVEL", logging.INFO).upper(),
     format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 

--- a/servers/mcpgw/config.py
+++ b/servers/mcpgw/config.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import os
 
 from pathlib import Path
 from typing import Optional
@@ -84,9 +83,13 @@ class Settings(BaseSettings):
     )
 
     # Logging configuration
-    LOG_LEVEL: int = Field(
+    log_level: int = Field(
         default=logging.INFO,
         description="Logging level (integer constant from logging module)"
+    )
+    log_format: str = Field(
+        default="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+        description="Logging format string"
     )
 
     API_VERSION: str = "v1"
@@ -178,9 +181,9 @@ def parse_arguments() -> argparse.Namespace:
 settings = Settings()
 
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+    level=settings.log_level,
+    format=settings.log_format
 )
-logger.setLevel(settings.LOG_LEVEL)
+logger.setLevel(settings.log_level)
 
 settings.log_config()

--- a/servers/mcpgw/config.py
+++ b/servers/mcpgw/config.py
@@ -4,15 +4,10 @@ import os
 
 from pathlib import Path
 from typing import Optional
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-logging.basicConfig(
-    level=os.environ.get("LOGLEVEL", "INFO"),
-    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
-)
 logger = logging.getLogger(__name__)
-
 
 class Constants:
     """Application constants that don't change."""
@@ -88,6 +83,12 @@ class Settings(BaseSettings):
         description="Key ID for self-signed JWT tokens"
     )
 
+    # Logging configuration
+    LOG_LEVEL: int = Field(
+        default=logging.INFO,
+        description="Logging level (integer constant from logging module)"
+    )
+
     API_VERSION: str = "v1"
 
     model_config = SettingsConfigDict(
@@ -106,6 +107,14 @@ class Settings(BaseSettings):
         if not v:
             raise ValueError("REGISTRY_URL must be set")
         return v.rstrip("/")
+    
+    @field_validator("LOG_LEVEL", mode='before')
+    @classmethod
+    def convert_log_level(cls, v):
+        """Convert string log level names to integers (e.g., 'DEBUG' -> 10)."""
+        if isinstance(v, str):
+            return getattr(logging, v.upper(), logging.INFO)
+        return v
 
     @property
     def scopes_config_path(self) -> Path:
@@ -135,6 +144,7 @@ class Settings(BaseSettings):
         logger.info(f"  MCP Transport: {self.MCP_TRANSPORT}")
         logger.info(f"  Listen Port: {self.MCP_SERVER_LISTEN_PORT}")
         logger.info(f"  Auth Server URL: {self.AUTH_SERVER_URL}")
+        logger.info(f"  Log Level: {self.LOG_LEVEL}")
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -166,5 +176,11 @@ def parse_arguments() -> argparse.Namespace:
 
 # Create global settings instance
 settings = Settings()
+
+logging.basicConfig(
+    level=settings.LOG_LEVEL,
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
+)
+logger.setLevel(settings.LOG_LEVEL)
 
 settings.log_config()


### PR DESCRIPTION
There is no uniform way to change logging level and it varies per sub-project. Most projects use `logger.basicConfig` so changing that to support using a loglevel you may want.