### PR TITLE
Remove unused settings route

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -135,18 +135,6 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                       )}
                     </Menu.Item>
 
-                    <Menu.Item>
-                      {({ active }) => (
-                        <Link
-                          to='/settings'
-                          className={`${active ? 'bg-gray-100 dark:bg-gray-800' : ''} flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-100`}
-                        >
-                          <Cog6ToothIcon className='mr-3 h-4 w-4' />
-                          Settings
-                        </Link>
-                      )}
-                    </Menu.Item>
-
                     <div className='border-t border-gray-100 dark:border-gray-700 my-1' />
 
                     <Menu.Item>


### PR DESCRIPTION
There is currently a `settings` route available in the top-right drop down. This route does not exist in the project.
<img width="455" height="433" alt="image" src="https://github.com/user-attachments/assets/edf40ad0-ee0a-458b-9e30-83d25617eb65" />

This PR removes the ability to go to the dead page
<img width="477" height="228" alt="image" src="https://github.com/user-attachments/assets/80b469ad-d94f-4a0d-93e9-c1eab03490d8" />
