### PR TITLE
add oauth and oauthMetadata storage case exception

### DIFF
--- a/registry/src/registry/schemas/server_api_schemas.py
+++ b/registry/src/registry/schemas/server_api_schemas.py
@@ -15,6 +15,7 @@ from pydantic import ConfigDict, Field, field_validator, model_serializer
 from registry.schemas.acl_schema import ResourcePermissions
 from registry.schemas.case_conversion import APIBaseModel
 from registry.utils.crypto_utils import decrypt_auth_fields
+from registry.utils.schema_converter import convert_dict_keys_to_camel
 
 # ==================== Request Schemas ====================
 
@@ -388,7 +389,8 @@ def convert_to_list_item(
     config = server.config or {}
     config = decrypt_auth_fields(config)
 
-    oauth_config = _mask_oauth_client_secret(config.get("oauth"))
+    # Mask first (reads snake_case keys), then convert to camelCase for API response
+    oauth_config = convert_dict_keys_to_camel(_mask_oauth_client_secret(config.get("oauth")))
     apikey_config = _mask_apikey(config.get("apiKey"))
 
     author_id = str(server.author) if server.author else None
@@ -410,7 +412,7 @@ def convert_to_list_item(
         headers=config.get("headers"),
         requiresOauth=config.get("requiresOAuth", False),
         capabilities=capabilities_str,
-        oauthMetadata=config.get("oauthMetadata"),
+        oauthMetadata=convert_dict_keys_to_camel(config.get("oauthMetadata")),
         tools=tools_str,
         author=author_id,
         status=server.status,
@@ -434,7 +436,8 @@ def convert_to_detail(
     config = server.config or {}
     config = decrypt_auth_fields(config)
 
-    oauth_config = _mask_oauth_client_secret(config.get("oauth"))
+    # Mask first (reads snake_case keys), then convert to camelCase for API response
+    oauth_config = convert_dict_keys_to_camel(_mask_oauth_client_secret(config.get("oauth")))
     apikey_config = _mask_apikey(config.get("apiKey"))
 
     author_id = str(server.author) if server.author else None
@@ -465,7 +468,7 @@ def convert_to_detail(
         headers=config.get("headers"),
         requiresOauth=config.get("requiresOAuth", False),
         capabilities=capabilities_str,
-        oauthMetadata=config.get("oauthMetadata"),
+        oauthMetadata=convert_dict_keys_to_camel(config.get("oauthMetadata")),
         tools=tools_str,
         toolFunctions=tool_functions,
         resources=resources,

--- a/registry/src/registry/services/server_service.py
+++ b/registry/src/registry/services/server_service.py
@@ -37,6 +37,7 @@ from ..schemas.server_api_schemas import (
     ServerUpdateRequest,
 )
 from ..utils.crypto_utils import encrypt_auth_fields, generate_service_jwt
+from ..utils.schema_converter import convert_dict_keys_to_snake
 from ..utils.utils import generate_server_name_from_title, normalize_headers
 from .user_service import user_service
 
@@ -397,8 +398,8 @@ def _build_config_from_request(data: ServerCreateRequest, server_name: str = Non
     # Handle mutually exclusive authentication fields: oauth and apiKey
     # Only store one of them, with oauth taking priority
     if data.oauth is not None:
-        # oauth is already added above, just ensure apiKey is not added
-        pass
+        # Normalize oauth sub-field keys to snake_case for DB storage
+        config["oauth"] = convert_dict_keys_to_snake(config["oauth"])
     elif data.apiKey is not None:
         # When only apiKey is provided, store it
         config["apiKey"] = data.apiKey
@@ -449,6 +450,8 @@ def _update_config_from_request(
                 pass
             # Otherwise, merge/update oauth config
             elif oauth_update:
+                # Normalize incoming camelCase keys to snake_case before merging/storing
+                oauth_update = convert_dict_keys_to_snake(oauth_update)
                 # Merge new oauth with existing oauth (upsert operation)
                 if isinstance(existing_oauth, dict) and isinstance(oauth_update, dict):
                     existing_oauth.update(oauth_update)

--- a/registry/tests/unit/servers/test_server_service.py
+++ b/registry/tests/unit/servers/test_server_service.py
@@ -424,8 +424,8 @@ class TestBuildCompleteHeaders:
         server.config = {
             "requiresOAuth": True,
             "oauth": {
-                "authorizationUrl": "https://oauth.example.com/authorize",
-                "tokenUrl": "https://oauth.example.com/token",
+                "authorization_url": "https://oauth.example.com/authorize",
+                "token_url": "https://oauth.example.com/token",
             },
         }
         return server


### PR DESCRIPTION
1. oauth and oauthMetadata has to be snake_case in the mongodb storage. because all oauth RFC using snake case.
2. add the case conversion for frontend so that frontend is unified with camel case
3. added unit test for it