### PR TITLE
Fix: Various config file paths.

### DIFF
--- a/auth-server/src/auth_server/core/config.py
+++ b/auth-server/src/auth_server/core/config.py
@@ -10,8 +10,8 @@ import secrets
 from pathlib import Path
 
 import yaml
-from pydantic import ConfigDict, field_validator
-from pydantic_settings import BaseSettings
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from ..utils.config_loader import get_oauth2_config
 
@@ -38,7 +38,7 @@ def load_scopes_config() -> dict:
 class AuthSettings(BaseSettings):
     """Auth server settings with environment variable support."""
 
-    model_config = ConfigDict(
+    model_config = SettingsConfigDict(
         env_file=".env",
         case_sensitive=False,
         extra="ignore",  # Ignore extra environment variables

--- a/docker/Dockerfile.auth
+++ b/docker/Dockerfile.auth
@@ -17,6 +17,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+WORKDIR /app
+
+# Copy over config files
+COPY ./config /app/config/
+
+# Point to the OTEL metrics config file
+ENV OTEL_METRICS_CONFIG_PATH=/app/config/metrics/auth_server.yml
+
 # Create logs directory
 RUN mkdir -p /app/logs
 

--- a/docker/Dockerfile.registry
+++ b/docker/Dockerfile.registry
@@ -28,6 +28,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Copy over config files
+COPY ./config /app/config/
+
+# Point to the OTEL metrics config file
+ENV OTEL_METRICS_CONFIG_PATH=/app/config/metrics/registry.yml
+
 # Create logs directory
 RUN mkdir -p /app/logs
 

--- a/registry-pkgs/src/registry_pkgs/core/config.py
+++ b/registry-pkgs/src/registry_pkgs/core/config.py
@@ -51,6 +51,9 @@ class Settings(BaseSettings):
     MONGODB_USERNAME: str = Field(default="", description="MongoDB username for authentication (optional)")
     MONGODB_PASSWORD: str = Field(default="", description="MongoDB password for authentication (optional)")
 
+    # ========== OpenTelemetry Configuration ==========
+    OTEL_METRICS_CONFIG_PATH: str = Field(default="", description="Path to the OpenTelemetry metrics config file")
+
     model_config = SettingsConfigDict(
         env_file=BASE_DIR / ".env",
         env_file_encoding="utf-8",

--- a/registry-pkgs/src/registry_pkgs/core/config.py
+++ b/registry-pkgs/src/registry_pkgs/core/config.py
@@ -14,48 +14,42 @@ class Settings(BaseSettings):
     """
 
     # ========== Text Chunking Configuration ==========
-    MAX_CHUNK_SIZE: int | None = Field(default=2048, description="Maximum size of text chunks for vectorization")
-    CHUNK_OVERLAP: int | None = Field(default=200, description="Overlap size between consecutive chunks")
+    MAX_CHUNK_SIZE: int = Field(default=2048, description="Maximum size of text chunks for vectorization")
+    CHUNK_OVERLAP: int = Field(default=200, description="Overlap size between consecutive chunks")
 
     # ========== Vector Store Configuration ==========
-    VECTOR_STORE_TYPE: str | None = Field(default="weaviate", description="Vector database type (supported: weaviate)")
-    EMBEDDING_PROVIDER: str | None = Field(
+    VECTOR_STORE_TYPE: str = Field(default="weaviate", description="Vector database type (supported: weaviate)")
+    EMBEDDING_PROVIDER: str = Field(
         default="aws_bedrock", description="Embedding provider (supported: openai, aws_bedrock)"
     )
 
     # ========== Weaviate Configuration ==========
-    WEAVIATE_HOST: str | None = Field(default="127.0.0.1", description="Weaviate server host address")
-    WEAVIATE_PORT: str | None = Field(default="8080", description="Weaviate server port")
-    WEAVIATE_API_KEY: str | None = Field(default="", description="Weaviate API key for authentication (optional)")
-    WEAVIATE_COLLECTION_PREFIX: str | None = Field(
-        default="", description="Prefix for Weaviate collection names (optional)"
-    )
+    WEAVIATE_HOST: str = Field(default="127.0.0.1", description="Weaviate server host address")
+    WEAVIATE_PORT: str = Field(default="8080", description="Weaviate server port")
+    WEAVIATE_API_KEY: str = Field(default="", description="Weaviate API key for authentication (optional)")
+    WEAVIATE_COLLECTION_PREFIX: str = Field(default="", description="Prefix for Weaviate collection names (optional)")
 
     # ========== OpenAI Configuration ==========
-    OPENAI_API_KEY: str | None = Field(
-        default="", description="OpenAI API key (required when EMBEDDING_PROVIDER=openai)"
-    )
-    OPENAI_MODEL: str | None = Field(default="text-embedding-3-small", description="OpenAI embedding model name")
+    OPENAI_API_KEY: str = Field(default="", description="OpenAI API key (required when EMBEDDING_PROVIDER=openai)")
+    OPENAI_MODEL: str = Field(default="text-embedding-3-small", description="OpenAI embedding model name")
 
     # ========== AWS Bedrock Configuration ==========
-    AWS_REGION: str | None = Field(default="us-east-1", description="AWS region for Bedrock service")
-    BEDROCK_MODEL: str | None = Field(
-        default="amazon.titan-embed-text-v2:0", description="AWS Bedrock embedding model name"
-    )
-    AWS_ACCESS_KEY_ID: str | None = Field(
+    AWS_REGION: str = Field(default="us-east-1", description="AWS region for Bedrock service")
+    BEDROCK_MODEL: str = Field(default="amazon.titan-embed-text-v2:0", description="AWS Bedrock embedding model name")
+    AWS_ACCESS_KEY_ID: str = Field(
         default="", description="AWS access key ID (optional, uses default credentials chain if not set)"
     )
-    AWS_SECRET_ACCESS_KEY: str | None = Field(
+    AWS_SECRET_ACCESS_KEY: str = Field(
         default="", description="AWS secret access key (optional, uses default credentials chain if not set)"
     )
 
     # ========== MongoDB Configuration ==========
-    MONGO_URI: str | None = Field(
+    MONGO_URI: str = Field(
         default="mongodb://127.0.0.1:27017/jarvis",
         description="MongoDB connection URI (format: mongodb://host:port/dbname)",
     )
-    MONGODB_USERNAME: str | None = Field(default="", description="MongoDB username for authentication (optional)")
-    MONGODB_PASSWORD: str | None = Field(default="", description="MongoDB password for authentication (optional)")
+    MONGODB_USERNAME: str = Field(default="", description="MongoDB username for authentication (optional)")
+    MONGODB_PASSWORD: str = Field(default="", description="MongoDB password for authentication (optional)")
 
     model_config = SettingsConfigDict(
         env_file=BASE_DIR / ".env",

--- a/registry-pkgs/src/registry_pkgs/telemetry/metrics_client.py
+++ b/registry-pkgs/src/registry_pkgs/telemetry/metrics_client.py
@@ -22,7 +22,7 @@ def load_metrics_config(service_name: str, config_path: str = "") -> dict | None
         service_name: Name of the service (e.g., 'registry', 'auth_server')
         config_path: Optional path to the config file. If config_path is the empty string "",
           try to use the OTEL_METRICS_CONFIG_PATH environment variable from the unified config.
-          If the env var is the emtpy string, try a standard location relative to the current working directory.
+          If the env var is the empty string, try a standard location relative to the current working directory.
 
     Returns:
         Configuration dictionary or None if file not found/invalid

--- a/registry-pkgs/src/registry_pkgs/telemetry/metrics_client.py
+++ b/registry-pkgs/src/registry_pkgs/telemetry/metrics_client.py
@@ -9,30 +9,40 @@ import yaml
 from opentelemetry import metrics
 from opentelemetry.metrics import Counter, Histogram
 
+from ..core.config import settings
+
 logger = logging.getLogger(__name__)
 
 
-def load_metrics_config(service_name: str, config_path: str | None = None) -> dict | None:
+def load_metrics_config(service_name: str, config_path: str = "") -> dict | None:
     """
     Load metrics configuration from YAML file for a specific service.
 
     Args:
         service_name: Name of the service (e.g., 'registry', 'auth_server')
-        config_path: Optional path to the config file. If not provided,
-                    defaults to standard location relative to this file.
+        config_path: Optional path to the config file. If config_path is the empty string "",
+          try to use the OTEL_METRICS_CONFIG_PATH environment variable from the unified config.
+          If the env var is the emtpy string, try a standard location relative to the current working directory.
 
     Returns:
         Configuration dictionary or None if file not found/invalid
     """
-    if config_path:
+    if config_path != "":
         path = Path(config_path)
+    elif settings.OTEL_METRICS_CONFIG_PATH != "":
+        path = Path(settings.OTEL_METRICS_CONFIG_PATH)
     else:
-        # Default: config/metrics/{service_name}.yml relative to project root
-        # derived from this file's location: packages/telemetry/metrics_client.py
-        path = Path(__file__).parent.parent.parent / "config" / "metrics" / f"{service_name}.yml"
+        # Default: config/metrics/{service_name}.yml relative to the current working directory.
+        # In a container, if the WORKDIR is /app/ and the "config" folder at project root is copied into /app/,
+        # this default path will find the file correctly.
+        path = Path().cwd() / "config" / "metrics" / f"{service_name}.yml"
 
     if not path.exists():
-        logger.debug(f"Metrics config not found at {path}, using defaults")
+        logger.warning(f"Metrics config not found at {path}, using defaults")
+        return None
+
+    if not path.is_file():
+        logger.warning(f"Metrics config found at {path}, but it's not a file, using defaults")
         return None
 
     try:

--- a/registry/src/registry/auth/dependencies.py
+++ b/registry/src/registry/auth/dependencies.py
@@ -34,6 +34,12 @@ def get_current_user_by_mid(request: Request) -> dict[str, Any]:
     return request.state.user
 
 
+# Use this type to annotate a parameter of a path operation function or its dependency function so that
+# FastAPI extracts the `user` attribute (typed as dict[str, Any]) of the current request and pass it to the parameter.
+# Since it's Python 3.12, we use he new type statement instead of typing.TypeAlias
+type CurrentUser = Annotated[dict[str, Any], Depends(get_current_user_by_mid)]
+
+
 def get_current_user(
     session: Annotated[str | None, Cookie(alias=settings.session_cookie_name)] = None,
 ) -> str:
@@ -688,6 +694,3 @@ def ui_permission_required(permission: str, service_name: str = None):
         return user_context
 
     return check_permission
-
-
-CurrentUser: type[dict[str, Any]] = Annotated[dict[str, Any], Depends(get_current_user_by_mid)]

--- a/registry/src/registry/auth/dependencies.py
+++ b/registry/src/registry/auth/dependencies.py
@@ -129,6 +129,14 @@ def load_scopes_config() -> dict[str, Any]:
 
         # Fall back to default location if env var not set
         if not scopes_path:
+            # IMPORTANT, TODO: Currently in the mcpgateway-registry container, the following `scope_file` path happens to work,
+            # because it starts from this file, goes up three levels to reach the `/usr/local/lib/python3.12/site-packages/` folder,
+            # and then reaches down to the `auth_server` package, which does have the `scopes.yml` file at its project root.
+            # However, we normally should not assume all 3rd party dependencies are installed to the same folder,
+            # so we should not rely on this coincidence for things to work.
+            # There is a refactoring ticket where we want to stop `registry` from depending on `auth_server`.
+            # In that ticket we will find a good way for registry to get scopes, and that is the right time to change this piece of code.
+            # This comment is left for that ticket.
             scopes_file = Path(__file__).parent.parent.parent / "auth_server" / "scopes.yml"
         else:
             scopes_file = Path(scopes_path)

--- a/registry/src/registry/auth/dependencies.py
+++ b/registry/src/registry/auth/dependencies.py
@@ -36,7 +36,7 @@ def get_current_user_by_mid(request: Request) -> dict[str, Any]:
 
 # Use this type to annotate a parameter of a path operation function or its dependency function so that
 # FastAPI extracts the `user` attribute (typed as dict[str, Any]) of the current request and pass it to the parameter.
-# Since it's Python 3.12, we use he new type statement instead of typing.TypeAlias
+# Since it's Python 3.12, we use the new type statement instead of typing.TypeAlias
 type CurrentUser = Annotated[dict[str, Any], Depends(get_current_user_by_mid)]
 
 

--- a/registry/src/registry/core/config.py
+++ b/registry/src/registry/core/config.py
@@ -2,14 +2,13 @@ import logging
 import secrets
 from pathlib import Path
 
-from pydantic import ConfigDict
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Application settings with environment variable support."""
 
-    model_config = ConfigDict(
+    model_config = SettingsConfigDict(
         env_file=".env",
         case_sensitive=False,
         extra="ignore",  # Ignore extra environment variables
@@ -142,14 +141,6 @@ class Settings(BaseSettings):
         if self.is_local_dev:
             return Path.cwd() / "logs" / "registry.log"
         return self.container_log_dir / "registry.log"
-
-    @property
-    def faiss_index_path(self) -> Path:
-        return self.servers_dir / "service_index.faiss"
-
-    @property
-    def faiss_metadata_path(self) -> Path:
-        return self.servers_dir / "service_index_metadata.json"
 
     @property
     def dotenv_path(self) -> Path:

--- a/registry/src/registry/core/config.py
+++ b/registry/src/registry/core/config.py
@@ -143,6 +143,14 @@ class Settings(BaseSettings):
         return self.container_log_dir / "registry.log"
 
     @property
+    def faiss_index_path(self) -> Path:
+        return self.servers_dir / "service_index.faiss"
+
+    @property
+    def faiss_metadata_path(self) -> Path:
+        return self.servers_dir / "service_index_metadata.json"
+
+    @property
     def dotenv_path(self) -> Path:
         if self.is_local_dev:
             return Path.cwd() / ".env"

--- a/registry/tests/unit/core/test_config.py
+++ b/registry/tests/unit/core/test_config.py
@@ -62,6 +62,7 @@ class TestSettings:
         assert isinstance(settings.container_log_dir, Path)
 
         # Test derived paths in container mode
+        assert settings.servers_dir == settings.container_registry_dir / "servers"
         assert settings.static_dir == settings.container_registry_dir / "static"
         assert settings.templates_dir == settings.container_registry_dir / "templates"
         assert (
@@ -77,7 +78,10 @@ class TestSettings:
         mock_exists.return_value = True
         settings = Settings()
 
+        assert settings.state_file_path == settings.servers_dir / "server_state.json"
         assert settings.log_file_path == settings.container_log_dir / "registry.log"
+        assert settings.faiss_index_path == settings.servers_dir / "service_index.faiss"
+        assert settings.faiss_metadata_path == settings.servers_dir / "service_index_metadata.json"
         assert settings.dotenv_path == settings.container_registry_dir / ".env"
 
     @pytest.mark.skip(reason="nginx_config_path removed in PR-113")
@@ -128,3 +132,4 @@ class TestSettings:
 
         assert settings.container_app_dir == custom_app_dir
         assert settings.container_registry_dir == custom_registry_dir
+        assert settings.servers_dir == custom_registry_dir / "servers"

--- a/registry/tests/unit/core/test_config.py
+++ b/registry/tests/unit/core/test_config.py
@@ -62,7 +62,6 @@ class TestSettings:
         assert isinstance(settings.container_log_dir, Path)
 
         # Test derived paths in container mode
-        assert settings.servers_dir == settings.container_registry_dir / "servers"
         assert settings.static_dir == settings.container_registry_dir / "static"
         assert settings.templates_dir == settings.container_registry_dir / "templates"
         assert (
@@ -78,10 +77,7 @@ class TestSettings:
         mock_exists.return_value = True
         settings = Settings()
 
-        assert settings.state_file_path == settings.servers_dir / "server_state.json"
         assert settings.log_file_path == settings.container_log_dir / "registry.log"
-        assert settings.faiss_index_path == settings.servers_dir / "service_index.faiss"
-        assert settings.faiss_metadata_path == settings.servers_dir / "service_index_metadata.json"
         assert settings.dotenv_path == settings.container_registry_dir / ".env"
 
     @pytest.mark.skip(reason="nginx_config_path removed in PR-113")
@@ -132,4 +128,3 @@ class TestSettings:
 
         assert settings.container_app_dir == custom_app_dir
         assert settings.container_registry_dir == custom_registry_dir
-        assert settings.servers_dir == custom_registry_dir / "servers"

--- a/servers/mcpgw/src/mcpgw/config.py
+++ b/servers/mcpgw/src/mcpgw/config.py
@@ -106,7 +106,7 @@ class Settings(BaseSettings):
             force=True,  # Override any existing configuration
         )
 
-    # IMPORTANT, TODO: The way the following method gets teh scopes information is not optimal,
+    # IMPORTANT, TODO: The way the following method gets the scopes information is not optimal,
     # but since it currently has no reference at all, we keep it here for now.
     # There is a ticket about refactoring how registry gets scope info without importing auth_server directly.
     # This method should probably be taken into consideration when working on that ticket.

--- a/servers/mcpgw/src/mcpgw/config.py
+++ b/servers/mcpgw/src/mcpgw/config.py
@@ -106,6 +106,13 @@ class Settings(BaseSettings):
             force=True,  # Override any existing configuration
         )
 
+    # IMPORTANT, TODO: The way the following method gets teh scopes information is not optimal,
+    # but since it currently has no reference at all, we keep it here for now.
+    # There is a ticket about refactoring how registry gets scope info without importing auth_server directly.
+    # This method should probably be taken into consideration when working on that ticket.
+    # If we decide to use a YAML file to convey scopes info, the better way for mcpgw to get this file is:
+    # - Get a file path from a specific env var, which is loaded via the unified settings object.
+    # - If env var isn't defined, try a default path _relative_ to the current working directory.
     @property
     def scopes_config_path(self) -> Path:
         """

--- a/tartufo.toml
+++ b/tartufo.toml
@@ -23,4 +23,6 @@ exclude-signatures = [
     {signature = '401b06103097ffe15734419a65da63877defd9b4bbf9fb961e0625111cdb6812', reason = 'public URL is not credential'},
     {signature = '7e1c4628cc213c5896e08f35c7b5837c00577bf22c0dda0a52169662d5659471', reason = 'public URL is not credential'},
     {signature = '8c376644d74fa3d82a64e5bbf7290a0af7b37f88986db19ffdae8aba3173d6fb', reason = 'public URL is not credential'},
+    {signature = '0d9297ac2fdff1a015e6b7352127dd6bce67d66c64fb606a432b260f31f33b4e', reason = 'config file path in a container is not credential'},
+    {signature = '8ebd4236ad5d438dd875a800006ab602de78d5d0d89e0b5f6a2bf055f9cedbba', reason = 'config file path in a container is not credential'},
 ]


### PR DESCRIPTION
There are several cases of using `Path(__file__)` to load config files relative to a Python source file. This creates tight coupling between Python code and the overall folder structure. This PR tries to deal with this.

There are two kinds of config files.

- `scopes.yml`

  The ticket `AS-1451` tries to refactor how the `registry` service obtains scope info. The change around `scopes.yml` should be figured out within this ticket. Therefore, this PR just leaves comments at various places in the code base. These comments are marked with `IMPORTANT, TODO`.

- OTEL metrics config file

  Changed to getting path from the `OTEL_METRICS_CONFIG_PATH`, which is read through the unified settings object.
  If not exist, use a default path relative to the current working directory.

Also corrected a few type annotation errors. These errors don't affect runtime but it's good to correct them.

Added unit test for `load_metrics_config` function.