### PR TITLE
fix: standardize Server/Agent API naming and response schemas

### DIFF
--- a/docs/a2a-agent-api-design.md
+++ b/docs/a2a-agent-api-design.md
@@ -61,6 +61,10 @@
 }
 ```
 
+**Note:**
+- Uses `AgentListItem` schema for list items
+- All field names use snake_case convention
+
 ---
 
 ### 2. Get Agent Statistics
@@ -155,6 +159,10 @@
 }
 ```
 
+**Note:**
+- Uses `AgentDetailResponse` schema
+- All field names use snake_case convention
+
 **Error**: `404` Agent not found, `403` Access denied
 
 ---
@@ -202,20 +210,48 @@
 **Response**: `201 Created`
 ```json
 {
-  "message": "Agent registered successfully",
-  "agent": {
-    "id": "507f1f77bcf86cd799439011",
-    "path": "/code-reviewer",
-    "name": "Code Review Agent",
-    "url": "https://example.com/agents/code-reviewer",
-    "created_at": "2024-01-15T10:30:00Z"
-  }
+  "id": "507f1f77bcf86cd799439011",
+  "path": "/code-reviewer",
+  "name": "Code Review Agent",
+  "description": "AI-powered code review assistant",
+  "url": "https://example.com/agents/code-reviewer",
+  "version": "1.0.0",
+  "protocol_version": "1.0",
+  "capabilities": {
+    "streaming": true,
+    "push_notifications": false
+  },
+  "skills": [...],
+  "security_schemes": {},
+  "preferred_transport": "HTTP+JSON",
+  "default_input_modes": ["text/plain"],
+  "default_output_modes": ["application/json"],
+  "provider": {
+    "organization": "AI Labs",
+    "url": "https://ailabs.com"
+  },
+  "tags": ["code", "review"],
+  "status": "active",
+  "enabled": false,
+  "permissions": {
+    "VIEW": true,
+    "EDIT": true,
+    "DELETE": true,
+    "SHARE": true
+  },
+  "author": "507f1f77bcf86cd799439012",
+  "well_known": null,
+  "created_at": "2024-01-15T10:30:00Z",
+  "updated_at": "2024-01-15T10:30:00Z"
 }
 ```
 
-**Error**: `400` Validation error, `409` Path already exists
+**Note:**
+- Uses `AgentDetailResponse` schema (not a separate create response)
+- Automatically grants OWNER permission to creator
+- ACL resource type is `ResourceType.AGENT`
 
-**Note**: Automatically grants OWNER permission to creator when creating Agent, ACL resource type is `ResourceType.A2AAGENT`
+**Error**: `400` Validation error, `409` Path already exists
 
 ---
 
@@ -238,15 +274,39 @@
 **Response**: `200 OK`
 ```json
 {
-  "message": "Agent updated successfully",
-  "agent": {
-    "id": "507f1f77bcf86cd799439011",
-    "path": "/code-reviewer",
-    "name": "Updated Agent Name",
-    "updated_at": "2024-01-20T15:45:00Z"
-  }
+  "id": "507f1f77bcf86cd799439011",
+  "path": "/code-reviewer",
+  "name": "Updated Agent Name",
+  "description": "Updated description",
+  "url": "https://example.com/agents/code-reviewer",
+  "version": "1.1.0",
+  "protocol_version": "1.0",
+  "capabilities": {...},
+  "skills": [...],
+  "security_schemes": {...},
+  "preferred_transport": "HTTP+JSON",
+  "default_input_modes": ["text/plain"],
+  "default_output_modes": ["application/json"],
+  "provider": {...},
+  "tags": ["new", "tags"],
+  "status": "active",
+  "enabled": true,
+  "permissions": {
+    "VIEW": true,
+    "EDIT": true,
+    "DELETE": true,
+    "SHARE": true
+  },
+  "author": "507f1f77bcf86cd799439012",
+  "well_known": {...},
+  "created_at": "2024-01-15T10:30:00Z",
+  "updated_at": "2024-01-20T15:45:00Z"
 }
 ```
+
+**Note:**
+- Uses `AgentDetailResponse` schema (not a separate update response)
+- Returns complete agent details after update
 
 **Error**: `404` Agent not found, `403` Access denied
 
@@ -282,14 +342,39 @@
 **Response**: `200 OK`
 ```json
 {
-  "message": "Agent enabled successfully",
-  "agent": {
-    "id": "507f1f77bcf86cd799439011",
-    "path": "/code-reviewer",
-    "enabled": true
-  }
+  "id": "507f1f77bcf86cd799439011",
+  "path": "/code-reviewer",
+  "name": "Code Review Agent",
+  "description": "AI-powered code review assistant",
+  "url": "https://example.com/agents/code-reviewer",
+  "version": "1.0.0",
+  "protocol_version": "1.0",
+  "capabilities": {...},
+  "skills": [...],
+  "security_schemes": {...},
+  "preferred_transport": "HTTP+JSON",
+  "default_input_modes": ["text/plain"],
+  "default_output_modes": ["application/json"],
+  "provider": {...},
+  "tags": ["code", "review"],
+  "status": "active",
+  "enabled": true,
+  "permissions": {
+    "VIEW": true,
+    "EDIT": true,
+    "DELETE": true,
+    "SHARE": true
+  },
+  "author": "507f1f77bcf86cd799439012",
+  "well_known": {...},
+  "created_at": "2024-01-15T10:30:00Z",
+  "updated_at": "2024-01-20T15:45:00Z"
 }
 ```
+
+**Note:**
+- Uses `AgentDetailResponse` schema (not a separate toggle response)
+- Returns complete agent details after toggle
 
 **Error**: `404` Agent not found, `403` Access denied
 

--- a/docs/mcp_db_persistence_design.md
+++ b/docs/mcp_db_persistence_design.md
@@ -386,12 +386,12 @@ Response 200:
   "servers": [
     {
       "id": "674e1a2b3c4d5e6f7a8b9c0d",
-      "serverName": "github-copilot",
-      "title": "GitHub Integration", #this is coming for config.title
+      "server_name": "github-copilot",
+      "title": "GitHub Integration",
       "description": "GitHub repository management and code search",
       "type": "streamable-http",
       "url": "http://github-server:8011",
-      "requiresOAuth": true,
+      "requires_oauth": true,
       "oauth": {
         "authorization_url": "https://github.com/login/oauth/authorize",
         "token_url": "https://github.com/login/oauth/access_token",
@@ -406,39 +406,45 @@ Response 200:
       "status": "active",
       "path": "/mcp/github",
       "tags": ["github", "version-control", "collaboration", "development"],
-      "numTools": 4,
-      "numStars": 1250,
-      "initDuration": 49,
-      "lastConnected": "2026-01-03T15:54:22.728+00:00",
-      "createdAt": "2026-01-01T10:00:00Z",
-      "updatedAt": "2026-01-03T15:45:00Z"
+      "num_tools": 4,
+      "num_stars": 1250,
+      "init_duration": 49,
+      "last_connected": "2026-01-03T15:54:22.728+00:00",
+      "created_at": "2026-01-01T10:00:00Z",
+      "updated_at": "2026-01-03T15:45:00Z"
     },
     {
       "id": "674e1a2b3c4d5e6f7a8b9c0e",
-      "serverName": "tavilysearchv1",
+      "server_name": "tavilysearchv1",
       "title": "Tavily Search v1",
       "description": "Search the web with Tavily",
       "type": "streamable-http",
       "url": "https://mcp.tavily.com/mcp/",
-      "apiKey": {
+      "api_key": {
         "key": "encrypted_api_key_here",
         "source": "admin",
         "authorization_type": "custom",
         "custom_header": "tavilyApiKey"
       },
-      "requiresOAuth": false,
+      "requires_oauth": false,
       "capabilities": "{\"experimental\":{},\"prompts\":{\"listChanged\":true},\"resources\":{\"subscribe\":false,\"listChanged\":true},\"tools\":{\"listChanged\":true}}",
       "tools": "tavily_search, tavily_extract, tavily_crawl, tavily_map",
       "author": "507f1f77bcf86cd799439011",
-      "scope": "shared_app",
       "status": "active",
       "path": "/mcp/tavilysearchv1",
       "tags": ["search", "web", "tavily"],
-      "numTools": 4,
-      "numStars": 890,
-      "lastConnected": "2026-01-04T15:09:45Z",
-      "createdAt": "2026-01-04T15:09:45Z",
-      "updatedAt": "2026-01-04T15:09:45Z"
+      "num_tools": 4,
+      "num_stars": 890,
+      "enabled": true,
+      "last_connected": "2026-01-04T15:09:45Z",
+      "permissions": {
+        "VIEW": true,
+        "EDIT": false,
+        "DELETE": false,
+        "SHARE": false
+      },
+      "created_at": "2026-01-04T15:09:45Z",
+      "updated_at": "2026-01-04T15:09:45Z"
     }
   ],
   "pagination": {
@@ -449,7 +455,10 @@ Response 200:
   }
 }
 
-**Note:** List endpoint does NOT return `toolFunctions` for performance.
+**Note:** 
+- List endpoint uses `ServerListItemResponse` schema
+- Does NOT return `tool_functions` for performance
+- All field names use snake_case convention
 ```
 
 **2. Get Server Details**
@@ -460,12 +469,12 @@ Authorization: Bearer <token>
 Response 200:
 {
   "id": "674e1a2b3c4d5e6f7a8b9c0d",
-  "serverName": "github-copilot",
+  "server_name": "github-copilot",
   "title": "GitHub Integration",
   "description": "GitHub repository management and code search",
   "type": "streamable-http",
   "url": "http://github-server:8011",
-  "requiresOAuth": true,
+  "requires_oauth": true,
   "oauth": {
     "authorization_url": "https://github.com/login/oauth/authorize",
     "token_url": "https://github.com/login/oauth/access_token",
@@ -474,7 +483,7 @@ Response 200:
     "client_secret": "***",
     "scope": "repo read:user read:org"
   },
-  "oauthMetadata": {
+  "oauth_metadata": {
     "resource": "https://api.githubcopilot.com/mcp",
     "authorization_servers": ["https://github.com/login/oauth"],
     "scopes_supported": ["repo", "user", "read:org", "gist", "notifications"],
@@ -483,7 +492,7 @@ Response 200:
   },
   "capabilities": "{\"experimental\":{},\"prompts\":{\"listChanged\":true},\"resources\":{\"subscribe\":false,\"listChanged\":true},\"tools\":{\"listChanged\":true}}",
   "tools": "search_code, create_issue, list_repos, get_pull_requests",
-  "toolFunctions": {
+  "tool_functions": {
     "search_code_mcp_github_copilot": {
       "type": "function",
       "function": {
@@ -523,22 +532,31 @@ Response 200:
       }
     }
   },
-  "initDuration": 150,
+  "init_duration": 150,
   "author": "507f1f77bcf86cd799439011",
-  "scope": "shared_app",
   "status": "active",
   "path": "/mcp/github-copilot",
   "tags": ["github", "version-control"],
-  "numTools": 4,
-  "numStars": 1250,
-  "lastConnected": "2026-01-03T15:54:22.728+00:00",
-  "lastError": null,
-  "errorMessage": null,
-  "createdAt": "2026-01-01T10:00:00Z",
-  "updatedAt": "2026-01-03T15:45:00Z"
+  "num_tools": 4,
+  "num_stars": 1250,
+  "enabled": true,
+  "last_connected": "2026-01-03T15:54:22.728+00:00",
+  "last_error": null,
+  "error_message": null,
+  "permissions": {
+    "VIEW": true,
+    "EDIT": true,
+    "DELETE": true,
+    "SHARE": true
+  },
+  "created_at": "2026-01-01T10:00:00Z",
+  "updated_at": "2026-01-03T15:45:00Z"
 }
 
-**Note:** Detail endpoint includes `toolFunctions` with complete OpenAI function schemas.
+**Note:** 
+- Detail endpoint uses `ServerDetailResponse` schema
+- Includes `tool_functions` with complete OpenAI function schemas
+- All field names use snake_case convention
 ```
 
 **3. Register Server**
@@ -549,38 +567,37 @@ Content-Type: application/json
 
 Request:
 {
-  "serverName": "custom-api-server",
   "title": "Custom API Server",
+  "path": "/mcp/custom-api-server",
   "description": "Internal API integration server",
   "type": "streamable-http",
   "url": "http://api-server:8080/mcp",
-  "apiKey": {
+  "api_key": {
     "key": "sk-123456",
     "source": "user",
     "authorization_type": "bearer"
   },
-  "requiresOAuth": false,
-  "scope": "private_user",
+  "requires_oauth": false,
   "tags": ["api", "custom"]
 }
 
 Response 201:
 {
   "id": "674e1a2b3c4d5e6f7a8b9c0e",
-  "serverName": "custom-api-server",
+  "server_name": "custom-api-server",
   "title": "Custom API Server",
   "description": "Internal API integration server",
   "type": "streamable-http",
   "url": "http://api-server:8080/mcp",
-  "apiKey": {
+  "api_key": {
     "key": "***",
     "source": "user",
     "authorization_type": "bearer"
   },
-  "requiresOAuth": false,
+  "requires_oauth": false,
   "capabilities": "{\"tools\":{\"listChanged\":true}}",
   "tools": "fetch_data, post_data, get_status",
-  "toolFunctions": {
+  "tool_functions": {
     "search_custom_api_server": {
       "type": "function",
       "function": {
@@ -612,25 +629,29 @@ Response 201:
       }
     }
   },
-  "initDuration": 80,
+  "init_duration": 80,
   "author": "507f1f77bcf86cd799439012",
-  "scope": "private_user",
   "status": "active",
   "path": "/mcp/custom-api-server",
   "tags": ["api", "custom"],
-  "numTools": 3,
-  "numStars": 0,
-  "lastConnected": "2026-01-04T16:00:00Z",
-  "createdAt": "2026-01-04T16:00:00Z",
-  "updatedAt": "2026-01-04T16:00:00Z"
+  "num_tools": 3,
+  "num_stars": 0,
+  "enabled": true,
+  "last_connected": "2026-01-04T16:00:00Z",
+  "permissions": {
+    "VIEW": true,
+    "EDIT": true,
+    "DELETE": true,
+    "SHARE": true
+  },
+  "created_at": "2026-01-04T16:00:00Z",
+  "updated_at": "2026-01-04T16:00:00Z"
 }
 
-**Note:** Upon registration, the registry automatically:
-1. Connects to the MCP server at the provided URL
-2. Retrieves the server's capabilities and tool list
-3. Stores `capabilities`, `tools` (comma-separated string), and `toolFunctions` (OpenAI format)
-4. Calculates `numTools` from the tools string
-5. Measures `initDuration` (connection time in ms)
+**Note:** 
+- Upon registration, uses `ServerDetailResponse` schema
+- Automatically connects to the MCP server and retrieves capabilities
+- All field names use snake_case convention
 ```
 
 **4. Update Server**
@@ -649,12 +670,12 @@ Request:
 Response 200:
 {
   "id": "674e1a2b3c4d5e6f7a8b9c0d",
-  "serverName": "github",
+  "server_name": "github",
   "title": "GitHub MCP Server",
   "description": "Updated description - Enhanced GitHub integration",
   "type": "streamable-http",
   "url": "http://github-server:8011",
-  "requiresOAuth": true,
+  "requires_oauth": true,
   "oauth": {
     "authorization_url": "https://github.com/login/oauth/authorize",
     "token_url": "https://github.com/login/oauth/access_token",
@@ -664,18 +685,20 @@ Response 200:
   },
   "capabilities": "{\"experimental\":{},\"prompts\":{\"listChanged\":true},\"resources\":{\"subscribe\":false,\"listChanged\":true},\"tools\":{\"listChanged\":true}}",
   "tools": "search_code, create_issue, list_repos, get_pull_requests",
-  "initDuration": 49,
+  "init_duration": 49,
   "author": "69593baec59bdd2853ad0ff1",
   "scope": "shared_app",
   "status": "active",
   "path": "/mcp/github-copilot",
   "tags": ["github", "version-control", "collaboration"],
-  "numTools": 4,
-  "numStars": 1250,
-  "lastConnected": "2026-01-04T14:30:00Z",
-  "createdAt": "2026-01-01T10:00:00Z",
-  "updatedAt": "2026-01-04T16:05:00Z"
+  "num_tools": 4,
+  "num_stars": 1250,
+  "last_connected": "2026-01-04T14:30:00Z",
+  "created_at": "2026-01-01T10:00:00Z",
+  "updated_at": "2026-01-04T16:05:00Z"
 }
+
+**Note:** Uses `ServerDetailResponse` schema with snake_case fields
 
 Response 409 (Conflict):
 {
@@ -720,12 +743,14 @@ Request:
 Response 200:
 {
   "id": "674e1a2b3c4d5e6f7a8b9c0d",
-  "serverName": "github",
+  "server_name": "github",
+  "path": "/mcp/github",
   "status": "active",
   "enabled": true,
-  "message": "Server enabled successfully",
-  "updatedAt": "2026-01-04T16:10:00Z"
+  "updated_at": "2026-01-04T16:10:00Z"
 }
+
+**Note:** Uses `ServerDetailResponse` schema with snake_case fields
 ```
 
 **7. Get Server Tools**
@@ -736,12 +761,13 @@ Authorization: Bearer <token>
 Response 200:
 {
   "id": "674e1a2b3c4d5e6f7a8b9c0d",
-  "serverName": "github",
+  "server_name": "github",
+  "path": "/mcp/github",
   "tools": [
     {
       "name": "search_code",
       "description": "Search for code across GitHub repositories",
-      "inputSchema": {
+      "input_schema": {
         "type": "object",
         "properties": {
           "query": {
@@ -759,7 +785,7 @@ Response 200:
     {
       "name": "create_issue_github",
       "description": "Create a new issue in a repository",
-      "inputSchema": {
+      "input_schema": {
         "type": "object",
         "properties": {
           "owner": {"type": "string", "description": "Repository owner"},
@@ -771,18 +797,19 @@ Response 200:
       }
     }
   ],
-  "numTools": 4,
+  "num_tools": 4,
   "capabilities": {
     "experimental": {},
     "prompts": {"listChanged": true},
     "resources": {"subscribe": false, "listChanged": true},
     "tools": {"listChanged": true}
-  },
-  "cached": false,
-  "retrievedAt": "2026-01-04T16:15:00Z"
+  }
 }
 
-**Note:** This endpoint returns tools in MCP's native format (with `inputSchema`), which is different from the `toolFunctions` OpenAI format stored in the database.
+**Note:** 
+- Uses `ServerDetailResponse` schema with snake_case fields
+- Returns tools in MCP's native format (with `input_schema`)
+- Different from `tool_functions` OpenAI format stored in the database
 ```
 
 **8. Refresh Server Health**
@@ -793,20 +820,22 @@ Authorization: Bearer <token>
 Response 200:
 {
   "id": "674e1a2b3c4d5e6f7a8b9c0d",
-  "serverName": "github",
+  "server_name": "github",
+  "path": "/mcp/github",
   "status": "active",
-  "lastConnected": "2026-01-04T16:20:00Z",
-  "lastError": null,
-  "errorMessage": null,
-  "numTools": 4,
+  "last_connected": "2026-01-04T16:20:00Z",
+  "last_error": null,
+  "error_message": null,
+  "num_tools": 4,
   "capabilities": "{\"experimental\":{},\"prompts\":{\"listChanged\":true},\"resources\":{\"subscribe\":false,\"listChanged\":true}}",
   "tools": "tavily_search, tavily_extract, tavily_crawl, tavily_map",
-  "initDuration": 168,
-  "message": "Server health check successful",
-  "updatedAt": "2026-01-04T16:20:00Z"
+  "init_duration": 168,
+  "updated_at": "2026-01-04T16:20:00Z"
 }
 
-**Note:** Health refresh reconnects to the MCP server and updates tools/capabilities if they changed.
+**Note:** 
+- Uses `ServerDetailResponse` schema with snake_case fields  
+- Health refresh reconnects to the MCP server and updates tools/capabilities if they changed
 ```
 
 #### Token Management Endpoints

--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -128,8 +128,8 @@ const ServerCard: React.FC<ServerCardProps> = ({ server, onEdit, onServerUpdate,
       if (onServerUpdate && result) {
         const updates: Partial<ServerInfo> = {
           status: result.status,
-          last_checked_time: result.lastConnected,
-          num_tools: result.numTools,
+          last_checked_time: result.last_connected,
+          num_tools: result.num_tools,
         };
         onServerUpdate(server.id, updates);
       } else if (onRefreshSuccess) {
@@ -430,11 +430,11 @@ const ServerCard: React.FC<ServerCardProps> = ({ server, onEdit, onServerUpdate,
                     {tool.description && (
                       <p className='text-sm text-gray-600 dark:text-gray-300 mb-2'>{tool.description}</p>
                     )}
-                    {tool.inputSchema && (
+                    {tool.input_schema && (
                       <details className='text-xs'>
                         <summary className='cursor-pointer text-gray-500 dark:text-gray-300'>View Schema</summary>
                         <pre className='mt-2 p-3 bg-gray-50 dark:bg-gray-900 border dark:border-gray-700 rounded overflow-x-auto text-gray-900 dark:text-gray-100'>
-                          {JSON.stringify(tool.inputSchema, null, 2)}
+                          {JSON.stringify(tool.input_schema, null, 2)}
                         </pre>
                       </details>
                     )}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,15 +1,8 @@
-import axios from 'axios';
 import type React from 'react';
 import { createContext, type ReactNode, useContext, useEffect, useState } from 'react';
 
 import { getBasePath } from '@/config';
 import SERVICES from '@/services';
-
-// Configure axios to include credentials (cookies) with all requests
-axios.defaults.withCredentials = true;
-
-// Add base URL from runtime config
-axios.defaults.baseURL = getBasePath() || '/';
 
 interface User {
   username: string;

--- a/frontend/src/contexts/ServerContext.tsx
+++ b/frontend/src/contexts/ServerContext.tsx
@@ -151,7 +151,7 @@ export const ServerProvider: React.FC<ServerProviderProps> = ({ children }) => {
     return serversList.map((serverInfo: Server) => {
       return {
         id: serverInfo.id,
-        name: serverInfo.serverName || 'Unknown Server',
+        name: serverInfo.server_name || 'Unknown Server',
         title: serverInfo.title,
         permissions: serverInfo.permissions,
         path: serverInfo.path,
@@ -159,16 +159,16 @@ export const ServerProvider: React.FC<ServerProviderProps> = ({ children }) => {
         official: serverInfo.is_official || false,
         enabled: serverInfo.enabled !== undefined ? serverInfo.enabled : false,
         tags: serverInfo.tags || [],
-        last_checked_time: serverInfo.lastConnected,
+        last_checked_time: serverInfo.last_connected,
         usersCount: 0,
-        rating: serverInfo.numStars || 0,
+        rating: serverInfo.num_stars || 0,
         status: serverInfo.status || 'unknown', // undefined
-        num_tools: serverInfo.numTools || 0,
+        num_tools: serverInfo.num_tools || 0,
         url: serverInfo.url,
-        num_stars: serverInfo.numStars || 0,
+        num_stars: serverInfo.num_stars || 0,
         is_python: serverInfo.is_python || false,
-        requires_oauth: serverInfo.requiresOAuth,
-        connection_state: serverInfo.connectionState,
+        requires_oauth: serverInfo.requires_oauth,
+        connection_state: serverInfo.connection_state,
       };
     });
   };
@@ -245,8 +245,8 @@ export const ServerProvider: React.FC<ServerProviderProps> = ({ children }) => {
   const getServerStatusById = useCallback(async (serverId: string): Promise<SERVER_CONNECTION | undefined> => {
     try {
       const result = await SERVICES.MCP.getServerStatusById(serverId);
-      handleServerUpdate(serverId, { connection_state: result.connectionState });
-      return result.connectionState;
+      handleServerUpdate(serverId, { connection_state: result.connection_state });
+      return result.connection_state;
     } catch (error: any) {
       console.log('error', error);
     }
@@ -278,8 +278,8 @@ export const ServerProvider: React.FC<ServerProviderProps> = ({ children }) => {
 
             const result = await SERVICES.SERVER.refreshServerHealth(serverId);
             handleServerUpdate(serverId, {
-              last_checked_time: result.lastConnected,
-              num_tools: result.numTools,
+              last_checked_time: result.last_connected,
+              num_tools: result.num_tools,
               status: result.status || 'unknown',
             });
           }

--- a/frontend/src/hooks/useSemanticSearch.ts
+++ b/frontend/src/hooks/useSemanticSearch.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { useEffect, useState } from 'react';
+import API from '@/services/api';
 
 type EntityType = 'mcp_server' | 'tool' | 'a2a_agent';
 
@@ -110,7 +111,7 @@ export const useSemanticSearch = (query: string, options: UseSemanticSearchOptio
       setError(null);
       try {
         const response = await axios.post<SemanticSearchResponse>(
-          '/api/v1/search/semantic',
+          API.getSemanticSearch,
           {
             query: debouncedQuery,
             entity_types: entityTypes,

--- a/frontend/src/pages/ServerRegistryOrEdit/AuthenticationConfig.tsx
+++ b/frontend/src/pages/ServerRegistryOrEdit/AuthenticationConfig.tsx
@@ -119,7 +119,7 @@ const AuthenticationConfig: React.FC<AuthenticationConfigProps> = ({
               onChange={val => handleTypeChange(val)}
               options={[
                 { label: 'No Auth', value: 'auto' },
-                { label: 'API Key', value: 'apiKey' },
+                { label: 'API Key', value: 'api_key' },
                 { label: 'OAuth', value: 'oauth' },
               ]}
               disabled={isReadOnly}
@@ -132,7 +132,7 @@ const AuthenticationConfig: React.FC<AuthenticationConfigProps> = ({
             </div>
           )}
 
-          {config.type === 'apiKey' && (
+          {config.type === 'api_key' && (
             <div className='space-y-4 animate-fadeIn'>
               <div>
                 <label className='block text-sm font-medium text-gray-900 dark:text-gray-100 mb-2'>

--- a/frontend/src/pages/ServerRegistryOrEdit/ServerCreationSuccessDialog.tsx
+++ b/frontend/src/pages/ServerRegistryOrEdit/ServerCreationSuccessDialog.tsx
@@ -6,7 +6,7 @@ import { getBasePath } from '@/config';
 
 interface ServerCreationSuccessDialogProps {
   isOpen: boolean;
-  serverData: { serverName: string; path: string };
+  serverData: { server_name: string; path: string };
   onClose: () => void;
 }
 

--- a/frontend/src/pages/ServerRegistryOrEdit/index.tsx
+++ b/frontend/src/pages/ServerRegistryOrEdit/index.tsx
@@ -16,16 +16,16 @@ const DEFAULT_AUTH_CONFIG: AuthConfigType = { type: 'auto', source: 'admin', aut
 const AUTH_ERROR_KEYS = ['key', 'custom_header', 'authorization_url', 'token_url'] as const;
 
 const parseAuthConfig = (result: GET_SERVERS_DETAIL_RESPONSE): AuthConfigType => {
-  if (result.apiKey) {
+  if (result.api_key) {
     return {
-      type: 'apiKey',
-      source: result.apiKey.source,
-      authorization_type: result.apiKey.authorization_type,
-      key: result.apiKey.key,
-      custom_header: result.apiKey.custom_header,
+      type: 'api_key',
+      source: result.api_key.source,
+      authorization_type: result.api_key.authorization_type,
+      key: result.api_key.key,
+      custom_header: result.api_key.custom_header,
     };
   }
-  if (result.oauth || result.requiresOAuth) {
+  if (result.oauth || result.requires_oauth) {
     return {
       type: 'oauth',
       client_id: result.oauth?.client_id,
@@ -33,7 +33,7 @@ const parseAuthConfig = (result: GET_SERVERS_DETAIL_RESPONSE): AuthConfigType =>
       authorization_url: result.oauth?.authorization_url,
       token_url: result.oauth?.token_url,
       scope: result.oauth?.scope,
-      use_dynamic_registration: result.requiresOAuth && !result.oauth,
+      use_dynamic_registration: result.requires_oauth && !result.oauth,
     };
   }
   return { ...DEFAULT_AUTH_CONFIG };
@@ -51,11 +51,11 @@ const processDataByAuthType = (data: ServerConfig, originalData: ServerConfig | 
   };
   switch (data.authConfig.type) {
     case 'auto':
-      return { ...baseData, apiKey: null, oauth: null, requiresOAuth: false };
-    case 'apiKey':
+      return { ...baseData, api_key: null, oauth: null, requires_oauth: false };
+    case 'api_key':
       return {
         ...baseData,
-        apiKey: {
+        api_key: {
           source: data.authConfig.source,
           authorization_type: data.authConfig.authorization_type,
           ...(data.authConfig.source !== 'user' &&
@@ -68,7 +68,7 @@ const processDataByAuthType = (data: ServerConfig, originalData: ServerConfig | 
             : {}),
         },
         oauth: null,
-        requiresOAuth: false,
+        requires_oauth: false,
       };
     case 'oauth':
       return {
@@ -84,8 +84,8 @@ const processDataByAuthType = (data: ServerConfig, originalData: ServerConfig | 
               token_url: data.authConfig.token_url,
               scope: data.authConfig.scope,
             },
-        apiKey: null,
-        requiresOAuth: true,
+        api_key: null,
+        requires_oauth: true,
       };
     default:
       return {};
@@ -117,7 +117,7 @@ const ServerRegistryOrEdit: React.FC = () => {
   const [formData, setFormData] = useState<ServerConfig>(INIT_DATA);
   const [originalData, setOriginalData] = useState<ServerConfig | null>(null);
   const [errors, setErrors] = useState<Record<string, string | undefined>>({});
-  const [serverData, setServerData] = useState<{ serverName: string; path: string }>({ serverName: '', path: '' });
+  const [serverData, setServerData] = useState<{ server_name: string; path: string }>({ server_name: '', path: '' });
   const [showSuccessDialog, setShowSuccessDialog] = useState(false);
 
   const isEditMode = !!id;
@@ -200,7 +200,7 @@ const ServerRegistryOrEdit: React.FC = () => {
 
     // Auth Validation
     const auth = formData.authConfig;
-    if (auth.type === 'apiKey') {
+    if (auth.type === 'api_key') {
       if (auth.source === 'admin' && !auth.key?.trim()) {
         newErrors.key = 'API Key is required';
       }
@@ -268,7 +268,7 @@ const ServerRegistryOrEdit: React.FC = () => {
           path: result.path,
           url: result.url,
           tags: result.tags,
-          last_checked_time: result.updatedAt ?? new Date().toISOString(),
+          last_checked_time: result.updated_at ?? new Date().toISOString(),
         });
       } else {
         const result = await SERVICES.SERVER.createServer(data);

--- a/frontend/src/pages/ServerRegistryOrEdit/types.ts
+++ b/frontend/src/pages/ServerRegistryOrEdit/types.ts
@@ -1,4 +1,4 @@
-export type AuthType = 'auto' | 'apiKey' | 'oauth';
+export type AuthType = 'auto' | 'api_key' | 'oauth';
 export type ApiKeySource = 'admin' | 'user';
 export type ApiKeyHeaderFormat = 'bearer' | 'basic' | 'custom';
 export type ServerType = 'streamable-http' | 'sse';

--- a/frontend/src/pages/TokenGeneration.tsx
+++ b/frontend/src/pages/TokenGeneration.tsx
@@ -10,8 +10,8 @@ const TokenGeneration: React.FC = () => {
   const [formData, setFormData] = useState({
     description: '',
     expires_in_hours: 8,
-    scopeMethod: 'current' as 'current' | 'custom',
-    customScopes: '',
+    scope_method: 'current' as 'current' | 'custom',
+    custom_scopes: '',
   });
   const [generatedToken, setGeneratedToken] = useState<string>('');
   const [tokenDetails, setTokenDetails] = useState<any>(null);
@@ -37,8 +37,8 @@ const TokenGeneration: React.FC = () => {
       };
 
       // Handle scopes based on the selected method
-      if (formData.scopeMethod === 'custom') {
-        const customScopesText = formData.customScopes.trim();
+      if (formData.scope_method === 'custom') {
+        const customScopesText = formData.custom_scopes.trim();
         if (customScopesText) {
           try {
             const parsedScopes = JSON.parse(customScopesText);
@@ -98,9 +98,9 @@ const TokenGeneration: React.FC = () => {
   };
 
   const validateCustomScopes = () => {
-    if (formData.scopeMethod === 'custom' && formData.customScopes.trim()) {
+    if (formData.scope_method === 'custom' && formData.custom_scopes.trim()) {
       try {
-        const parsed = JSON.parse(formData.customScopes);
+        const parsed = JSON.parse(formData.custom_scopes);
         if (!Array.isArray(parsed)) {
           return 'Custom scopes must be a JSON array';
         }
@@ -217,11 +217,11 @@ const TokenGeneration: React.FC = () => {
                       <label className='flex items-center space-x-2'>
                         <input
                           type='radio'
-                          name='scopeMethod'
+                          name='scope_method'
                           value='current'
-                          checked={formData.scopeMethod === 'current'}
+                          checked={formData.scope_method === 'current'}
                           onChange={e =>
-                            setFormData(prev => ({ ...prev, scopeMethod: e.target.value as 'current' | 'custom' }))
+                            setFormData(prev => ({ ...prev, scope_method: e.target.value as 'current' | 'custom' }))
                           }
                           className='rounded border-gray-300 text-primary-600 focus:ring-primary-500'
                         />
@@ -236,11 +236,11 @@ const TokenGeneration: React.FC = () => {
                       <label className='flex items-center space-x-2'>
                         <input
                           type='radio'
-                          name='scopeMethod'
+                          name='scope_method'
                           value='custom'
-                          checked={formData.scopeMethod === 'custom'}
+                          checked={formData.scope_method === 'custom'}
                           onChange={e =>
-                            setFormData(prev => ({ ...prev, scopeMethod: e.target.value as 'current' | 'custom' }))
+                            setFormData(prev => ({ ...prev, scope_method: e.target.value as 'current' | 'custom' }))
                           }
                           className='rounded border-gray-300 text-primary-600 focus:ring-primary-500'
                         />
@@ -256,20 +256,20 @@ const TokenGeneration: React.FC = () => {
                     </div>
 
                     {/* Custom Scopes JSON Input */}
-                    {formData.scopeMethod === 'custom' && (
+                    {formData.scope_method === 'custom' && (
                       <div className='mt-3'>
                         <label
-                          htmlFor='customScopes'
+                          htmlFor='custom_scopes'
                           className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1'
                         >
                           Custom Scopes (JSON format)
                         </label>
                         <textarea
-                          id='customScopes'
+                          id='custom_scopes'
                           className={`input h-24 font-mono text-xs ${scopeValidationError ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : ''}`}
                           placeholder={`["mcp-servers-restricted/read", "mcp-registry-user"]`}
-                          value={formData.customScopes}
-                          onChange={e => setFormData(prev => ({ ...prev, customScopes: e.target.value }))}
+                          value={formData.custom_scopes}
+                          onChange={e => setFormData(prev => ({ ...prev, custom_scopes: e.target.value }))}
                         />
                         <p className='mt-1 text-xs text-gray-500 dark:text-gray-400'>
                           Enter a JSON array of scope names. Must be a subset of your current scopes.

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -10,7 +10,6 @@ const API = {
   refreshToken: '/redirect/refresh',
 
   // mcp
-  getServerStatus: `${MCP_BASE_URL}/connection/status`,
   getServerStatusById: (id: string) => `${MCP_BASE_URL}/connection/status/${id}`,
   getOauthInitiate: (id: string) => `${MCP_BASE_URL}/${id}/oauth/initiate`,
   getOauthReinit: (id: string) => `${MCP_BASE_URL}/${id}/reinitialize`,
@@ -19,6 +18,7 @@ const API = {
   getDiscover: `${MCP_BASE_URL}/oauth/discover`,
 
   // server
+  getSemanticSearch: `${BASE_URL}/search/semantic`,
   getVersion: '/api/version',
   getServers: `${SERVER_BASE_URL}`,
   getServerDetail: (id: string) => `${SERVER_BASE_URL}/${id}`,

--- a/frontend/src/services/auth/type.ts
+++ b/frontend/src/services/auth/type.ts
@@ -12,8 +12,8 @@ export type GET_AUTH_ME_RESPONSE = {
 export type GET_TOKEN_REQUEST = {
   expires_in_hours: number;
   description: string;
-  scopeMethod?: 'current' | 'custom';
-  customScopes?: string;
+  scope_method?: 'current' | 'custom';
+  custom_scopes?: string;
 };
 
 type TOKEN_DATA = {

--- a/frontend/src/services/mcp/index.ts
+++ b/frontend/src/services/mcp/index.ts
@@ -3,9 +3,6 @@ import Request from '@/services/request';
 
 import type * as TYPE from './type';
 
-const getServerStatus: () => Promise<TYPE.GET_SERVER_STATUS_RESPONSE> = async () =>
-  await Request.get(API.getServerStatus);
-
 const getServerStatusById: (id: string) => Promise<TYPE.GET_SERVER_STATUS_BY_ID_RESPONSE> = async id =>
   await Request.get(API.getServerStatusById(id));
 
@@ -25,7 +22,6 @@ const getDiscover: (url: string, config?: object) => Promise<any> = async (url, 
   await Request.get(API.getDiscover, { url }, config);
 
 export default {
-  getServerStatus,
   getServerStatusById,
   getOauthInitiate,
   getOauthReinit,

--- a/frontend/src/services/mcp/type.ts
+++ b/frontend/src/services/mcp/type.ts
@@ -11,13 +11,6 @@ export type SERVER_STATUS = {
   error?: string;
 };
 
-export type GET_SERVER_STATUS_RESPONSE = {
-  success: boolean;
-  connection_status: {
-    [server_name: string]: SERVER_STATUS;
-  };
-};
-
 export type GET_SERVER_STATUS_BY_ID_RESPONSE = {
   success: boolean;
   connection_state: SERVER_CONNECTION;

--- a/frontend/src/services/mcp/type.ts
+++ b/frontend/src/services/mcp/type.ts
@@ -13,15 +13,15 @@ export type SERVER_STATUS = {
 
 export type GET_SERVER_STATUS_RESPONSE = {
   success: boolean;
-  connectionStatus: {
-    [serverName: string]: SERVER_STATUS;
+  connection_status: {
+    [server_name: string]: SERVER_STATUS;
   };
 };
 
 export type GET_SERVER_STATUS_BY_ID_RESPONSE = {
   success: boolean;
-  connectionState: SERVER_CONNECTION;
-  requiresOAuth: boolean;
+  connection_state: SERVER_CONNECTION;
+  requires_oauth: boolean;
 };
 
 export type GET_OAUTH_INITIATE_RESPONSE = {
@@ -34,9 +34,9 @@ export type GET_OAUTH_INITIATE_RESPONSE = {
 export type GET_SERVER_AUTH_URL_RESPONSE = {
   success: boolean;
   message: string;
-  oauthUrl: string;
-  serverName: string;
-  oauthRequired: boolean;
+  oauth_url: string;
+  server_name: string;
+  oauth_required: boolean;
 };
 
 export type CANCEL_AUTH_RESPONSE = {

--- a/frontend/src/services/server/type.ts
+++ b/frontend/src/services/server/type.ts
@@ -34,14 +34,14 @@ export type PermissionType = {
 };
 export type Server = {
   id: string;
-  serverName: string;
+  server_name: string;
   title: string;
   description: string;
   type: ServerType;
   url: string;
   enabled: boolean;
-  requiresOAuth: boolean;
-  connectionState: SERVER_CONNECTION;
+  requires_oauth: boolean;
+  connection_state: SERVER_CONNECTION;
   capabilities: string;
   tools: string;
   author: string;
@@ -50,16 +50,16 @@ export type Server = {
   path: string;
   permissions: PermissionType;
   tags: string[];
-  numTools: number;
-  numStars: number;
-  initDuration: number;
-  lastConnected: string;
-  createdAt: string;
-  updatedAt: string;
+  num_tools: number;
+  num_stars: number;
+  init_duration: number;
+  last_connected: string;
+  created_at: string;
+  updated_at: string;
   is_python?: boolean;
   is_official?: boolean;
   oauth?: OauthConfig;
-  apiKey?: ApiKeyConfig;
+  api_key?: ApiKeyConfig;
 };
 
 export type GET_SERVERS_RESPONSE = {
@@ -84,7 +84,7 @@ export type TEST_SERVER_URL_RESPONSE = {
 };
 
 export type CREATE_SERVER_REQUEST = {
-  serverName: string;
+  server_name: string;
   description: string;
   path: string;
   url: string;
@@ -92,13 +92,13 @@ export type CREATE_SERVER_REQUEST = {
   enabled: boolean;
   type: ServerType;
   oauth?: OauthConfig;
-  apiKey?: ApiKeyConfig;
+  api_key?: ApiKeyConfig;
 };
 
 export type Tool = {
   name: string;
   description?: string;
-  inputSchema?: any;
+  input_schema?: any;
 };
 export type GET_SERVER_TOOLS_RESPONSE = {
   id: string;

--- a/registry-pkgs/src/registry_pkgs/scopes.yml
+++ b/registry-pkgs/src/registry_pkgs/scopes.yml
@@ -101,9 +101,6 @@ agents-write:
   - action: sync_wellknown
     method: POST
     endpoint: /agents/{agent_id}/wellknown
-  - action: rate_agent
-    method: POST
-    endpoint: /agents/{agent_id}/rate
 
 server-write:
   - action: register_service

--- a/registry-pkgs/src/registry_pkgs/scopes.yml
+++ b/registry-pkgs/src/registry_pkgs/scopes.yml
@@ -68,10 +68,13 @@ agents-read:
     endpoint: /agents
   - action: get_agent
     method: GET
-    endpoint: /agents/{path}
+    endpoint: /agents/{agent_id}
+  - action: get_agent_skills
+    method: GET
+    endpoint: /agents/{agent_id}/skills
   - action: get_agent_rating
     method: GET
-    endpoint: /agents/{path}/rating
+    endpoint: /agents/{agent_id}/rating
   - action: discover_agents
     method: POST
     endpoint: /agents/discover
@@ -80,24 +83,27 @@ agents-read:
     endpoint: /agents/discover/semantic
   - action: check_agent_health
     method: POST
-    endpoint: /agents/{path}/health
+    endpoint: /agents/{agent_id}/health
 
 agents-write:
-  - action: publish_agent
+  - action: create_agent
     method: POST
-    endpoint: /agents/register
+    endpoint: /agents
   - action: modify_agent
-    method: PUT
-    endpoint: /agents/{path}
+    method: PATCH
+    endpoint: /agents/{agent_id}
   - action: delete_agent
     method: DELETE
-    endpoint: /agents/{path}
+    endpoint: /agents/{agent_id}
   - action: toggle_agent
     method: POST
-    endpoint: /agents/{path}/toggle
+    endpoint: /agents/{agent_id}/toggle
+  - action: sync_wellknown
+    method: POST
+    endpoint: /agents/{agent_id}/wellknown
   - action: rate_agent
     method: POST
-    endpoint: /agents/{path}/rate
+    endpoint: /agents/{agent_id}/rate
 
 server-write:
   - action: register_service

--- a/registry/src/registry/api/v1/a2a/agent_routes.py
+++ b/registry/src/registry/api/v1/a2a/agent_routes.py
@@ -34,6 +34,7 @@ from registry.services.access_control_service import acl_service
 from registry_pkgs.database.decorators import use_transaction
 from registry_pkgs.models._generated import PrincipalType, ResourceType
 from registry_pkgs.models.enums import RoleBits
+from registry.schemas.acl_schema import ResourcePermissions
 
 logger = logging.getLogger(__name__)
 
@@ -273,7 +274,6 @@ async def create_agent(
         )
 
         logger.info(f"Granted user {user_id} OWNER permissions for agent {agent.id}")
-        from registry.schemas.acl_schema import ResourcePermissions
 
         permissions = ResourcePermissions(
             VIEW=True,

--- a/registry/src/registry/api/v1/a2a/agent_routes.py
+++ b/registry/src/registry/api/v1/a2a/agent_routes.py
@@ -16,23 +16,17 @@ from registry.auth.dependencies import CurrentUser
 from registry.core.telemetry_decorators import track_registry_operation
 from registry.schemas.a2a_agent_api_schemas import (
     AgentCreateRequest,
-    AgentCreateResponse,
     AgentDetailResponse,
     AgentListResponse,
     AgentSkillsResponse,
     AgentStatsResponse,
     AgentToggleRequest,
-    AgentToggleResponse,
     AgentUpdateRequest,
-    AgentUpdateResponse,
     PaginationMetadata,
     WellKnownSyncResponse,
-    convert_to_create_response,
     convert_to_detail,
     convert_to_list_item,
     convert_to_skills_response,
-    convert_to_toggle_response,
-    convert_to_update_response,
 )
 from registry.schemas.errors import ErrorCode, create_error_detail
 from registry.services.a2a_agent_service import a2a_agent_service
@@ -66,6 +60,7 @@ def check_admin_permission(user_context: dict) -> bool:
 @router.get(
     "/agents",
     response_model=AgentListResponse,
+    response_model_by_alias=False,  # Use snake_case in API responses
     summary="List Agents",
     description="List all agents with filtering, searching, and pagination",
 )
@@ -121,8 +116,8 @@ async def list_agents(
             pagination=PaginationMetadata(
                 total=total,
                 page=page,
-                perPage=per_page,
-                totalPages=total_pages,
+                per_page=per_page,
+                total_pages=total_pages,
             ),
         )
 
@@ -171,13 +166,13 @@ async def get_agent_stats(
         stats = await a2a_agent_service.get_stats()
 
         return AgentStatsResponse(
-            totalAgents=stats["total_agents"],
-            enabledAgents=stats["enabled_agents"],
-            disabledAgents=stats["disabled_agents"],
-            byStatus=stats["by_status"],
-            byTransport=stats["by_transport"],
-            totalSkills=stats["total_skills"],
-            averageSkillsPerAgent=stats["average_skills_per_agent"],
+            total_agents=stats["total_agents"],
+            enabled_agents=stats["enabled_agents"],
+            disabled_agents=stats["disabled_agents"],
+            by_status=stats["by_status"],
+            by_transport=stats["by_transport"],
+            total_skills=stats["total_skills"],
+            average_skills_per_agent=stats["average_skills_per_agent"],
         )
 
     except HTTPException:
@@ -194,6 +189,7 @@ async def get_agent_stats(
 @router.get(
     "/agents/{agent_id}",
     response_model=AgentDetailResponse,
+    response_model_by_alias=False,  # Use snake_case in API responses
     summary="Get Agent Detail",
     description="Get detailed information about a specific agent",
 )
@@ -244,7 +240,8 @@ async def get_agent(
 
 @router.post(
     "/agents",
-    response_model=AgentCreateResponse,
+    response_model=AgentDetailResponse,
+    response_model_by_alias=False,  # Use snake_case in API responses
     status_code=http_status.HTTP_201_CREATED,
     summary="Create Agent",
     description="Register a new A2A agent",
@@ -276,15 +273,16 @@ async def create_agent(
         )
 
         logger.info(f"Granted user {user_id} OWNER permissions for agent {agent.id}")
+        from registry.schemas.acl_schema import ResourcePermissions
 
-        # Get permissions for response
-        permissions = await acl_service.get_user_permissions_for_resource(
-            user_id=PydanticObjectId(user_id),
-            resource_type=ResourceType.AGENT.value,
-            resource_id=agent.id,
+        permissions = ResourcePermissions(
+            VIEW=True,
+            EDIT=True,
+            DELETE=True,
+            SHARE=True,
         )
 
-        return convert_to_create_response(agent, acl_permission=permissions)
+        return convert_to_detail(agent, acl_permission=permissions)
 
     except ValueError as e:
         error_msg = str(e)
@@ -315,7 +313,8 @@ async def create_agent(
 
 @router.patch(
     "/agents/{agent_id}",
-    response_model=AgentUpdateResponse,
+    response_model=AgentDetailResponse,
+    response_model_by_alias=False,  # Use snake_case in API responses
     summary="Update Agent",
     description="Update agent configuration",
 )
@@ -341,7 +340,7 @@ async def update_agent(
         # Update agent
         agent = await a2a_agent_service.update_agent(agent_id=agent_id, data=data)
 
-        return convert_to_update_response(agent, acl_permission=permissions)
+        return convert_to_detail(agent, acl_permission=permissions)
 
     except ValueError as e:
         error_msg = str(e)
@@ -436,7 +435,8 @@ async def delete_agent(
 
 @router.post(
     "/agents/{agent_id}/toggle",
-    response_model=AgentToggleResponse,
+    response_model=AgentDetailResponse,
+    response_model_by_alias=False,  # Use snake_case in API responses
     summary="Toggle Agent Status",
     description="Enable or disable an agent",
 )
@@ -461,7 +461,7 @@ async def toggle_agent(
         # Toggle agent status
         agent = await a2a_agent_service.toggle_agent_status(agent_id=agent_id, enabled=data.enabled)
 
-        return convert_to_toggle_response(agent, acl_permission=permissions)
+        return convert_to_detail(agent, acl_permission=permissions)
 
     except ValueError as e:
         error_msg = str(e)
@@ -566,8 +566,8 @@ async def sync_wellknown(
 
         return WellKnownSyncResponse(
             message=result["message"],
-            syncStatus=result["sync_status"],
-            syncedAt=result["synced_at"],
+            sync_status=result["sync_status"],
+            synced_at=result["synced_at"],
             version=result["version"],
             changes=result["changes"],
         )

--- a/registry/src/registry/api/v1/a2a/agent_routes.py
+++ b/registry/src/registry/api/v1/a2a/agent_routes.py
@@ -28,13 +28,13 @@ from registry.schemas.a2a_agent_api_schemas import (
     convert_to_list_item,
     convert_to_skills_response,
 )
+from registry.schemas.acl_schema import ResourcePermissions
 from registry.schemas.errors import ErrorCode, create_error_detail
 from registry.services.a2a_agent_service import a2a_agent_service
 from registry.services.access_control_service import acl_service
 from registry_pkgs.database.decorators import use_transaction
 from registry_pkgs.models._generated import PrincipalType, ResourceType
 from registry_pkgs.models.enums import RoleBits
-from registry.schemas.acl_schema import ResourcePermissions
 
 logger = logging.getLogger(__name__)
 

--- a/registry/src/registry/api/v1/server/server_routes.py
+++ b/registry/src/registry/api/v1/server/server_routes.py
@@ -13,6 +13,7 @@ from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi import status as http_status
 
+from registry.schemas.acl_schema import ResourcePermissions
 from registry_pkgs.database.decorators import use_transaction
 from registry_pkgs.models._generated import PrincipalType, ResourceType
 from registry_pkgs.models.enums import RoleBits
@@ -41,7 +42,7 @@ from ....services.oauth.connection_status_service import (
 )
 from ....services.oauth.mcp_service import get_mcp_service
 from ....services.server_service import server_service_v1
-from registry.schemas.acl_schema import ResourcePermissions
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()

--- a/registry/src/registry/api/v1/server/server_routes.py
+++ b/registry/src/registry/api/v1/server/server_routes.py
@@ -41,7 +41,7 @@ from ....services.oauth.connection_status_service import (
 )
 from ....services.oauth.mcp_service import get_mcp_service
 from ....services.server_service import server_service_v1
-
+from registry.schemas.acl_schema import ResourcePermissions
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
@@ -396,10 +396,6 @@ async def create_server(
         )
 
         logger.info(f"Granted user {user_id} {RoleBits.OWNER} permissions for server Id {server.id}")
-
-        # ✅ 直接构造OWNER权限（避免事务内查询问题）
-        # 创建者被授予OWNER权限，包含所有操作权限
-        from registry.schemas.acl_schema import ResourcePermissions
 
         perms = ResourcePermissions(
             VIEW=True,

--- a/registry/src/registry/api/v1/server/server_routes.py
+++ b/registry/src/registry/api/v1/server/server_routes.py
@@ -26,23 +26,13 @@ from ....schemas.server_api_schemas import (
     ServerConnectionTestRequest,
     ServerConnectionTestResponse,
     ServerCreateRequest,
-    ServerCreateResponse,
     ServerDetailResponse,
-    ServerHealthResponse,
     ServerListResponse,
     ServerStatsResponse,
     ServerToggleRequest,
-    ServerToggleResponse,
-    ServerToolsResponse,
     ServerUpdateRequest,
-    ServerUpdateResponse,
-    convert_to_create_response,
     convert_to_detail,
-    convert_to_health_response,
     convert_to_list_item,
-    convert_to_toggle_response,
-    convert_to_tools_response,
-    convert_to_update_response,
 )
 from ....services.access_control_service import acl_service
 from ....services.oauth.connection_status_service import (
@@ -69,13 +59,13 @@ def apply_connection_status_to_server(
     Apply connection status to a server response object.
     """
     if status:
-        server_item.connectionState = status.get("connection_state")
-        server_item.requiresOAuth = status.get("requires_oauth", False)
+        server_item.connection_state = status.get("connection_state")
+        server_item.requires_oauth = status.get("requires_oauth", False)
         server_item.error = status.get("error")
     else:
         # Fallback if status not found
-        server_item.connectionState = ConnectionState.ERROR.value
-        server_item.requiresOAuth = fallback_requires_oauth
+        server_item.connection_state = ConnectionState.ERROR.value
+        server_item.requires_oauth = fallback_requires_oauth
         server_item.error = "Connection status not available"
 
 
@@ -85,6 +75,7 @@ def apply_connection_status_to_server(
 @router.get(
     "/servers",
     response_model=ServerListResponse,
+    response_model_by_alias=False,  # Use snake_case in API responses
     summary="List Servers",
     description="List all servers with filtering, searching, and pagination. Includes connection status for each server.",
 )
@@ -316,6 +307,7 @@ async def check_server_connection(
 @router.get(
     "/servers/{server_id}",
     response_model=ServerDetailResponse,
+    response_model_by_alias=False,  # Use snake_case in API responses
     summary="Get Server Details",
     description="Get detailed information about a specific server, including connection status",
 )
@@ -370,7 +362,8 @@ async def get_server(
 
 @router.post(
     "/servers",
-    response_model=ServerCreateResponse,
+    response_model=ServerDetailResponse,
+    response_model_by_alias=False,  # Use snake_case in API responses
     status_code=http_status.HTTP_201_CREATED,
     summary="Register Server",
     description="Register a new MCP server",
@@ -403,7 +396,18 @@ async def create_server(
         )
 
         logger.info(f"Granted user {user_id} {RoleBits.OWNER} permissions for server Id {server.id}")
-        return convert_to_create_response(server)
+
+        # ✅ 直接构造OWNER权限（避免事务内查询问题）
+        # 创建者被授予OWNER权限，包含所有操作权限
+        from registry.schemas.acl_schema import ResourcePermissions
+
+        perms = ResourcePermissions(
+            VIEW=True,
+            EDIT=True,
+            DELETE=True,
+            SHARE=True,
+        )
+        return convert_to_detail(server, acl_permission=perms)
 
     except ValueError as e:
         error_msg = str(e)
@@ -429,7 +433,8 @@ async def create_server(
 
 @router.patch(
     "/servers/{server_id}",
-    response_model=ServerUpdateResponse,
+    response_model=ServerDetailResponse,
+    response_model_by_alias=False,  # Use snake_case in API responses
     summary="Update Server",
     description="Update server configuration",
 )
@@ -443,7 +448,7 @@ async def update_server(
     """Update a server with partial data"""
     try:
         user_id = user_context.get("user_id")
-        await acl_service.check_user_permission(
+        permissions = await acl_service.check_user_permission(
             user_id=PydanticObjectId(user_id),
             resource_type=ResourceType.MCPSERVER.value,
             resource_id=PydanticObjectId(server_id),
@@ -456,7 +461,7 @@ async def update_server(
             user_id=user_id,
         )
 
-        return convert_to_update_response(server)
+        return convert_to_detail(server, acl_permission=permissions)
 
     except ValueError as e:
         error_msg = str(e)
@@ -546,7 +551,8 @@ async def delete_server(
 
 @router.post(
     "/servers/{server_id}/toggle",
-    response_model=ServerToggleResponse,
+    response_model=ServerDetailResponse,
+    response_model_by_alias=False,  # Use snake_case in API responses
     summary="Toggle Server Status",
     description="Enable or disable a server",
 )
@@ -559,7 +565,7 @@ async def toggle_server(
     """Toggle server enabled/disabled status. When enabling, fetches tools from server."""
     try:
         user_id = user_context.get("user_id")
-        await acl_service.check_user_permission(
+        permissions = await acl_service.check_user_permission(
             user_id=PydanticObjectId(user_id),
             resource_type=ResourceType.MCPSERVER.value,
             resource_id=PydanticObjectId(server_id),
@@ -572,7 +578,7 @@ async def toggle_server(
             user_id=user_id,
         )
 
-        return convert_to_toggle_response(server, data.enabled)
+        return convert_to_detail(server, acl_permission=permissions)
 
     except ValueError as e:
         error_msg = str(e)
@@ -599,7 +605,8 @@ async def toggle_server(
 
 @router.get(
     "/servers/{server_id}/tools",
-    response_model=ServerToolsResponse,
+    response_model=ServerDetailResponse,
+    response_model_by_alias=False,  # Use snake_case in API responses
     summary="Get Server Tools",
     description="Get the list of tools provided by a server",
 )
@@ -611,7 +618,7 @@ async def get_server_tools(
     """Get server tools"""
     try:
         user_id = user_context.get("user_id")
-        await acl_service.check_user_permission(
+        permissions = await acl_service.check_user_permission(
             user_id=PydanticObjectId(user_id),
             resource_type=ResourceType.MCPSERVER.value,
             resource_id=PydanticObjectId(server_id),
@@ -623,7 +630,7 @@ async def get_server_tools(
             user_id=None,
         )
 
-        return convert_to_tools_response(server, tools)
+        return convert_to_detail(server, acl_permission=permissions)
 
     except ValueError as e:
         error_msg = str(e)
@@ -660,7 +667,8 @@ async def get_server_tools(
 
 @router.post(
     "/servers/{server_id}/refresh",
-    response_model=ServerHealthResponse,
+    response_model=ServerDetailResponse,
+    response_model_by_alias=False,  # Use snake_case in API responses
     summary="Refresh Server Health",
     description="Refresh server health status and check connectivity",
 )
@@ -671,8 +679,14 @@ async def refresh_server_health(
 ):
     """Refresh server health status. Updates tools if server becomes active."""
     try:
-        # Get user_id from context for OAuth token retrieval
         user_id = user_context.get("user_id")
+
+        permissions = await acl_service.check_user_permission(
+            user_id=PydanticObjectId(user_id),
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_id=PydanticObjectId(server_id),
+            required_permission="VIEW",
+        )
 
         health_info = await server_service_v1.refresh_server_health(
             server_id=server_id,
@@ -691,7 +705,7 @@ async def refresh_server_health(
 
         server = health_info["server"]
 
-        return convert_to_health_response(server, health_info)
+        return convert_to_detail(server, acl_permission=permissions)
 
     except ValueError as e:
         error_msg = str(e)

--- a/registry/src/registry/main.py
+++ b/registry/src/registry/main.py
@@ -160,6 +160,8 @@ app = FastAPI(
     swagger_ui_parameters={
         "persistAuthorization": True,
     },
+    # API responses should use snake_case field names, not aliases
+    generate_unique_id_function=lambda route: f"{route.tags[0]}-{route.name}" if route.tags else route.name,
     openapi_tags=[
         {"name": "Authentication", "description": "OAuth2 and session-based authentication endpoints"},
         {

--- a/registry/src/registry/schemas/a2a_agent_api_schemas.py
+++ b/registry/src/registry/schemas/a2a_agent_api_schemas.py
@@ -3,19 +3,23 @@ Pydantic Schemas for A2A Agent Management API v1
 
 These schemas define the request and response models for the
 A2A Agent Management endpoints based on the API documentation.
+
+All schemas use snake_case for API input/output and automatically
+convert to camelCase for MongoDB storage.
 """
 
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import Field, HttpUrl
 
 from registry.schemas.acl_schema import ResourcePermissions
+from registry.schemas.case_conversion import APIBaseModel
 
 # ==================== Nested Models ====================
 
 
-class AgentSkillInput(BaseModel):
+class AgentSkillInput(APIBaseModel):
     """Input schema for agent skill"""
 
     id: str = Field(description="Unique skill identifier")
@@ -23,59 +27,50 @@ class AgentSkillInput(BaseModel):
     description: str = Field(description="Detailed skill description")
     tags: list[str] = Field(default_factory=list, description="Skill categorization tags")
     examples: list[str] | None = Field(None, description="Usage examples")
-    input_modes: list[str] | None = Field(None, alias="inputModes", description="Skill-specific input MIME types")
-    output_modes: list[str] | None = Field(None, alias="outputModes", description="Skill-specific output MIME types")
+    input_modes: list[str] | None = Field(None, description="Skill-specific input MIME types")
+    output_modes: list[str] | None = Field(None, description="Skill-specific output MIME types")
     security: list[dict[str, list[str]]] | None = Field(None, description="Skill-level security requirements")
 
-    class Config:
-        populate_by_name = True
 
-
-class AgentSkillOutput(BaseModel):
+class AgentSkillOutput(APIBaseModel):
     """Output schema for agent skill"""
 
     id: str
     name: str
     description: str
     tags: list[str] = []
-    input_modes: list[str] | None = Field(None, alias="inputModes")
-    output_modes: list[str] | None = Field(None, alias="outputModes")
-
-    class Config:
-        populate_by_name = True
+    input_modes: list[str] | None = None
+    output_modes: list[str] | None = None
 
 
-class AgentProviderInput(BaseModel):
+class AgentProviderInput(APIBaseModel):
     """Input schema for agent provider"""
 
     organization: str = Field(description="Provider organization name")
     url: str = Field(description="Provider website or documentation URL")
 
 
-class AgentProviderOutput(BaseModel):
+class AgentProviderOutput(APIBaseModel):
     """Output schema for agent provider"""
 
     organization: str
     url: str
 
 
-class WellKnownInfo(BaseModel):
+class WellKnownInfo(APIBaseModel):
     """Well-known configuration info"""
 
     enabled: bool
     url: str | None = None
-    last_sync_at: datetime | None = Field(None, alias="lastSyncAt")
-    last_sync_status: str | None = Field(None, alias="lastSyncStatus")
-    last_sync_version: str | None = Field(None, alias="lastSyncVersion")
-
-    class Config:
-        populate_by_name = True
+    last_sync_at: datetime | None = None
+    last_sync_status: str | None = None
+    last_sync_version: str | None = None
 
 
 # ==================== Request Schemas ====================
 
 
-class AgentCreateRequest(BaseModel):
+class AgentCreateRequest(APIBaseModel):
     """Request schema for creating a new agent"""
 
     path: str = Field(description="Registry path (e.g., /code-reviewer)")
@@ -83,34 +78,25 @@ class AgentCreateRequest(BaseModel):
     description: str = Field(default="", description="Agent description")
     url: HttpUrl | str = Field(description="Agent endpoint URL")
     version: str = Field(description="Agent version")
-    protocol_version: str = Field(default="1.0", alias="protocolVersion", description="A2A protocol version")
+    protocol_version: str = Field(default="1.0", description="A2A protocol version")
     capabilities: dict[str, Any] = Field(
         default_factory=dict, description="Feature declarations (e.g., {'streaming': true})"
     )
     skills: list[AgentSkillInput] = Field(default_factory=list, description="Agent capabilities (skills)")
-    security_schemes: dict[str, Any] = Field(
-        default_factory=dict, alias="securitySchemes", description="Supported authentication methods"
-    )
-    preferred_transport: str = Field(
-        default="HTTP+JSON", alias="preferredTransport", description="Preferred transport protocol"
-    )
+    security_schemes: dict[str, Any] = Field(default_factory=dict, description="Supported authentication methods")
+    preferred_transport: str = Field(default="HTTP+JSON", description="Preferred transport protocol")
     default_input_modes: list[str] = Field(
-        default_factory=lambda: ["text/plain"], alias="defaultInputModes", description="Supported input MIME types"
+        default_factory=lambda: ["text/plain"], description="Supported input MIME types"
     )
     default_output_modes: list[str] = Field(
-        default_factory=lambda: ["application/json"],
-        alias="defaultOutputModes",
-        description="Supported output MIME types",
+        default_factory=lambda: ["application/json"], description="Supported output MIME types"
     )
     provider: AgentProviderInput | None = Field(None, description="Agent provider information")
     tags: list[str] = Field(default_factory=list, description="Categorization tags")
     enabled: bool = Field(default=False, description="Whether agent is enabled in registry")
 
-    class Config:
-        populate_by_name = True
 
-
-class AgentUpdateRequest(BaseModel):
+class AgentUpdateRequest(APIBaseModel):
     """Request schema for updating an agent (partial update)"""
 
     name: str | None = None
@@ -120,17 +106,14 @@ class AgentUpdateRequest(BaseModel):
     tags: list[str] | None = None
     enabled: bool | None = None
     capabilities: dict[str, Any] | None = None
-    security_schemes: dict[str, Any] | None = Field(None, alias="securitySchemes")
-    preferred_transport: str | None = Field(None, alias="preferredTransport")
-    default_input_modes: list[str] | None = Field(None, alias="defaultInputModes")
-    default_output_modes: list[str] | None = Field(None, alias="defaultOutputModes")
+    security_schemes: dict[str, Any] | None = None
+    preferred_transport: str | None = None
+    default_input_modes: list[str] | None = None
+    default_output_modes: list[str] | None = None
     provider: AgentProviderInput | None = None
 
-    class Config:
-        populate_by_name = True
 
-
-class AgentToggleRequest(BaseModel):
+class AgentToggleRequest(APIBaseModel):
     """Request schema for toggling agent status"""
 
     enabled: bool = Field(description="New enabled state")
@@ -139,19 +122,16 @@ class AgentToggleRequest(BaseModel):
 # ==================== Response Schemas ====================
 
 
-class PaginationMetadata(BaseModel):
+class PaginationMetadata(APIBaseModel):
     """Pagination metadata"""
 
     total: int
     page: int
-    per_page: int = Field(alias="perPage")
-    total_pages: int = Field(alias="totalPages")
-
-    class Config:
-        populate_by_name = True
+    per_page: int
+    total_pages: int
 
 
-class AgentListItem(BaseModel):
+class AgentListItem(APIBaseModel):
     """Agent item in list response"""
 
     id: str
@@ -160,44 +140,47 @@ class AgentListItem(BaseModel):
     description: str
     url: str
     version: str
-    protocol_version: str = Field(alias="protocolVersion")
+    protocol_version: str
     tags: list[str]
-    num_skills: int = Field(alias="numSkills")
+    num_skills: int
     enabled: bool
     status: str
     permissions: ResourcePermissions
     author: str
-    created_at: datetime = Field(alias="createdAt")
-    updated_at: datetime = Field(alias="updatedAt")
-
-    class Config:
-        populate_by_name = True
+    created_at: datetime
+    updated_at: datetime
 
 
-class AgentListResponse(BaseModel):
+class AgentListResponse(APIBaseModel):
     """Response schema for listing agents"""
 
     agents: list[AgentListItem]
     pagination: PaginationMetadata
 
 
-class AgentStatsResponse(BaseModel):
+class AgentStatsResponse(APIBaseModel):
     """Response schema for agent statistics"""
 
-    total_agents: int = Field(alias="totalAgents")
-    enabled_agents: int = Field(alias="enabledAgents")
-    disabled_agents: int = Field(alias="disabledAgents")
-    by_status: dict[str, int] = Field(alias="byStatus")
-    by_transport: dict[str, int] = Field(alias="byTransport")
-    total_skills: int = Field(alias="totalSkills")
-    average_skills_per_agent: float = Field(alias="averageSkillsPerAgent")
-
-    class Config:
-        populate_by_name = True
+    total_agents: int
+    enabled_agents: int
+    disabled_agents: int
+    by_status: dict[str, int]
+    by_transport: dict[str, int]
+    total_skills: int
+    average_skills_per_agent: float
 
 
-class AgentDetailResponse(BaseModel):
-    """Response schema for agent detail"""
+class AgentDetailResponse(APIBaseModel):
+    """
+    Unified response schema for agent detail operations
+
+    Used for:
+    - GET /agents/{path} - Get agent details
+    - POST /agents - Create agent
+    - PUT /agents/{path} - Update agent
+    - POST /agents/{path}/toggle - Toggle agent
+    - GET /agents/{path}/skills - Get agent skills
+    """
 
     id: str
     path: str
@@ -205,71 +188,41 @@ class AgentDetailResponse(BaseModel):
     description: str
     url: str
     version: str
-    protocol_version: str = Field(alias="protocolVersion")
+    protocol_version: str
     capabilities: dict[str, Any]
     skills: list[AgentSkillOutput]
-    security_schemes: dict[str, Any] = Field(alias="securitySchemes")
-    preferred_transport: str = Field(alias="preferredTransport")
-    default_input_modes: list[str] = Field(alias="defaultInputModes")
-    default_output_modes: list[str] = Field(alias="defaultOutputModes")
+    security_schemes: dict[str, Any]
+    preferred_transport: str
+    default_input_modes: list[str]
+    default_output_modes: list[str]
     provider: AgentProviderOutput | None = None
     tags: list[str]
     status: str
     enabled: bool
     permissions: ResourcePermissions
     author: str
-    well_known: WellKnownInfo | None = Field(None, alias="wellKnown")
-    created_at: datetime = Field(alias="createdAt")
-    updated_at: datetime = Field(alias="updatedAt")
-
-    class Config:
-        populate_by_name = True
+    well_known: WellKnownInfo | None = None
+    created_at: datetime
+    updated_at: datetime
 
 
-class AgentCreateResponse(BaseModel):
-    """Response schema for creating an agent"""
-
-    message: str
-    agent: AgentDetailResponse
-
-
-class AgentUpdateResponse(BaseModel):
-    """Response schema for updating an agent"""
-
-    message: str
-    agent: AgentDetailResponse
-
-
-class AgentToggleResponse(BaseModel):
-    """Response schema for toggling agent"""
-
-    message: str
-    agent: AgentDetailResponse
-
-
-class AgentSkillsResponse(BaseModel):
+class AgentSkillsResponse(APIBaseModel):
     """Response schema for agent skills"""
 
-    agent_id: str = Field(alias="agentId")
-    agent_name: str = Field(alias="agentName")
+    agent_id: str
+    agent_name: str
     skills: list[AgentSkillOutput]
-    total_skills: int = Field(alias="totalSkills")
-
-    class Config:
-        populate_by_name = True
+    total_skills: int
 
 
-class WellKnownSyncResponse(BaseModel):
+class WellKnownSyncResponse(APIBaseModel):
     """Response schema for well-known sync"""
 
     message: str
-    sync_status: str = Field(alias="syncStatus")
-    synced_at: datetime = Field(alias="syncedAt")
+    sync_status: str
+    synced_at: datetime
     version: str
     changes: list[str]
-
-    class Config:
-        populate_by_name = True
 
 
 # ==================== Converter Functions ====================
@@ -279,7 +232,6 @@ def convert_to_list_item(agent: Any, acl_permission: int | ResourcePermissions) 
     """Convert A2AAgent document to list item"""
     from registry_pkgs.models.enums import PermissionBits
 
-    # Handle both int (permission bits) and ResourcePermissions object
     if isinstance(acl_permission, ResourcePermissions):
         permissions = acl_permission
     else:
@@ -297,15 +249,15 @@ def convert_to_list_item(agent: Any, acl_permission: int | ResourcePermissions) 
         description=agent.card.description,
         url=str(agent.card.url),
         version=agent.card.version,
-        protocolVersion=agent.card.protocol_version,
+        protocol_version=agent.card.protocol_version,
         tags=agent.tags,
-        numSkills=len(agent.card.skills or []),
+        num_skills=len(agent.card.skills or []),
         enabled=agent.isEnabled,
         status=agent.status,
         permissions=permissions,
         author=str(agent.author),
-        createdAt=agent.createdAt,
-        updatedAt=agent.updatedAt,
+        created_at=agent.createdAt,
+        updated_at=agent.updatedAt,
     )
 
 
@@ -313,7 +265,6 @@ def convert_to_detail(agent: Any, acl_permission: int | ResourcePermissions) -> 
     """Convert A2AAgent document to detail response"""
     from registry_pkgs.models.enums import PermissionBits
 
-    # Handle both int (permission bits) and ResourcePermissions object
     if isinstance(acl_permission, ResourcePermissions):
         permissions = acl_permission
     else:
@@ -330,8 +281,8 @@ def convert_to_detail(agent: Any, acl_permission: int | ResourcePermissions) -> 
             name=skill.name,
             description=skill.description,
             tags=skill.tags or [],
-            inputModes=skill.input_modes if hasattr(skill, "input_modes") else None,
-            outputModes=skill.output_modes if hasattr(skill, "output_modes") else None,
+            input_modes=skill.input_modes if hasattr(skill, "input_modes") else None,
+            output_modes=skill.output_modes if hasattr(skill, "output_modes") else None,
         )
         for skill in (agent.card.skills or [])
     ]
@@ -347,12 +298,11 @@ def convert_to_detail(agent: Any, acl_permission: int | ResourcePermissions) -> 
         well_known_info = WellKnownInfo(
             enabled=agent.wellKnown.enabled,
             url=str(agent.wellKnown.url) if agent.wellKnown.url else None,
-            lastSyncAt=agent.wellKnown.lastSyncAt,
-            lastSyncStatus=agent.wellKnown.lastSyncStatus,
-            lastSyncVersion=agent.wellKnown.lastSyncVersion,
+            last_sync_at=agent.wellKnown.lastSyncAt,
+            last_sync_status=agent.wellKnown.lastSyncStatus,
+            last_sync_version=agent.wellKnown.lastSyncVersion,
         )
 
-    # Convert capabilities to dict if it's a Pydantic model
     capabilities_dict = {}
     if agent.card.capabilities:
         if hasattr(agent.card.capabilities, "model_dump"):
@@ -362,7 +312,6 @@ def convert_to_detail(agent: Any, acl_permission: int | ResourcePermissions) -> 
         else:
             capabilities_dict = dict(agent.card.capabilities)
 
-    # Convert security_schemes to dict if needed
     security_schemes_dict = {}
     if agent.card.security_schemes:
         if hasattr(agent.card.security_schemes, "model_dump"):
@@ -379,47 +328,22 @@ def convert_to_detail(agent: Any, acl_permission: int | ResourcePermissions) -> 
         description=agent.card.description,
         url=str(agent.card.url),
         version=agent.card.version,
-        protocolVersion=agent.card.protocol_version,
+        protocol_version=agent.card.protocol_version,
         capabilities=capabilities_dict,
         skills=skills_output,
-        securitySchemes=security_schemes_dict,
-        preferredTransport=agent.card.preferred_transport,
-        defaultInputModes=agent.card.default_input_modes or [],
-        defaultOutputModes=agent.card.default_output_modes or [],
+        security_schemes=security_schemes_dict,
+        preferred_transport=agent.card.preferred_transport,
+        default_input_modes=agent.card.default_input_modes or [],
+        default_output_modes=agent.card.default_output_modes or [],
         provider=provider_output,
         tags=agent.tags,
         status=agent.status,
         enabled=agent.isEnabled,
         permissions=permissions,
         author=str(agent.author),
-        wellKnown=well_known_info,
-        createdAt=agent.createdAt,
-        updatedAt=agent.updatedAt,
-    )
-
-
-def convert_to_create_response(agent: Any, acl_permission: int | ResourcePermissions) -> AgentCreateResponse:
-    """Convert A2AAgent document to create response with full details"""
-    return AgentCreateResponse(
-        message="Agent registered successfully",
-        agent=convert_to_detail(agent, acl_permission),
-    )
-
-
-def convert_to_update_response(agent: Any, acl_permission: int | ResourcePermissions) -> AgentUpdateResponse:
-    """Convert A2AAgent document to update response with full details"""
-    return AgentUpdateResponse(
-        message="Agent updated successfully",
-        agent=convert_to_detail(agent, acl_permission),
-    )
-
-
-def convert_to_toggle_response(agent: Any, acl_permission: int | ResourcePermissions) -> AgentToggleResponse:
-    """Convert A2AAgent document to toggle response with full details"""
-    message = f"Agent {'enabled' if agent.isEnabled else 'disabled'} successfully"
-    return AgentToggleResponse(
-        message=message,
-        agent=convert_to_detail(agent, acl_permission),
+        well_known=well_known_info,
+        created_at=agent.createdAt,
+        updated_at=agent.updatedAt,
     )
 
 
@@ -431,12 +355,15 @@ def convert_to_skills_response(agent: Any) -> AgentSkillsResponse:
             name=skill.name,
             description=skill.description,
             tags=skill.tags or [],
-            inputModes=skill.input_modes if hasattr(skill, "input_modes") else None,
-            outputModes=skill.output_modes if hasattr(skill, "output_modes") else None,
+            input_modes=skill.input_modes if hasattr(skill, "input_modes") else None,
+            output_modes=skill.output_modes if hasattr(skill, "output_modes") else None,
         )
         for skill in (agent.card.skills or [])
     ]
 
     return AgentSkillsResponse(
-        agentId=str(agent.id), agentName=agent.card.name, skills=skills_output, totalSkills=len(agent.card.skills or [])
+        agent_id=str(agent.id),
+        agent_name=agent.card.name,
+        skills=skills_output,
+        total_skills=len(agent.card.skills or []),
     )

--- a/registry/src/registry/schemas/case_conversion.py
+++ b/registry/src/registry/schemas/case_conversion.py
@@ -1,0 +1,78 @@
+"""
+Base schema classes with automatic snake_case <-> camelCase conversion
+
+All API schemas should inherit from APIBaseModel to ensure consistent
+field naming conventions:
+- API uses snake_case (external interface)
+- MongoDB uses camelCase (internal storage)
+- Automatic conversion handled by Pydantic
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+def to_camel_case(snake_str: str) -> str:
+    """
+    Convert snake_case to camelCase for Pydantic alias generation
+
+    Examples:
+        server_name -> serverName
+        num_tools -> numTools
+        created_at -> createdAt
+    """
+    components = snake_str.split("_")
+    return components[0] + "".join(x.title() for x in components[1:])
+
+
+class APIBaseModel(BaseModel):
+    """
+    Base model for all API schemas
+
+    Features:
+    - API uses snake_case field names (external)
+    - MongoDB uses camelCase field names (internal)
+    - Automatic alias generation for camelCase
+    - Supports both field name and alias on input
+    - API responses use snake_case (by_alias=False by default)
+    - Methods for explicit conversion when needed
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,  # Allow both snake_case and camelCase on input
+        alias_generator=to_camel_case,  # Auto-generate camelCase aliases for all fields
+        # API responses should use field names (snake_case), not aliases
+        # This ensures JSON responses match API documentation
+        json_schema_serialization_defaults_required=True,
+    )
+
+    def model_dump_for_mongo(self, **kwargs) -> dict[str, Any]:
+        """
+        Dump model for MongoDB storage (camelCase keys)
+
+        This method serializes the model using aliases (camelCase),
+        which matches the MongoDB storage format.
+
+        Args:
+            **kwargs: Additional arguments passed to model_dump
+
+        Returns:
+            Dictionary with camelCase keys suitable for MongoDB
+        """
+        return self.model_dump(by_alias=True, exclude_none=True, **kwargs)
+
+    def model_dump_for_api(self, **kwargs) -> dict[str, Any]:
+        """
+        Dump model for API response (snake_case keys)
+
+        This method serializes the model using field names (snake_case),
+        which matches the API response format.
+
+        Args:
+            **kwargs: Additional arguments passed to model_dump
+
+        Returns:
+            Dictionary with snake_case keys suitable for API responses
+        """
+        return self.model_dump(by_alias=False, exclude_none=True, **kwargs)

--- a/registry/src/registry/schemas/case_conversion.py
+++ b/registry/src/registry/schemas/case_conversion.py
@@ -12,18 +12,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
-
-def to_camel_case(snake_str: str) -> str:
-    """
-    Convert snake_case to camelCase for Pydantic alias generation
-
-    Examples:
-        server_name -> serverName
-        num_tools -> numTools
-        created_at -> createdAt
-    """
-    components = snake_str.split("_")
-    return components[0] + "".join(x.title() for x in components[1:])
+from registry.utils.schema_converter import to_camel_case
 
 
 class APIBaseModel(BaseModel):

--- a/registry/src/registry/schemas/server_api_schemas.py
+++ b/registry/src/registry/schemas/server_api_schemas.py
@@ -3,14 +3,18 @@ Pydantic Schemas for Server Management API v1
 
 These schemas define the request and response models for the
 Server Management endpoints based on the API documentation.
+
+All schemas use snake_case for API input/output and automatically
+convert to camelCase for MongoDB storage.
 """
 
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator, model_serializer
+from pydantic import Field, field_validator, model_serializer
 
 from registry.schemas.acl_schema import ResourcePermissions
+from registry.schemas.case_conversion import APIBaseModel
 from registry.utils.crypto_utils import decrypt_auth_fields
 
 # ==================== Request Schemas ====================
@@ -26,10 +30,10 @@ def _validate_headers_value(headers: dict[str, Any] | None) -> dict[str, Any] | 
     return headers
 
 
-class ServerCreateRequest(BaseModel):
+class ServerCreateRequest(APIBaseModel):
     """Request schema for creating a new server"""
 
-    title: str = Field(..., alias="title", description="Display title of the MCP server")
+    title: str = Field(..., description="Display title of the MCP server")
     path: str = Field(..., description="Unique path/route for the server")
     description: str | None = Field(default="", description="Server description")
     url: str | None = Field(default=None, description="Backend proxy URL")
@@ -52,14 +56,11 @@ class ServerCreateRequest(BaseModel):
     requires_oauth: bool = Field(default=False, description="Requires OAuth")
     oauth: dict[str, Any] | None = Field(default=None, description="OAuth configuration")
     custom_user_vars: dict[str, Any] | None = Field(default=None, description="Custom variables")
-    apiKey: dict[str, Any] | None = Field(default=None, description="API Key authentication configuration")
+    api_key: dict[str, Any] | None = Field(default=None, description="API Key authentication configuration")
     headers: dict[str, Any] | None = Field(default=None, description="Custom headers (key/value pairs)")
     enabled: bool | None = Field(
         default=None, description="Whether the server is enabled (auto-set to False during registration)"
     )
-
-    class ConfigDict:
-        populate_by_name = True  # Allow both serverName and server_name
 
     @field_validator("tags", mode="before")
     @classmethod
@@ -75,10 +76,10 @@ class ServerCreateRequest(BaseModel):
         return _validate_headers_value(v)
 
 
-class ServerUpdateRequest(BaseModel):
+class ServerUpdateRequest(APIBaseModel):
     """Request schema for updating a server (partial update)"""
 
-    title: str | None = Field(None, alias="title")
+    title: str | None = None
     path: str | None = None
     description: str | None = None
     url: str | None = None
@@ -102,13 +103,10 @@ class ServerUpdateRequest(BaseModel):
     requires_oauth: bool | None = None
     oauth: dict[str, Any] | None = None
     custom_user_vars: dict[str, Any] | None = None
-    apiKey: dict[str, Any] | None = None
+    api_key: dict[str, Any] | None = None
     headers: dict[str, Any] | None = None
     status: str | None = None
     enabled: bool | None = None
-
-    class ConfigDict:
-        populate_by_name = True  # Allow both serverName and server_name
 
     @field_validator("tags", mode="before")
     @classmethod
@@ -134,13 +132,13 @@ class ServerUpdateRequest(BaseModel):
         return _validate_headers_value(v)
 
 
-class ServerToggleRequest(BaseModel):
+class ServerToggleRequest(APIBaseModel):
     """Request schema for toggling server status"""
 
     enabled: bool = Field(..., description="Enable or disable the server")
 
 
-class ServerConnectionTestRequest(BaseModel):
+class ServerConnectionTestRequest(APIBaseModel):
     """Request schema for testing connection to an MCP server URL"""
 
     url: str = Field(..., description="MCP server URL to test connection")
@@ -150,298 +148,147 @@ class ServerConnectionTestRequest(BaseModel):
 # ==================== Response Schemas ====================
 
 
-class ToolSchema(BaseModel):
+class ToolSchema(APIBaseModel):
     """Schema for a tool definition"""
 
     name: str
     description: str
-    inputSchema: dict[str, Any] | None = None
+    input_schema: dict[str, Any] | None = None
 
-    class ConfigDict:
-        extra = "allow"
+    model_config = {"extra": "allow"}
 
 
-class ServerListItemResponse(BaseModel):
+class ServerListItemResponse(APIBaseModel):
     """Response schema for a server in the list"""
 
     id: str = Field(..., description="Server ID")
-    serverName: str = Field(..., alias="serverName")
+    server_name: str = Field(..., description="Server name")
     title: str | None = Field(None, description="Display title for the server")
     description: str | None = None
     type: str | None = Field(None, description="Transport type (e.g., streamable-http, sse, stdio)")
     url: str | None = None
-    apiKey: dict[str, Any] | None = None
+    api_key: dict[str, Any] | None = None
     oauth: dict[str, Any] | None = None
     headers: dict[str, Any] | None = Field(None, description="Custom headers (key/value pairs)")
-    requiresOAuth: bool = Field(False, alias="requiresOAuth", description="Whether OAuth is required")
+    requires_oauth: bool = Field(False, description="Whether OAuth is required")
     capabilities: str | None = Field(None, description="JSON string of server capabilities")
-    oauthMetadata: dict[str, Any] | None = Field(
-        None, alias="oauthMetadata", description="OAuth metadata from autodiscovery"
-    )
+    oauth_metadata: dict[str, Any] | None = Field(None, description="OAuth metadata from autodiscovery")
     tools: str | None = Field(None, description="Comma-separated list of tool names")
     author: str | None = Field(None, description="Author user ID")
     status: str = "active"
-    path: str | None = Field(None, description="API path for this server, option to consider jarvis model schema")
+    path: str | None = Field(None, description="API path for this server")
     tags: list[str] = Field(default_factory=list)
-    numTools: int = Field(0, alias="numTools")
-    numStars: int = Field(0, alias="numStars")
+    num_tools: int = Field(0, description="Number of tools")
+    num_stars: int = Field(0, description="Star count")
     enabled: bool = Field(default=True, description="Whether the server is enabled")
-    lastConnected: datetime | None = Field(None, alias="lastConnected")
-    createdAt: datetime
-    updatedAt: datetime
-    # Connection status fields
-    connectionState: str | None = Field(default=None, description="Connection state")
+    last_connected: datetime | None = Field(None, description="Last connection timestamp")
+    created_at: datetime
+    updated_at: datetime
+    connection_state: str | None = Field(default=None, description="Connection state")
     error: str | None = Field(default=None, description="Error message if connection failed")
-    # ACL permissions for the requesting user
     permissions: ResourcePermissions | None = Field(
         default=None, description="Resolved ACL permissions for the current user"
     )
 
-    class ConfigDict:
-        from_attributes = True
-        populate_by_name = True
+    model_config = {"from_attributes": True}
 
     @model_serializer(mode="wrap")
     def _serialize(self, serializer, info):
         data = serializer(self)
-        # Handle mutually exclusive authentication fields: oauth and apiKey
         has_oauth = data.get("oauth") is not None
-        has_api_key = data.get("apiKey") is not None
+        has_api_key = data.get("api_key") is not None
 
         if has_oauth:
-            # If oauth exists, remove apiKey from response
-            data.pop("apiKey", None)
+            data.pop("api_key", None)
         elif has_api_key:
-            # If only apiKey exists, remove oauth from response
             data.pop("oauth", None)
         else:
-            # If both are None/empty, remove both fields
             data.pop("oauth", None)
-            data.pop("apiKey", None)
+            data.pop("api_key", None)
         return data
 
 
-class ServerDetailResponse(BaseModel):
-    """Response schema for detailed server information"""
+class ServerDetailResponse(APIBaseModel):
+    """
+    Unified response schema for server detail operations
+
+    Used for:
+    - GET /servers/{path} - Get server details
+    - POST /servers - Create server
+    - PUT /servers/{path} - Update server
+    - POST /servers/{path}/toggle - Toggle server
+    - GET /servers/{path}/tools - Get server tools
+    - POST /servers/{path}/health - Health check
+    """
 
     id: str
-    serverName: str = Field(..., alias="serverName")
+    server_name: str = Field(..., description="Server name")
     title: str | None = Field(None, description="Display title for the server")
     description: str | None = None
     type: str | None = Field(None, description="Transport type (e.g., streamable-http, sse, stdio)")
     url: str | None = None
-    apiKey: dict[str, Any] | None = None
+    api_key: dict[str, Any] | None = None
     oauth: dict[str, Any] | None = None
     headers: dict[str, Any] | None = Field(None, description="Custom headers (key/value pairs)")
-    requiresOAuth: bool = Field(False, alias="requiresOAuth", description="Whether OAuth is required")
+    requires_oauth: bool = Field(False, description="Whether OAuth is required")
     capabilities: str | None = Field(None, description="JSON string of server capabilities")
-    oauthMetadata: dict[str, Any] | None = Field(
-        None, alias="oauthMetadata", description="OAuth metadata from autodiscovery"
-    )
+    oauth_metadata: dict[str, Any] | None = Field(None, description="OAuth metadata from autodiscovery")
     tools: str | None = Field(None, description="Comma-separated list of tool names")
-    toolFunctions: dict[str, Any] | None = Field(
-        None, alias="toolFunctions", description="Complete OpenAI function schemas with mcpToolName"
-    )
+    tool_functions: dict[str, Any] | None = Field(None, description="Complete OpenAI function schemas with mcpToolName")
     resources: list[dict[str, Any]] | None = Field(None, description="List of available resources")
     prompts: list[dict[str, Any]] | None = Field(None, description="List of available prompts")
-    initDuration: int | None = Field(None, alias="initDuration", description="Initialization duration in ms")
+    init_duration: int | None = Field(None, description="Initialization duration in ms")
     author: str | None = Field(None, description="Author user ID")
     status: str
-    path: str | None = Field(None, description="API path for this server, compatible with jarvis model schema")
+    path: str | None = Field(None, description="API path for this server")
     tags: list[str] = Field(default_factory=list)
-    numTools: int = Field(0, alias="numTools")
-    numStars: int = Field(0, alias="numStars")
+    num_tools: int = Field(0, description="Number of tools")
+    num_stars: int = Field(0, description="Star count")
     enabled: bool = Field(default=True, description="Whether the server is enabled")
-    lastConnected: datetime | None = Field(None, alias="lastConnected")
-    lastError: str | None = Field(None, alias="lastError")
-    errorMessage: str | None = Field(None, alias="errorMessage")
-    createdAt: datetime
-    updatedAt: datetime
-
-    connectionState: str | None = Field(default=None, description="Connection state")
+    last_connected: datetime | None = Field(None, description="Last connection timestamp")
+    last_error: str | None = Field(None, description="Last error timestamp")
+    error_message: str | None = Field(None, description="Error message")
+    created_at: datetime
+    updated_at: datetime
+    connection_state: str | None = Field(default=None, description="Connection state")
     error: str | None = Field(default=None, description="Error message if connection failed")
-    # ACL permissions for the requesting user
     permissions: ResourcePermissions | None = Field(
         default=None, description="Resolved ACL permissions for the current user"
     )
 
-    class ConfigDict:
-        from_attributes = True
-        populate_by_name = True
+    model_config = {"from_attributes": True}
 
     @model_serializer(mode="wrap")
     def _serialize(self, serializer, info):
         data = serializer(self)
-        # Handle mutually exclusive authentication fields: oauth and apiKey
         has_oauth = data.get("oauth") is not None
-        has_api_key = data.get("apiKey") is not None
+        has_api_key = data.get("api_key") is not None
 
         if has_oauth:
-            # If oauth exists, remove apiKey from response
-            data.pop("apiKey", None)
+            data.pop("api_key", None)
         elif has_api_key:
-            # If only apiKey exists, remove oauth from response
             data.pop("oauth", None)
         else:
-            # If both are None/empty, remove both fields
             data.pop("oauth", None)
-            data.pop("apiKey", None)
+            data.pop("api_key", None)
         return data
 
 
-class ServerCreateResponse(BaseModel):
-    """Response schema for server creation - flattened structure matching API doc"""
-
-    serverName: str = Field(..., alias="serverName")
-    title: str | None = None
-    description: str | None = None
-    type: str | None = None
-    url: str | None = None
-    apiKey: dict[str, Any] | None = None
-    oauth: dict[str, Any] | None = None
-    headers: dict[str, Any] | None = Field(None, description="Custom headers (key/value pairs)")
-    requiresOAuth: bool = Field(False, alias="requiresOAuth")
-    capabilities: str | None = None
-    oauthMetadata: dict[str, Any] | None = Field(
-        None, alias="oauthMetadata", description="OAuth metadata from autodiscovery"
-    )
-    tools: str | None = None
-    toolFunctions: dict[str, Any] | None = Field(
-        None, alias="toolFunctions", description="Complete OpenAI function schemas with mcpToolName"
-    )
-    resources: list[dict[str, Any]] | None = Field(None, description="List of available resources")
-    prompts: list[dict[str, Any]] | None = Field(None, description="List of available prompts")
-    initDuration: int | None = Field(None, alias="initDuration")
-    author: str | None = None
-    status: str
-    path: str
-    tags: list[str] = Field(default_factory=list)
-    numTools: int = Field(0, alias="numTools")
-    numStars: int = Field(0, alias="numStars")
-    enabled: bool = Field(default=True, description="Whether the server is enabled")
-    lastConnected: datetime | None = Field(None, alias="lastConnected")
-    lastError: datetime | None = Field(None, alias="lastError")
-    errorMessage: str | None = Field(None, alias="errorMessage")
-    createdAt: datetime
-    updatedAt: datetime
-
-    class ConfigDict:
-        from_attributes = True
-        populate_by_name = True
-
-    @model_serializer(mode="wrap")
-    def _serialize(self, serializer, info):
-        data = serializer(self)
-
-        # Handle mutually exclusive auth fields: oauth and apiKey
-        # Priority: oauth > apiKey
-        # If all are None/empty, remove all auth fields
-        has_oauth = data.get("oauth") is not None
-        has_api_key = data.get("apiKey") is not None
-
-        if has_oauth:
-            # Keep oauth, remove apiKey
-            data.pop("apiKey", None)
-        elif has_api_key:
-            # Keep apiKey, remove oauth
-            data.pop("oauth", None)
-        else:
-            # No auth required, remove all auth fields
-            data.pop("oauth", None)
-            data.pop("apiKey", None)
-
-        return data
-
-
-class ServerUpdateResponse(BaseModel):
-    """Response schema for server update"""
-
-    id: str
-    serverName: str = Field(..., alias="serverName")
-    title: str | None = None
-    path: str
-    description: str | None = None
-    headers: dict[str, Any] | None = Field(None, description="Custom headers (key/value pairs)")
-    requiresOAuth: bool = Field(False, alias="requiresOAuth")
-    tags: list[str] = Field(default_factory=list)
-    num_tools: int = 0
-    num_stars: int = 0
-    status: str
-    updatedAt: datetime
-
-    class ConfigDict:
-        from_attributes = True
-        populate_by_name = True
-
-
-class ServerToggleResponse(BaseModel):
-    """Response schema for server toggle"""
-
-    id: str
-    serverName: str = Field(..., alias="serverName")
-    path: str
-    enabled: bool
-    status: str
-    updatedAt: datetime
-
-    class ConfigDict:
-        from_attributes = True
-        populate_by_name = True
-
-
-class ServerToolsResponse(BaseModel):
-    """Response schema for server tools"""
-
-    id: str
-    serverName: str = Field(..., alias="serverName")
-    path: str
-    tools: list[dict[str, Any]]
-    num_tools: int
-    cached: bool = False
-
-    class ConfigDict:
-        from_attributes = True
-        populate_by_name = True
-
-
-class ServerHealthResponse(BaseModel):
-    """Response schema for server health refresh"""
-
-    id: str
-    serverName: str = Field(..., alias="serverName")
-    status: str
-    lastConnected: datetime | None = None
-    lastError: datetime | None = None
-    errorMessage: str | None = None
-    numTools: int
-    capabilities: str | None = None  # JSON string
-    tools: str | None = None  # Comma-separated tool names
-    initDuration: int | None = None  # Initialization duration in ms
-    message: str
-    updatedAt: datetime
-
-    class ConfigDict:
-        from_attributes = True
-        populate_by_name = True
-
-
-class ServerConnectionTestResponse(BaseModel):
+class ServerConnectionTestResponse(APIBaseModel):
     """Response schema for connection test"""
 
     success: bool = Field(..., description="Whether the connection test was successful")
     message: str = Field(..., description="Descriptive message about the connection result")
-    serverName: str | None = Field(None, description="MCP server name from serverInfo")
-    protocolVersion: str | None = Field(None, description="MCP protocol version")
-    responseTimeMs: int | None = Field(None, description="Response time in milliseconds")
+    server_name: str | None = Field(None, description="MCP server name from serverInfo")
+    protocol_version: str | None = Field(None, description="MCP protocol version")
+    response_time_ms: int | None = Field(None, description="Response time in milliseconds")
     capabilities: dict[str, Any] | None = Field(None, description="Server capabilities")
     error: str | None = Field(None, description="Error message if connection failed")
 
-    class ConfigDict:
-        from_attributes = True
-        populate_by_name = True
+    model_config = {"from_attributes": True}
 
 
-class PaginationMetadata(BaseModel):
+class PaginationMetadata(APIBaseModel):
     """Pagination metadata"""
 
     total: int
@@ -450,21 +297,21 @@ class PaginationMetadata(BaseModel):
     total_pages: int
 
 
-class ServerListResponse(BaseModel):
+class ServerListResponse(APIBaseModel):
     """Response schema for server list with pagination"""
 
     servers: list[ServerListItemResponse]
     pagination: PaginationMetadata
 
 
-class ErrorResponse(BaseModel):
+class ErrorResponse(APIBaseModel):
     """Error response schema"""
 
     error: str
     message: str
 
 
-class ServerStatsResponse(BaseModel):
+class ServerStatsResponse(APIBaseModel):
     """Response schema for server statistics (Admin only)"""
 
     total_servers: int = Field(..., description="Total number of servers")
@@ -477,8 +324,7 @@ class ServerStatsResponse(BaseModel):
     active_users: int = Field(..., description="Number of users with active tokens")
     total_tools: int = Field(..., description="Total number of tools across all servers")
 
-    class ConfigDict:
-        from_attributes = True
+    model_config = {"from_attributes": True}
 
 
 # ==================== Helper Functions ====================
@@ -494,25 +340,16 @@ def _get_config_field(server, field: str, default=None):
 def _mask_oauth_client_secret(oauth_config: dict[str, Any] | None) -> dict[str, Any] | None:
     """
     Mask OAuth client_secret to show only the last 6 characters.
-
-    Args:
-        oauth_config: OAuth configuration dictionary
-
-    Returns:
-        OAuth config with masked client_secret (only last 6 characters visible)
     """
     if not oauth_config or not isinstance(oauth_config, dict):
         return oauth_config
 
-    # Create a copy to avoid modifying the original
     masked_oauth = oauth_config.copy()
 
     if "client_secret" in masked_oauth and masked_oauth["client_secret"]:
         client_secret = str(masked_oauth["client_secret"])
-        # Only show last 6 characters
         if len(client_secret) > 6:
             masked_oauth["client_secret"] = "************" + client_secret[-6:]
-        # If secret is 6 chars or less, just show it as is (edge case)
 
     return masked_oauth
 
@@ -520,25 +357,16 @@ def _mask_oauth_client_secret(oauth_config: dict[str, Any] | None) -> dict[str, 
 def _mask_apikey(apikey_config: dict[str, Any] | None) -> dict[str, Any] | None:
     """
     Mask API Key to show only the last 6 characters.
-
-    Args:
-        apikey_config: API Key configuration dictionary
-
-    Returns:
-        API Key config with masked key (only last 6 characters visible)
     """
     if not apikey_config or not isinstance(apikey_config, dict):
         return apikey_config
 
-    # Create a copy to avoid modifying the original
     masked_apikey = apikey_config.copy()
 
     if "key" in masked_apikey and masked_apikey["key"]:
         key_value = str(masked_apikey["key"])
-        # Only show last 6 characters
         if len(key_value) > 6:
             masked_apikey["key"] = "************" + key_value[-6:]
-        # If key is 6 chars or less, just show it as is (edge case)
 
     return masked_apikey
 
@@ -547,66 +375,44 @@ def convert_to_list_item(
     server,
     acl_permission: ResourcePermissions | None = None,
 ) -> ServerListItemResponse:
-    """Convert ExtendedMCPServer to ServerListItemResponse matching API documentation.
-
-    Args:
-        server: The ExtendedMCPServer document.
-        acl_permission: Optional resolved permissions for the requesting user.
-    """
+    """Convert ExtendedMCPServer to ServerListItemResponse"""
     config = server.config or {}
-
-    # Decrypt sensitive authentication fields before returning
     config = decrypt_auth_fields(config)
 
-    # Mask OAuth client_secret to only show last 6 characters
     oauth_config = _mask_oauth_client_secret(config.get("oauth"))
-
-    # Mask API Key to only show last 6 characters
     apikey_config = _mask_apikey(config.get("apiKey"))
 
-    # Extract author_id from server.author PydanticObjectId
     author_id = str(server.author) if server.author else None
-
-    # Get transport type from config.type
     transport_type = config.get("type", "streamable-http")
-
-    # Generate title from config.title or serverName
     title = config.get("title") or server.serverName
-
-    # Get tools string from config (already comma-separated)
     tools_str = config.get("tools", "")
-
-    # Get capabilities from config (already JSON string)
     capabilities_str = config.get("capabilities", "{}")
-
-    # Get numTools from root level (already calculated)
     num_tools = server.numTools if hasattr(server, "numTools") else 0
 
     return ServerListItemResponse(
         id=str(server.id),
-        serverName=server.serverName,
+        server_name=server.serverName,
         title=title,
         description=config.get("description"),
         type=transport_type,
         url=config.get("url"),
-        apiKey=apikey_config,
+        api_key=apikey_config,
         oauth=oauth_config,
         headers=config.get("headers"),
-        requiresOAuth=config.get("requiresOAuth", False),
+        requires_oauth=config.get("requiresOAuth", False),
         capabilities=capabilities_str,
-        oauthMetadata=config.get("oauthMetadata"),
+        oauth_metadata=config.get("oauthMetadata"),
         tools=tools_str,
         author=author_id,
-        # Registry fields from root level
         status=server.status,
         path=server.path,
         tags=server.tags,
-        numTools=num_tools,
-        numStars=server.numStars,
-        enabled=config.get("enabled", True),  # Read enabled from config, default to True for backward compatibility
-        lastConnected=server.lastConnected,
-        createdAt=server.createdAt or datetime.now(),
-        updatedAt=server.updatedAt or datetime.now(),
+        num_tools=num_tools,
+        num_stars=server.numStars,
+        enabled=config.get("enabled", True),
+        last_connected=server.lastConnected,
+        created_at=server.createdAt or datetime.now(),
+        updated_at=server.updatedAt or datetime.now(),
         permissions=acl_permission,
     )
 
@@ -615,49 +421,23 @@ def convert_to_detail(
     server,
     acl_permission: ResourcePermissions | None = None,
 ) -> ServerDetailResponse:
-    """Convert ExtendedMCPServer to ServerDetailResponse matching API documentation.
-
-    Args:
-        server: The ExtendedMCPServer document.
-        acl_permission: Optional resolved permissions for the requesting user.
-    """
+    """Convert ExtendedMCPServer to ServerDetailResponse"""
     config = server.config or {}
-
-    # Decrypt sensitive authentication fields before returning
     config = decrypt_auth_fields(config)
 
-    # Mask OAuth client_secret to only show last 6 characters
     oauth_config = _mask_oauth_client_secret(config.get("oauth"))
-
-    # Mask API Key to only show last 6 characters
     apikey_config = _mask_apikey(config.get("apiKey"))
 
-    # Extract author_id from server.author PydanticObjectId
     author_id = str(server.author) if server.author else None
-
-    # Get transport type from config.type
     transport_type = config.get("type", "streamable-http")
-
-    # Generate title from config.title or serverName
     title = config.get("title") or server.serverName
-
-    # Get tools string from config (already comma-separated)
     tools_str = config.get("tools", "")
-
-    # Get toolFunctions directly from config (already in OpenAI format with mcpToolName)
     tool_functions = config.get("toolFunctions")
-
-    # Get resources and prompts from config
     resources = config.get("resources", [])
     prompts = config.get("prompts", [])
-
-    # Get capabilities from config (already JSON string)
     capabilities_str = config.get("capabilities", "{}")
-
-    # Get numTools from root level (already calculated)
     num_tools = server.numTools if hasattr(server, "numTools") else 0
 
-    # Format lastError as ISO string if present
     last_error_str = None
     if server.lastError:
         last_error_str = (
@@ -666,189 +446,33 @@ def convert_to_detail(
 
     return ServerDetailResponse(
         id=str(server.id),
-        serverName=server.serverName,
+        server_name=server.serverName,
         title=title,
         description=config.get("description"),
         type=transport_type,
         url=config.get("url"),
-        apiKey=apikey_config,
+        api_key=apikey_config,
         oauth=oauth_config,
         headers=config.get("headers"),
-        requiresOAuth=config.get("requiresOAuth", False),
+        requires_oauth=config.get("requiresOAuth", False),
         capabilities=capabilities_str,
-        oauthMetadata=config.get("oauthMetadata"),
+        oauth_metadata=config.get("oauthMetadata"),
         tools=tools_str,
-        toolFunctions=tool_functions,
+        tool_functions=tool_functions,
         resources=resources,
         prompts=prompts,
-        initDuration=config.get("initDuration"),
-        author=author_id,
-        # Registry fields from root level
-        status=server.status,
-        path=server.path,
-        tags=server.tags,
-        numTools=num_tools,
-        numStars=server.numStars,
-        enabled=config.get("enabled", True),  # Read enabled from config, default to True for backward compatibility
-        lastConnected=server.lastConnected,
-        lastError=last_error_str,
-        errorMessage=server.errorMessage if hasattr(server, "errorMessage") else None,
-        createdAt=server.createdAt or datetime.now(),
-        updatedAt=server.updatedAt or datetime.now(),
-        permissions=acl_permission,
-    )
-
-
-def convert_to_create_response(server) -> ServerCreateResponse:
-    """Convert ExtendedMCPServer to ServerCreateResponse - flattened structure"""
-    config = server.config or {}
-
-    # Decrypt sensitive authentication fields before returning
-    config = decrypt_auth_fields(config)
-
-    # Mask OAuth client_secret to only show last 6 characters
-    oauth_config = _mask_oauth_client_secret(config.get("oauth"))
-
-    # Mask API Key to only show last 6 characters
-    apikey_config = _mask_apikey(config.get("apiKey"))
-
-    # Extract author_id from server.author PydanticObjectId
-    author_id = str(server.author) if server.author else None
-
-    # Get numTools from root level
-    num_tools = server.numTools if hasattr(server, "numTools") else 0
-
-    # Format lastError as ISO string if present
-    last_error = None
-    if server.lastError:
-        last_error = server.lastError if isinstance(server.lastError, datetime) else None
-
-    return ServerCreateResponse(
-        serverName=server.serverName,
-        title=config.get("title", server.serverName),
-        description=config.get("description"),
-        type=config.get("type", "streamable-http"),
-        url=config.get("url"),
-        apiKey=apikey_config,
-        oauth=oauth_config,
-        headers=config.get("headers"),
-        requiresOAuth=config.get("requiresOAuth", False),
-        capabilities=config.get("capabilities", "{}"),
-        oauthMetadata=config.get("oauthMetadata"),
-        tools=config.get("tools", ""),
-        toolFunctions=config.get("toolFunctions", {}),
-        resources=config.get("resources", []),
-        prompts=config.get("prompts", []),
-        initDuration=config.get("initDuration"),
+        init_duration=config.get("initDuration"),
         author=author_id,
         status=server.status,
         path=server.path,
-        tags=server.tags,
-        numTools=num_tools,
-        numStars=server.numStars,
-        enabled=config.get("enabled", True),  # Read enabled from config, default to True for backward compatibility
-        lastConnected=server.lastConnected,
-        lastError=last_error,
-        errorMessage=server.errorMessage if hasattr(server, "errorMessage") else None,
-        createdAt=server.createdAt or datetime.now(),
-        updatedAt=server.updatedAt or datetime.now(),
-    )
-
-
-def convert_to_update_response(server) -> ServerUpdateResponse:
-    """Convert ExtendedMCPServer to ServerUpdateResponse matching API documentation"""
-    config = server.config or {}
-
-    # Get numTools from root level
-    num_tools = server.numTools if hasattr(server, "numTools") else 0
-
-    return ServerUpdateResponse(
-        id=str(server.id),
-        serverName=server.serverName,
-        title=config.get("title"),
-        path=server.path,
-        description=config.get("description"),
-        headers=config.get("headers"),
-        requiresOAuth=config.get("requiresOAuth"),
         tags=server.tags,
         num_tools=num_tools,
         num_stars=server.numStars,
-        status=server.status,
-        updatedAt=server.updatedAt or datetime.now(),
-    )
-
-
-def convert_to_toggle_response(server, enabled: bool) -> ServerToggleResponse:
-    """Convert ExtendedMCPServer to ServerToggleResponse matching API documentation"""
-    return ServerToggleResponse(
-        id=str(server.id),
-        serverName=server.serverName,
-        path=server.path,
-        enabled=enabled,
-        status=server.status,
-        updatedAt=server.updatedAt or datetime.now(),
-    )
-
-
-def convert_to_tools_response(server, tool_functions: dict[str, Any]) -> ServerToolsResponse:
-    """Convert ExtendedMCPServer to ServerToolsResponse matching API documentation"""
-    # Convert toolFunctions dict to list format for response
-    tools_list = []
-    if tool_functions:
-        for _func_key, func_def in tool_functions.items():
-            if isinstance(func_def, dict) and "function" in func_def:
-                func = func_def["function"]
-                tools_list.append(
-                    {
-                        "name": func.get("name", ""),
-                        "description": func.get("description", ""),
-                        "inputSchema": func.get("parameters", {}),
-                    }
-                )
-
-    return ServerToolsResponse(
-        id=str(server.id),
-        serverName=server.serverName,
-        path=server.path,
-        tools=tools_list,
-        num_tools=len(tools_list),
-        cached=False,
-    )
-
-
-def convert_to_health_response(server, health_data: dict[str, Any]) -> ServerHealthResponse:
-    """Convert ExtendedMCPServer to ServerHealthResponse matching API documentation"""
-    # Get config fields
-    config = server.config or {}
-
-    # Get numTools from root level
-    num_tools = server.numTools if hasattr(server, "numTools") else 0
-
-    # Get capabilities and tools from config
-    capabilities = config.get("capabilities", "{}")
-    tools = config.get("tools", "")
-
-    # Get initDuration from config
-    init_duration = config.get("initDuration")
-
-    # Build message based on status
-    status = health_data.get("status", "healthy")
-    if status == "healthy":
-        message = "Server health check successful"
-    else:
-        message = health_data.get("status_message", "Server health check failed")
-
-    return ServerHealthResponse(
-        id=str(server.id),
-        serverName=server.serverName,
-        status=server.status,  # Use server.status (active/error) from database
-        lastConnected=server.lastConnected,
-        lastError=server.lastError,
-        errorMessage=server.errorMessage,
-        numTools=num_tools,
-        capabilities=capabilities,
-        tools=tools,
-        initDuration=init_duration,
-        message=message,
-        updatedAt=server.updatedAt,
+        enabled=config.get("enabled", True),
+        last_connected=server.lastConnected,
+        last_error=last_error_str,
+        error_message=server.errorMessage if hasattr(server, "errorMessage") else None,
+        created_at=server.createdAt or datetime.now(),
+        updated_at=server.updatedAt or datetime.now(),
+        permissions=acl_permission,
     )

--- a/registry/src/registry/services/server_service.py
+++ b/registry/src/registry/services/server_service.py
@@ -352,21 +352,21 @@ def _build_config_from_request(data: ServerCreateRequest, server_name: str = Non
         "capabilities": "{}",  # Default empty JSON string
     }
 
-    # Add optional MCP config fields
+    # Add optional MCP config fields (convert to camelCase for MongoDB storage)
     if data.timeout is not None:
         config["timeout"] = data.timeout
     if data.init_timeout is not None:
-        config[inflection.camelize("init_timeout", uppercase_first_letter=False)] = data.init_timeout
+        config["initTimeout"] = data.init_timeout
     if data.server_instructions is not None:
-        config["server_instructions"] = data.server_instructions
+        config["serverInstructions"] = data.server_instructions
     if data.oauth is not None:
         config["oauth"] = data.oauth
     if data.custom_user_vars is not None:
-        config["custom_user_vars"] = data.custom_user_vars
+        config["customUserVars"] = data.custom_user_vars
     if data.headers is not None:
         config["headers"] = data.headers
     if data.requires_oauth is not None:
-        config[inflection.camelize("requires_oauth", uppercase_first_letter=False)] = data.requires_oauth
+        config["requiresOAuth"] = data.requires_oauth
 
     # Convert tool_list to toolFunctions in OpenAI format
     if data.tool_list is not None:
@@ -388,9 +388,9 @@ def _build_config_from_request(data: ServerCreateRequest, server_name: str = Non
     if data.oauth is not None:
         # oauth is already added above, just ensure apiKey is not added
         pass
-    elif data.apiKey is not None:
+    elif data.api_key is not None:
         # When only apiKey is provided, store it
-        config["apiKey"] = data.apiKey
+        config["apiKey"] = data.api_key
 
     # Always set enabled to False during registration (regardless of frontend input)
     config["enabled"] = False
@@ -415,19 +415,20 @@ def _update_config_from_request(
 
     # Remove root-level registry fields from update_dict (these are handled at root level)
     # Note: enabled is removed here but will be added to config separately
+    # Note: model_dump() returns snake_case keys, so we use snake_case field names here
     registry_fields = [
         "path",
         "tags",
         "status",
-        "serverName",
+        "server_name",  # snake_case from model_dump
         "num_stars",
         "enabled",
     ]
     for field in registry_fields:
         update_dict.pop(field, None)
 
-    # Handle mutually exclusive authentication fields: oauth and apiKey
-    if "oauth" in update_dict or "apiKey" in update_dict:
+    # Handle mutually exclusive authentication fields: oauth and api_key (snake_case from model_dump)
+    if "oauth" in update_dict or "api_key" in update_dict:
         existing_oauth = config.pop("oauth", {})
         existing_apikey = config.pop("apiKey", {})
         if "oauth" in update_dict:
@@ -444,8 +445,8 @@ def _update_config_from_request(
                 else:
                     config["oauth"] = oauth_update
 
-        if "apiKey" in update_dict:
-            apikey_update = update_dict.pop("apiKey")
+        if "api_key" in update_dict:
+            apikey_update = update_dict.pop("api_key")
 
             # Only save if not None and not empty
             if apikey_update:
@@ -462,7 +463,7 @@ def _update_config_from_request(
         else:
             config.pop("headers", None)
 
-    # Update config with MCP-specific fields only
+    # Update config with MCP-specific fields only (convert snake_case to camelCase)
     mcp_config_fields = [
         "title",
         "url",
@@ -474,11 +475,11 @@ def _update_config_from_request(
         "requires_oauth",
         "oauth",
         "custom_user_vars",
-        "tool_list",
+        # Note: tool_list is handled separately below, not directly stored in config
     ]
     for key, value in update_dict.items():
         if key in mcp_config_fields and value is not None:
-            # Convert snake_case to camelCase for config keys using inflection
+            # Convert snake_case to camelCase for config keys
             config_key = inflection.camelize(key, uppercase_first_letter=False) if "_" in key else key
             config[config_key] = value
 
@@ -859,7 +860,7 @@ class ServerServiceV1:
         updated_config = _update_config_from_request(config, data, server_name=server.serverName)
 
         # Encrypt sensitive authentication fields if they were updated
-        if data.oauth is not None or data.apiKey is not None:
+        if data.oauth is not None or data.api_key is not None:
             updated_config = encrypt_auth_fields(updated_config)
 
         if data.requires_oauth:

--- a/registry/src/registry/utils/schema_converter.py
+++ b/registry/src/registry/utils/schema_converter.py
@@ -1,0 +1,96 @@
+"""
+Schema field naming conversion utilities
+
+Handles conversion between snake_case (API) and camelCase (MongoDB)
+"""
+
+import re
+from typing import Any
+
+
+def to_camel_case(snake_str: str) -> str:
+    """
+    Convert snake_case to camelCase
+
+    Examples:
+        server_name -> serverName
+        num_tools -> numTools
+        created_at -> createdAt
+    """
+    components = snake_str.split("_")
+    return components[0] + "".join(x.title() for x in components[1:])
+
+
+def to_snake_case(camel_str: str) -> str:
+    """
+    Convert camelCase to snake_case
+
+    Examples:
+        serverName -> server_name
+        numTools -> num_tools
+        createdAt -> created_at
+    """
+    snake_str = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", camel_str)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", snake_str).lower()
+
+
+def convert_dict_keys_to_camel(data: dict[str, Any] | Any) -> dict[str, Any] | Any:
+    """
+    Recursively convert dictionary keys from snake_case to camelCase
+
+    Used when: API input (snake_case) -> MongoDB storage (camelCase)
+
+    Args:
+        data: Dictionary with snake_case keys or any other type
+
+    Returns:
+        Dictionary with camelCase keys, or original data if not a dict
+    """
+    if not isinstance(data, dict):
+        return data
+
+    converted = {}
+    for key, value in data.items():
+        camel_key = to_camel_case(key)
+
+        if isinstance(value, dict):
+            converted[camel_key] = convert_dict_keys_to_camel(value)
+        elif isinstance(value, list):
+            converted[camel_key] = [
+                convert_dict_keys_to_camel(item) if isinstance(item, dict) else item for item in value
+            ]
+        else:
+            converted[camel_key] = value
+
+    return converted
+
+
+def convert_dict_keys_to_snake(data: dict[str, Any] | Any) -> dict[str, Any] | Any:
+    """
+    Recursively convert dictionary keys from camelCase to snake_case
+
+    Used when: MongoDB data (camelCase) -> API response (snake_case)
+
+    Args:
+        data: Dictionary with camelCase keys or any other type
+
+    Returns:
+        Dictionary with snake_case keys, or original data if not a dict
+    """
+    if not isinstance(data, dict):
+        return data
+
+    converted = {}
+    for key, value in data.items():
+        snake_key = to_snake_case(key)
+
+        if isinstance(value, dict):
+            converted[snake_key] = convert_dict_keys_to_snake(value)
+        elif isinstance(value, list):
+            converted[snake_key] = [
+                convert_dict_keys_to_snake(item) if isinstance(item, dict) else item for item in value
+            ]
+        else:
+            converted[snake_key] = value
+
+    return converted

--- a/registry/src/registry/utils/schema_converter.py
+++ b/registry/src/registry/utils/schema_converter.py
@@ -4,34 +4,33 @@ Schema field naming conversion utilities
 Handles conversion between snake_case (API) and camelCase (MongoDB)
 """
 
-import re
 from typing import Any
+
+import inflection
 
 
 def to_camel_case(snake_str: str) -> str:
     """
-    Convert snake_case to camelCase
+    Convert snake_case to camelCase using inflection library
 
     Examples:
         server_name -> serverName
         num_tools -> numTools
         created_at -> createdAt
     """
-    components = snake_str.split("_")
-    return components[0] + "".join(x.title() for x in components[1:])
+    return inflection.camelize(snake_str, uppercase_first_letter=False)
 
 
 def to_snake_case(camel_str: str) -> str:
     """
-    Convert camelCase to snake_case
+    Convert camelCase to snake_case using inflection library
 
     Examples:
         serverName -> server_name
         numTools -> num_tools
         createdAt -> created_at
     """
-    snake_str = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", camel_str)
-    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", snake_str).lower()
+    return inflection.underscore(camel_str)
 
 
 def convert_dict_keys_to_camel(data: dict[str, Any] | Any) -> dict[str, Any] | Any:

--- a/registry/tests/unit/api/v1/test_server_routes.py
+++ b/registry/tests/unit/api/v1/test_server_routes.py
@@ -66,7 +66,7 @@ async def test_create_server_route_creates_acl_entry(
         ) as mock_grant_permission,
         patch("registry_pkgs.database.decorators.MongoDB.get_client") as mock_get_client,
         patch(
-            "registry.api.v1.server.server_routes.convert_to_create_response",
+            "registry.api.v1.server.server_routes.convert_to_detail",
             return_value={"id": str(mock_created_server.id)},
         ),
     ):

--- a/scripts/seed_mongodb.py
+++ b/scripts/seed_mongodb.py
@@ -31,6 +31,72 @@ from registry_pkgs.models._generated.user import IUser
 from registry_pkgs.models.extended_acl_entry import IAclEntry
 from registry_pkgs.models.extended_mcp_server import MCPServerDocument
 
+# Try to import IGroup if it exists, otherwise we'll skip group seeding
+try:
+    from registry_pkgs.models._generated import IGroup
+
+    HAS_GROUP_MODEL = True
+except ImportError:
+    IGroup = None
+    HAS_GROUP_MODEL = False
+    print("Warning: IGroup model not found. Skipping group seeding.")
+
+
+async def seed_groups():
+    """Seed sample groups based on scopes.yml group_mappings."""
+    if not HAS_GROUP_MODEL:
+        print("Skipping groups seeding (IGroup model not available)")
+        return []
+
+    print("Seeding groups...")
+
+    # Groups from scopes.yml group_mappings
+    groups_data = [
+        {
+            "name": "jarvis-registry-admin",
+            "description": "Full access to all registry resources",
+            "email": "registry-admin@example.com",
+            "createdAt": datetime.now(UTC),
+            "updatedAt": datetime.now(UTC),
+        },
+        {
+            "name": "jarvis-registry-power-user",
+            "description": "Create/delete/share servers and agents",
+            "email": "registry-power-user@example.com",
+            "createdAt": datetime.now(UTC),
+            "updatedAt": datetime.now(UTC),
+        },
+        {
+            "name": "jarvis-registry-user",
+            "description": "Create servers and agents, cannot share",
+            "email": "registry-user@example.com",
+            "createdAt": datetime.now(UTC),
+            "updatedAt": datetime.now(UTC),
+        },
+        {
+            "name": "jarvis-registry-read-only",
+            "description": "Read-only access to servers and agents",
+            "email": "registry-read-only@example.com",
+            "createdAt": datetime.now(UTC),
+            "updatedAt": datetime.now(UTC),
+        },
+    ]
+
+    created_groups = []
+    for group_data in groups_data:
+        # Check if group already exists
+        existing_group = await IGroup.find_one(IGroup.name == group_data["name"])
+        if existing_group:
+            print(f"  Group {group_data['name']} already exists, skipping...")
+            created_groups.append(existing_group)
+        else:
+            group = IGroup(**group_data)
+            await group.insert()
+            created_groups.append(group)
+            print(f"  Created group: {group_data['name']}")
+
+    return created_groups
+
 
 async def seed_users():
     """Seed sample users."""
@@ -680,8 +746,12 @@ async def clean_database():
         server_count = await MCPServerDocument.delete_all()
         print(f"  Deleted {server_count.deleted_count} MCP servers")
 
-        server_count = await IAclEntry.delete_all()
-        print(f"  Deleted {server_count.deleted_count} ACL Entries")
+        acl_count = await IAclEntry.delete_all()
+        print(f"  Deleted {acl_count.deleted_count} ACL Entries")
+
+        if HAS_GROUP_MODEL:
+            group_count = await IGroup.delete_all()
+            print(f"  Deleted {group_count.deleted_count} groups")
 
         print("\n" + "=" * 60)
         print("✅ Database cleaned successfully!")
@@ -734,6 +804,9 @@ async def main():
             await clean_database()
         else:
             # Seed data in order
+            groups = await seed_groups()
+            print()
+
             users = await seed_users()
             print()
 
@@ -753,6 +826,7 @@ async def main():
             print("✅ Database seeding completed successfully!")
             print("=" * 60)
             print("Created/Found:")
+            print(f"  - {len(groups)} groups" if groups else "  - 0 groups (model not available)")
             print(f"  - {len(users)} users")
             print(f"  - {len(keys)} API keys")
             print(f"  - {len(tokens)} tokens")


### PR DESCRIPTION
1. Use snake_case for all API field names
   - Fix service/route layer field access
   - Ensure consistency with APIBaseModel convention

2. Consolidate response schemas into two types
   - ServerListItemResponse (for list operations)
   - ServerDetailResponse (for single object operations)

Resolves field naming conflicts and unifies API response structure.