### PR TITLE
Clean up Toast Component

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -53,7 +53,7 @@ const Toast: React.FC<ToastProps> = ({ message, type, onClose }) => {
 
   return createPortal(
     <div
-      className='fixed top-4 right-4 z-[100] animate-slide-in-top'
+      className='fixed top-4 right-4 z-[100] max-w-full animate-slide-in-top'
       onClick={e => e.stopPropagation()}
       onMouseDown={e => e.stopPropagation()}
     >
@@ -69,7 +69,7 @@ const Toast: React.FC<ToastProps> = ({ message, type, onClose }) => {
         ) : (
           <ExclamationCircleIcon className='h-5 w-5 mr-3 flex-shrink-0' />
         )}
-        <p className='text-sm font-medium'>{message}</p>
+        <p className='text-sm font-medium max-w-full truncate'>{message}</p>
         <button
           onClick={e => {
             e.stopPropagation();


### PR DESCRIPTION
If the toast was too long it would overflow off of the page. 
If the toast had too many characters within it, the text would overflow outside of the toast.

Fix:
1. Toast should go no bigger than the width of the page
2. If the text is too long it will be truncated.

# Old Behavior
<img width="711" height="647" alt="image" src="https://github.com/user-attachments/assets/7d28360a-0b44-4f33-a204-531b7ab76742" />
<img width="1512" height="739" alt="image" src="https://github.com/user-attachments/assets/3a2175a5-669c-49de-a788-f851cb424347" />

# New Behavior
<img width="641" height="533" alt="image" src="https://github.com/user-attachments/assets/f7c52b3f-cb94-4654-aaf9-4ba2d63b4d3a" />
<img width="1512" height="726" alt="image" src="https://github.com/user-attachments/assets/8bc1d52a-d684-415f-9527-77215dfe5548" />

