### PR TITLE
as-1500: (fix) - remove original_mcp_name from Weaviate tool metadata

### DIFF
--- a/registry-pkgs/src/registry_pkgs/models/extended_mcp_server.py
+++ b/registry-pkgs/src/registry_pkgs/models/extended_mcp_server.py
@@ -167,7 +167,7 @@ class ExtendedMCPServer(Document):
         ]
 
     # ========== Vector Search Integration (Weaviate) ==========
-    COLLECTION_NAME: ClassVar[str] = "Jarvis_Registry"
+    COLLECTION_NAME: ClassVar[str] = "MCP_Servers"
 
     def to_documents(self) -> list[LangChainDocument]:
         """
@@ -222,10 +222,11 @@ class ExtendedMCPServer(Document):
 
     def _create_tool_docs(self, tool_name: str, tool_data: dict) -> list[LangChainDocument]:
         """Create Tool document(s) with text splitting if needed."""
-        content = self.generate_tool_content(tool_name, tool_data)
+        downstream_tool_name = tool_data.get("mcpToolName", tool_name)
+        content = self.generate_tool_content(downstream_tool_name, tool_data)
 
         metadata = self._get_base_metadata(ServerEntityType.TOOL)
-        metadata.update({"tool_name": tool_name, "original_mcp_name": tool_data.get("mcpToolName", tool_name)})
+        metadata.update({"tool_name": downstream_tool_name})
 
         return self._split_if_needed(content, metadata)
 
@@ -459,7 +460,6 @@ class ExtendedMCPServer(Document):
         entity_type = metadata.get("entity_type")
         if entity_type == ServerEntityType.TOOL:
             result["tool_name"] = metadata.get("tool_name")
-            result["original_mcp_name"] = metadata.get("original_mcp_name")
         elif entity_type == ServerEntityType.RESOURCE:
             result["resource_name"] = metadata.get("resource_name")
             result["resource_uri"] = metadata.get("resource_uri")

--- a/registry-pkgs/tests/unit/test_models.py
+++ b/registry-pkgs/tests/unit/test_models.py
@@ -265,6 +265,44 @@ class TestExtendedMCPServerStructure:
         assert docs
         assert docs[0].metadata.get("runtime_version") == "7"
 
+    def test_tool_documents_use_downstream_mcp_tool_name_only(self):
+        server = ExtendedMCPServer.model_construct(
+            id=PydanticObjectId(),
+            serverName="tool-server",
+            config={
+                "title": "Tool Server",
+                "description": "desc",
+                "type": "streamable-http",
+                "url": "https://example.com/mcp",
+                "toolFunctions": {
+                    "scoped_tool_mcp_tool_server": {
+                        "type": "function",
+                        "mcpToolName": "downstream_tool",
+                        "function": {
+                            "name": "scoped_tool_mcp_tool_server",
+                            "description": "desc",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                },
+                "resources": [],
+                "prompts": [],
+            },
+            author=PydanticObjectId(),
+            path="/mcp/tool-server",
+            status="active",
+        )
+
+        docs = server.to_documents()
+        tool_doc = next(doc for doc in docs if doc.metadata.get("entity_type") == "tool")
+
+        assert tool_doc.metadata["tool_name"] == "downstream_tool"
+        assert "original_mcp_name" not in tool_doc.metadata
+
+        result = ExtendedMCPServer.from_document(tool_doc)
+        assert result["tool_name"] == "downstream_tool"
+        assert "original_mcp_name" not in result
+
     def test_a2a_to_documents_includes_runtime_version_metadata(self):
         agent = A2AAgent.model_construct(
             id=PydanticObjectId(),

--- a/registry/src/registry/api/v1/search_routes.py
+++ b/registry/src/registry/api/v1/search_routes.py
@@ -281,14 +281,24 @@ async def search_servers(search: SearchRequest, user_context: CurrentUser):
         # if it includes the server, add tool,resource and prompt.
         # search only server and get server detail from mongo
         if len(search.type_list) == 1 and search.type_list[0] == ServerEntityType.SERVER:
-            filters = {"enabled": not search.include_disabled}
+            filters = {
+                "enabled": not search.include_disabled,
+                "entity_type": [ServerEntityType.SERVER.value],
+            }
             results = await mcp_server_repo.asearch_with_rerank(
                 query=query, search_type=search.search_type, filters=filters, k=top_n
             )
-            server_ids = [str(result.get("server_id")) for result in results]
+            seen_server_ids: set[str] = set()
+            server_ids: list[str] = []
+            for result in results:
+                server_id = str(result.get("server_id"))
+                if not server_id or server_id in seen_server_ids:
+                    continue
+                seen_server_ids.add(server_id)
+                server_ids.append(server_id)
             async with asyncio.TaskGroup() as tg:
                 tasks = [tg.create_task(server_service_v1.get_server_by_id(sid)) for sid in server_ids]
-            search_results = [t.result() for t in tasks]
+            search_results = [server for t in tasks if (server := t.result()) is not None]
             logger.info(f"Found {len(search_results)} servers with full details")
         else:
             filters = {"enabled": not search.include_disabled, "entity_type": [dt.value for dt in search.type_list]}
@@ -308,7 +318,8 @@ async def search_servers(search: SearchRequest, user_context: CurrentUser):
 
         success = True
         results_count = len(search_results)
-        return {"query": query, "total": len(search_results), "servers": search_results}
+
+        return {"query": query, "type_list": search.type_list, "total": len(search_results), "servers": search_results}
     finally:
         # Record tool discovery metrics per discovered server
         duration = time.perf_counter() - start_time

--- a/registry/src/registry/api/v1/search_routes.py
+++ b/registry/src/registry/api/v1/search_routes.py
@@ -256,7 +256,7 @@ def _build_search_filters(search: SearchRequest) -> dict[str, object]:
     """Build shared vector-store filters from the request."""
     return {
         "enabled": not search.include_disabled,
-        "entity_type": [entity_type.value for entity_type in search.type_list],
+        "entity_type": list(search.type_list),
     }
 
 

--- a/registry/src/registry/api/v1/search_routes.py
+++ b/registry/src/registry/api/v1/search_routes.py
@@ -238,13 +238,123 @@ class ToolDiscoveryResponse(BaseModel):
 
 
 class SearchRequest(BaseModel):
-    query: str = Field(..., min_length=1, max_length=512, description="Natural language query")
+    query: str = Field(default="", min_length=0, max_length=512, description="Natural language query")
     top_n: int = Field(1, description="Number of results to return")
     search_type: SearchType = Field(default=SearchType.HYBRID, description="Type of search to perform")
     type_list: list[ServerEntityType] | None = Field(
         default_factory=lambda: list(ServerEntityType), description="Type of document to return (default: all types)"
     )
     include_disabled: bool = Field(default=False, description="Include disabled results")
+
+
+def _is_server_only_search(type_list: list[ServerEntityType] | None) -> bool:
+    """Return True only for the dedicated full-server discovery path."""
+    return bool(type_list) and len(type_list) == 1 and type_list[0] == ServerEntityType.SERVER
+
+
+def _build_search_filters(search: SearchRequest) -> dict[str, object]:
+    """Build shared vector-store filters from the request."""
+    return {
+        "enabled": not search.include_disabled,
+        "entity_type": [entity_type.value for entity_type in search.type_list],
+    }
+
+
+def _serialize_search_results(results: list) -> list:
+    """Normalize model instances into JSON-compatible dicts for API/tool output."""
+    return [result.model_dump(mode="json") if hasattr(result, "model_dump") else result for result in results]
+
+
+async def _fetch_servers_by_ids(server_ids: list[str]) -> list:
+    """Load full server documents from Mongo for the matched server ids."""
+    async with asyncio.TaskGroup() as tg:
+        tasks = [tg.create_task(server_service_v1.get_server_by_id(server_id)) for server_id in server_ids]
+    return [server for task in tasks if (server := task.result()) is not None]
+
+
+def _extract_unique_server_ids(results: list[dict[str, object]]) -> list[str]:
+    """Preserve result order while removing duplicate/empty server ids."""
+    seen_server_ids: set[str] = set()
+    server_ids: list[str] = []
+    for result in results:
+        server_id = str(result.get("server_id"))
+        if not server_id or server_id in seen_server_ids:
+            continue
+        seen_server_ids.add(server_id)
+        server_ids.append(server_id)
+    return server_ids
+
+
+async def _search_server_documents(search: SearchRequest, query: str) -> list:
+    """Run the full-server discovery path using Mongo fallback for empty queries."""
+    if not query:
+        status = None if search.include_disabled else "active"
+        raw_servers, _ = await server_service_v1.list_servers(
+            query=None,
+            status=status,
+            page=1,
+            per_page=search.top_n,
+        )
+        return raw_servers
+
+    filters = _build_search_filters(search)
+    results = await mcp_server_repo.asearch_with_rerank(
+        query=query,
+        search_type=search.search_type,
+        filters=filters,
+        k=search.top_n,
+    )
+    server_ids = _extract_unique_server_ids(results)
+    return await _fetch_servers_by_ids(server_ids)
+
+
+async def _search_non_server_documents(search: SearchRequest, query: str) -> list:
+    """Run tool/resource/prompt discovery, using metadata filtering for empty queries."""
+    filters = _build_search_filters(search)
+    if not query:
+        return await mcp_server_repo.afilter(filters=filters, limit=search.top_n)
+
+    return await mcp_server_repo.asearch_with_rerank(
+        query=query,
+        k=search.top_n,
+        candidate_k=min(search.top_n * 5, 100),
+        search_type=search.search_type,
+        filters=filters,
+    )
+
+
+def _record_discovery_metrics(
+    search_results: list,
+    success: bool,
+    duration: float,
+    search_type: SearchType,
+    results_count: int,
+) -> None:
+    """Record discovery metrics once per discovered server name."""
+    discovered_names: set[str] = set()
+    for result in search_results:
+        name = getattr(result, "serverName", None) or (result.get("server_name") if isinstance(result, dict) else None)
+        if name:
+            discovered_names.add(name)
+
+    if discovered_names:
+        for name in discovered_names:
+            record_tool_discovery(
+                server_name=name,
+                success=success,
+                duration_seconds=duration,
+                transport_type=str(search_type.value),
+                tools_count=results_count,
+            )
+        return
+
+    record_tool_discovery(
+        server_name="registry",
+        success=success,
+        duration_seconds=duration,
+        transport_type=str(search_type.value),
+        tools_count=results_count,
+    )
 
 
 @router.post("/search/servers")
@@ -265,7 +375,7 @@ async def search_servers(search: SearchRequest, user_context: CurrentUser):
 
     Returns raw JSON that can be converted to ExtendedMCPServer format.
     """
-    query = search.query
+    query = search.query.strip()
     top_n = search.top_n
     start_time = time.perf_counter()
     success = False
@@ -278,45 +388,12 @@ async def search_servers(search: SearchRequest, user_context: CurrentUser):
     )
 
     try:
-        # if it includes the server, add tool,resource and prompt.
-        # search only server and get server detail from mongo
-        if len(search.type_list) == 1 and search.type_list[0] == ServerEntityType.SERVER:
-            filters = {
-                "enabled": not search.include_disabled,
-                "entity_type": [ServerEntityType.SERVER.value],
-            }
-            results = await mcp_server_repo.asearch_with_rerank(
-                query=query, search_type=search.search_type, filters=filters, k=top_n
-            )
-            seen_server_ids: set[str] = set()
-            server_ids: list[str] = []
-            for result in results:
-                server_id = str(result.get("server_id"))
-                if not server_id or server_id in seen_server_ids:
-                    continue
-                seen_server_ids.add(server_id)
-                server_ids.append(server_id)
-            async with asyncio.TaskGroup() as tg:
-                tasks = [tg.create_task(server_service_v1.get_server_by_id(sid)) for sid in server_ids]
-            raw_servers = [server for t in tasks if (server := t.result()) is not None]
-            search_results = [
-                server.model_dump(mode="json") if hasattr(server, "model_dump") else server for server in raw_servers
-            ]
+        if _is_server_only_search(search.type_list):
+            raw_servers = await _search_server_documents(search, query)
+            search_results = _serialize_search_results(raw_servers)
             logger.info(f"Found {len(search_results)} servers with full details")
         else:
-            filters = {"enabled": not search.include_disabled, "entity_type": [dt.value for dt in search.type_list]}
-            search_results = await mcp_server_repo.asearch_with_rerank(
-                query=query,
-                k=top_n,
-                candidate_k=min(top_n * 5, 100),  # Fetch 5x candidates for reranking (max 100)
-                search_type=search.search_type,
-                filters=filters,
-            )
-            logger.info(
-                "Search completed: %d results for query=%r",
-                len(search_results),
-                query,
-            )
+            search_results = await _search_non_server_documents(search, query)
             logger.info(f"✅ Found {len(search_results)} servers")
 
         success = True
@@ -327,30 +404,6 @@ async def search_servers(search: SearchRequest, user_context: CurrentUser):
         # Record tool discovery metrics per discovered server
         duration = time.perf_counter() - start_time
         try:
-            discovered_names: set[str] = set()
-            for result in search_results:
-                name = getattr(result, "serverName", None) or (
-                    result.get("server_name") if isinstance(result, dict) else None
-                )
-                if name:
-                    discovered_names.add(name)
-
-            if discovered_names:
-                for name in discovered_names:
-                    record_tool_discovery(
-                        server_name=name,
-                        success=success,
-                        duration_seconds=duration,
-                        transport_type=str(search.search_type.value),
-                        tools_count=results_count,
-                    )
-            else:
-                record_tool_discovery(
-                    server_name="registry",
-                    success=success,
-                    duration_seconds=duration,
-                    transport_type=str(search.search_type.value),
-                    tools_count=results_count,
-                )
+            _record_discovery_metrics(search_results, success, duration, search.search_type, results_count)
         except Exception as e:
             logger.warning(f"Failed to record tool discovery metric: {e}")

--- a/registry/src/registry/api/v1/search_routes.py
+++ b/registry/src/registry/api/v1/search_routes.py
@@ -298,7 +298,10 @@ async def search_servers(search: SearchRequest, user_context: CurrentUser):
                 server_ids.append(server_id)
             async with asyncio.TaskGroup() as tg:
                 tasks = [tg.create_task(server_service_v1.get_server_by_id(sid)) for sid in server_ids]
-            search_results = [server for t in tasks if (server := t.result()) is not None]
+            raw_servers = [server for t in tasks if (server := t.result()) is not None]
+            search_results = [
+                server.model_dump(mode="json") if hasattr(server, "model_dump") else server for server in raw_servers
+            ]
             logger.info(f"Found {len(search_results)} servers with full details")
         else:
             filters = {"enabled": not search.include_disabled, "entity_type": [dt.value for dt in search.type_list]}

--- a/registry/src/registry/mcpgw/server.py
+++ b/registry/src/registry/mcpgw/server.py
@@ -10,82 +10,60 @@ from .core.event_store import InMemoryEventStore
 from .core.types import McpAppContext
 from .tools import proxied, search
 
-_SYSTEM_INSTRUCTIONS = """This MCP Gateway provides unified access to 100+ MCP servers, tools, resources, and prompts through a centralized discovery and execution interface.
+_SYSTEM_INSTRUCTIONS = """This MCP Gateway provides unified access to registered MCP servers through centralized discovery and execution.
 
 KEY CAPABILITIES:
-- 🔍 Discover any tool, resource, or prompt across all registered MCP servers
-- 🚀 Execute tools from any MCP server through unified proxy
-- 📚 Access resources (URIs, caches, data sources) from any server
-- 💬 Use prompts from any server for specialized workflows
-- 🎯 Automatic routing, authentication, and execution with proper credentials
+- Discover tools, resources, prompts, or full server documents across registered MCP servers
+- Execute downstream MCP tools through a unified proxy
+- Access downstream resources and prompts through the same registry
+- Route requests with the server's configured authentication and connection settings
 
-CRITICAL RULE - ALWAYS USE DISCOVERY FIRST:
-⚠️ MANDATORY: If you don't have a suitable tool for the user's request, you MUST use discover_servers to find one.
-⚠️ NEVER respond with "I don't have the capability" without first attempting discovery.
-⚠️ The gateway provides access to 100+ specialized tools - they must be discovered before use.
+GLOBAL WORKFLOW RULES:
+1. If you do not already have a suitable tool for the user's request, call `discover_servers` first.
+2. Do not respond that you lack capability until you have attempted discovery.
+3. If a native fetch or direct access attempt fails with authentication, permission, or access errors, fall back to `discover_servers`.
+4. Prefer `type_list=["tool"]` first. Use `type_list=["server"]` only when you need a full server document to inspect all capabilities on that server.
 
-CRITICAL RULE - WHEN NATIVE TOOLS FAIL:
-⚠️ If you encounter FAILURES (fetch fails, can't access resource, authentication errors, permission denied):
-  1. DON'T give up or say "I can't access this" - The registry has specialized authenticated tools
-  2. IMMEDIATELY use discover_servers to find a specialized tool for that service
-  3. Specialized tools in registry have proper authentication/authorization configured
-  4. Most services (GitHub, APIs, databases) have authenticated tools available
-
-EXAMPLES OF WHEN TO FALL BACK TO REGISTRY:
-✓ Fetch fails on private repository URL → discover_servers(query="<service> repository", type_list=["tool"])
-✓ Can't access API endpoint → discover_servers(query="<service name> API", type_list=["tool"])
-✓ Authentication error (401/403) → discover_servers(query="<service> authenticated", type_list=["tool"])
-✓ Rate limit exceeded → discover_servers(query="<service> premium access", type_list=["tool"])
-✓ Permission denied → discover_servers(query="<service> <operation>", type_list=["tool"])
-✓ Resource unavailable → Specialized tools in registry have proper credentials and access
-
-WHEN TO USE DISCOVERY TOOLS:
-✓ User needs external/real-time data (news, weather, stock prices, current events)
-✓ User asks "what can you do?" → Use discover_servers with type_list=["server"]
-✓ User mentions specific services (GitHub, databases, APIs, search engines)
-✓ User requests functionality you don't have built-in → ALWAYS try discover_servers first
-✓ You encounter a task requiring specialized tools → discover_servers before saying "I can't"
-✓ User asks about capabilities in a domain → Use discover_servers with domain keyword
-✓ Native tool FAILED → Try discover_servers to find authenticated/specialized alternative
-
-DISCOVERY WORKFLOW:
-1. User makes request → Check if you have suitable tools
-2. No suitable tools? → MUST call discover_servers("description of need", type_list=["tool"])
-3. Review discovered tools/servers
-4. Execute appropriate tool with execute_tool(server_path, tool_name, arguments)
-5. Present results to user
+WHEN TO FALL BACK TO DISCOVERY:
+- Private repository or API access fails
+- Authentication or authorization fails (401, 403, permission denied)
+- A specialized external service is likely needed
+- The user asks what capabilities exist for a domain or service
 
 TOKEN-EFFICIENT DISCOVERY:
-- Use type_list=["tool"] (default) for specific executable tools (returns 3 results)
-- Use type_list=["resource"] for data sources/URIs (returns 3 results)
-- Use type_list=["prompt"] for workflows (returns 3 results)
-- Use type_list=["server"] only when exploring all capabilities (returns 1 server, token-heavy)
+- `type_list=["tool"]`: default and preferred for executable tools
+- `type_list=["resource"]`: for data sources or URIs
+- `type_list=["prompt"]`: for reusable prompt workflows
+- `type_list=["server"]`: only when you need the full Mongo-style server document
+
+CRITICAL RESULT INTERPRETATION RULE:
+- Treat discovery results as full server documents only when `type_list` is exactly `["server"]`.
+- In every other case, including `type_list=["tool"]`, treat each returned item as a directly usable result for execution purposes.
+
+EXECUTION RULES:
+- `execute_tool` always runs exactly one downstream MCP tool.
+- `execute_tool.tool_name` must always be the final downstream MCP tool name.
+- If the previous discovery call used exactly `type_list=["server"]`, first inspect `server.config.toolFunctions`, choose one tool entry, and pass that chosen entry's `mcpToolName` as `tool_name`. Only if `mcpToolName` is missing may you fall back to that tool entry's key or name.
+- In every other discovery case, pass the returned `tool_name` unchanged into `execute_tool.tool_name`.
+- Pair the chosen `tool_name` with the matching `server_id` from the same discovery result or chosen server document.
 
 EXAMPLES:
-- "What's the weather?" → discover_servers(query="weather forecast", type_list=["tool"])
-- "Search for news on AI" → discover_servers(query="web search news", type_list=["tool"])
-- "What can you do?" → discover_servers(query="", type_list=["server"])
-- "Get stock prices" → discover_servers(query="financial data stock market", type_list=["tool"])
-- "Send an email" → discover_servers(query="email send message", type_list=["tool"])
-- Fetch/access fails → discover_servers(query="<service> <operation>", type_list=["tool"])
+- Weather or current events → `discover_servers(query="weather forecast", type_list=["tool"])`
+- Web search → `discover_servers(query="web search news", type_list=["tool"])`
+- Stock prices → `discover_servers(query="financial data stock market", type_list=["tool"])`
+- Explore full capabilities of a server domain → `discover_servers(query="github", type_list=["server"])`
+- Access failure on a protected service → `discover_servers(query="<service> authenticated", type_list=["tool"])`
 
-RESILIENCE PATTERN:
-```
-# When you see errors (fetch failed, 403, 401, permission denied):
-if error_occurred:
-    # Don't give up! Find authenticated tool from registry
-    tools = discover_servers(query="<service> <operation>", type_list=["tool"])
-    if tools:
-        result = execute_tool(tools[0]["server_path"], tools[0]["tool_name"], args)
+SERVER-DOCUMENT EXAMPLE:
+- If `discover_servers(..., type_list=["server"])` returns a server whose `config.toolFunctions` contains:
+  - `add_numbers_mcp_minimal_mcp_iam -> mcpToolName="add_numbers"`
+  - `greet_mcp_minimal_mcp_iam -> mcpToolName="greet"`
+- Then first choose the single tool entry that matches the task.
+- To execute the add tool, call `execute_tool(tool_name="add_numbers", server_id="<server id>", arguments={...})`.
+- To execute the greet tool, call `execute_tool(tool_name="greet", server_id="<server id>", arguments={...})`.
 
-# For authenticated resources, prefer registry tools proactively:
-# - Private repositories → discover_servers("<service> repository", type_list=["tool"])
-# - Private APIs → discover_servers("<api name>", type_list=["tool"])
-# - Database queries → discover_servers("database <operation>", type_list=["tool"])
-# - Authenticated services → discover_servers("<service> authenticated", type_list=["tool"])
-```
-
-ALWAYS be proactive: Discover and use available tools automatically. When native tools fail, try registry tools - they often have proper authentication and elevated permissions!
+TOOL-RESULT EXAMPLE:
+- If discovery returns `{"tool_name": "tavily_search", "server_id": "abc123", ...}`, call `execute_tool(tool_name="tavily_search", server_id="abc123", arguments={...})`.
 """
 
 

--- a/registry/src/registry/mcpgw/server.py
+++ b/registry/src/registry/mcpgw/server.py
@@ -42,9 +42,9 @@ CRITICAL RESULT INTERPRETATION RULE:
 
 EXECUTION RULES:
 - `execute_tool` always runs exactly one downstream MCP tool.
-- `execute_tool.tool_name` must always be the final downstream MCP tool name.
-- If the previous discovery call used exactly `type_list=["server"]`, first inspect `server.config.toolFunctions`, choose one tool entry, and pass that chosen entry's `mcpToolName` as `tool_name`. Only if `mcpToolName` is missing may you fall back to that tool entry's key or name.
-- In every other discovery case, pass the returned `tool_name` unchanged into `execute_tool.tool_name`.
+- The `tool_name` parameter of the `execute_tool` call must always be the final downstream MCP tool name.
+- If the previous discovery call used exactly `type_list=["server"]`, first inspect the `$.config.toolFunctions` field of the server document, choose one tool entry, and pass that chosen entry's `mcpToolName` as `tool_name`. Only if `mcpToolName` is missing may you fall back to that tool entry's key or name.
+- In every other discovery case, pass the returned `tool_name` unchanged into the `tool_name` parameter of the `execute_tool` call.
 - Pair the chosen `tool_name` with the matching `server_id` from the same discovery result or chosen server document.
 
 EXAMPLES:
@@ -55,7 +55,7 @@ EXAMPLES:
 - Access failure on a protected service → `discover_servers(query="<service> authenticated", type_list=["tool"])`
 
 SERVER-DOCUMENT EXAMPLE:
-- If `discover_servers(..., type_list=["server"])` returns a server whose `config.toolFunctions` contains:
+- If `discover_servers(..., type_list=["server"])` returns a server whose `$.config.toolFunctions` contains:
   - `add_numbers_mcp_minimal_mcp_iam -> mcpToolName="add_numbers"`
   - `greet_mcp_minimal_mcp_iam -> mcpToolName="greet"`
 - Then first choose the single tool entry that matches the task.

--- a/registry/src/registry/mcpgw/tools/proxied.py
+++ b/registry/src/registry/mcpgw/tools/proxied.py
@@ -595,7 +595,7 @@ def get_tools() -> list[tuple[str, Callable]]:
         tool_name: Annotated[
             str,
             Field(
-                description="Final downstream MCP tool name to execute. If the previous discovery call used `type_list=[\"server\"]` and only `server`, first choose one tool entry from `server.config.toolFunctions`, then pass that chosen entry's `mcpToolName` as `tool_name` (or fall back to that chosen entry's key/name only if `mcpToolName` is missing). In every other discovery case, pass the returned `tool_name` unchanged. This exact string is forwarded as downstream MCP `tools/call.params.name`."
+                description="Final downstream MCP tool name to execute. If the previous discovery call used `type_list=[\"server\"]` and only `server`, first choose one tool entry from `$.config.toolFunctions`, then pass that chosen entry's `mcpToolName` as `tool_name` (or fall back to that chosen entry's key/name only if `mcpToolName` is missing). In every other discovery case, pass the returned `tool_name` unchanged. This exact string is forwarded as the value of the `$.params.name` field in the JSON-RPC payload of the `tools/call` request to downstream MCP."
             ),
         ],
         arguments: Annotated[dict[str, Any], Field(description="Tool parameters from input_schema")],
@@ -622,7 +622,7 @@ def get_tools() -> list[tuple[str, Callable]]:
         ```
 
         **Parameters:**
-        - tool_name: Final downstream MCP tool name. This is the exact value that will be forwarded to downstream MCP as `tools/call.params.name`.
+        - tool_name: Final downstream MCP tool name. This is the exact value that becomes the `$.params.name` field in the JSON-RPC payload of the `tools/call` request to downstream MCP.
         - arguments: Tool-specific parameters from input_schema
         - server_id: Server ID from discovery
 
@@ -630,7 +630,7 @@ def get_tools() -> list[tuple[str, Callable]]:
         - Case 1: the previous discovery call used `type_list=["server"]` and only `server`.
           - The discovery response contains full server documents in `servers`.
           - Pick one server document.
-          - Inspect that server document's `config.toolFunctions`.
+          - Inspect the `$.config.toolFunctions` field of that server document.
           - Choose the single tool entry that best matches the user's task.
           - Set `server_id` to that server document's `id`.
           - Set `tool_name` to that chosen tool entry's `mcpToolName`.
@@ -652,8 +652,8 @@ def get_tools() -> list[tuple[str, Callable]]:
         - If discover_servers returns `{"tool_name": "tavily_search", "server_id": "abc123"}`,
           then call `execute_tool(tool_name="tavily_search", server_id="abc123", arguments={...})`.
         - If a server result contains:
-          - `config.toolFunctions["add_numbers_mcp_minimal_mcp_iam"].mcpToolName = "add_numbers"`
-          - `config.toolFunctions["greet_mcp_minimal_mcp_iam"].mcpToolName = "greet"`
+          - `$.config.toolFunctions["add_numbers_mcp_minimal_mcp_iam"].mcpToolName = "add_numbers"`
+          - `$.config.toolFunctions["greet_mcp_minimal_mcp_iam"].mcpToolName = "greet"`
           then first choose the correct tool entry for the task.
           - To execute the add tool, call `execute_tool(tool_name="add_numbers", server_id="<server id>", arguments={...})`.
           - To execute the greet tool, call `execute_tool(tool_name="greet", server_id="<server id>", arguments={...})`.

--- a/registry/src/registry/mcpgw/tools/proxied.py
+++ b/registry/src/registry/mcpgw/tools/proxied.py
@@ -595,7 +595,7 @@ def get_tools() -> list[tuple[str, Callable]]:
         tool_name: Annotated[
             str,
             Field(
-                description="Actual downstream MCP tool name to execute, matching .config.toolFunctions[*].mcpToolName"
+                description="Use the exact `tool_name` field from one discover_servers result for the same `server_id`. Pass it unchanged. Do not use a display name, registry-scoped function key, or rewritten name. This exact string is forwarded as `tools/call.params.name` to the downstream MCP server."
             ),
         ],
         arguments: Annotated[dict[str, Any], Field(description="Tool parameters from input_schema")],
@@ -622,11 +622,19 @@ def get_tools() -> list[tuple[str, Callable]]:
         ```
 
         **Parameters:**
-        - tool_name: Actual downstream MCP tool name (same value as `.config.toolFunctions[*].mcpToolName`)
+        - tool_name: The exact `tool_name` value from a single `discover_servers` result. Use it unchanged and pair it with the matching `server_id` from that same result. This exact value is forwarded as `tools/call.params.name` to the downstream MCP server.
         - arguments: Tool-specific parameters from input_schema
         - server_id: Server ID from discovery
 
-        **Important:** Pass the real downstream MCP tool name here, not the registry-scoped toolFunction key.
+        **Important:**
+        - Do not invent, rename, scope, or rewrite the tool name.
+        - Do not pass a display name or registry-scoped function key.
+        - Use the `tool_name` field from discover_servers exactly as returned.
+        - Pair it with the matching `server_id` from the same discovery result.
+
+        **Example:**
+        - If discover_servers returns `{"tool_name": "tavily_search", "server_id": "abc123"}`,
+          then call `execute_tool(tool_name="tavily_search", server_id="abc123", arguments={...})`.
 
         ⚠️ Use after discover_servers to execute tools.
         Returns: Tool-specific results (format varies by tool)

--- a/registry/src/registry/mcpgw/tools/proxied.py
+++ b/registry/src/registry/mcpgw/tools/proxied.py
@@ -595,17 +595,11 @@ def get_tools() -> list[tuple[str, Callable]]:
         tool_name: Annotated[
             str,
             Field(
-                description="Tool name from discovery - can be scoped name (e.g., 'tavily_search_mcp_tavily_search')"
+                description="Actual downstream MCP tool name to execute, matching .config.toolFunctions[*].mcpToolName"
             ),
         ],
         arguments: Annotated[dict[str, Any], Field(description="Tool parameters from input_schema")],
         server_id: Annotated[str, Field(description="Server ID from discovery")],
-        mcp_tool_name: Annotated[
-            str | None,
-            Field(
-                description="Original MCP tool name (e.g., 'tavily_search') - extract from toolFunction.mcpToolName if available",
-            ),
-        ] = None,
     ) -> CallToolResult:
         """
         🚀 AUTO-USE: Execute any discovered tool to get real-time data.
@@ -615,7 +609,6 @@ def get_tools() -> list[tuple[str, Callable]]:
         # Web search
         execute_tool(
             tool_name="tavily_search",
-            mcp_tool_name="tavily_search",  # Extract from toolFunction.mcpToolName
             arguments={"query": "latest AI news", "max_results": 5},
             server_id="6972e222755441652c23090f"
         )
@@ -629,27 +622,18 @@ def get_tools() -> list[tuple[str, Callable]]:
         ```
 
         **Parameters:**
-        - tool_name: Tool identifier (can be scoped name like "tavily_search_mcp_tavily_search")
-        - mcp_tool_name: Original MCP name from toolFunction.mcpToolName (e.g., "tavily_search")
+        - tool_name: Actual downstream MCP tool name (same value as `.config.toolFunctions[*].mcpToolName`)
         - arguments: Tool-specific parameters from input_schema
         - server_id: Server ID from discovery
 
-        **Note:** If mcp_tool_name is provided, it's used for execution (MCP standard).
-        Otherwise, tool_name is used directly.
+        **Important:** Pass the real downstream MCP tool name here, not the registry-scoped toolFunction key.
 
         ⚠️ Use after discover_servers to execute tools.
         Returns: Tool-specific results (format varies by tool)
         """
-        # Resolve tool name at interface layer: use mcpToolName if provided, otherwise use tool_name
-        resolved_tool_name = mcp_tool_name or tool_name
-
-        # Log the resolution for debugging
-        if mcp_tool_name and mcp_tool_name != tool_name:
-            logger.debug(f"Resolved tool name: '{resolved_tool_name}' (from mcpToolName, scoped was '{tool_name}')")
-
         return await execute_tool_impl(
             ctx,
-            resolved_tool_name,
+            tool_name,
             arguments,
             server_id,
         )

--- a/registry/src/registry/mcpgw/tools/proxied.py
+++ b/registry/src/registry/mcpgw/tools/proxied.py
@@ -595,7 +595,7 @@ def get_tools() -> list[tuple[str, Callable]]:
         tool_name: Annotated[
             str,
             Field(
-                description="Use the exact `tool_name` field from one discover_servers result for the same `server_id`. Pass it unchanged. Do not use a display name, registry-scoped function key, or rewritten name. This exact string is forwarded as `tools/call.params.name` to the downstream MCP server."
+                description="Final downstream MCP tool name to execute. If the previous discovery call used `type_list=[\"server\"]` and only `server`, first choose one tool entry from `server.config.toolFunctions`, then pass that chosen entry's `mcpToolName` as `tool_name` (or fall back to that chosen entry's key/name only if `mcpToolName` is missing). In every other discovery case, pass the returned `tool_name` unchanged. This exact string is forwarded as downstream MCP `tools/call.params.name`."
             ),
         ],
         arguments: Annotated[dict[str, Any], Field(description="Tool parameters from input_schema")],
@@ -622,19 +622,41 @@ def get_tools() -> list[tuple[str, Callable]]:
         ```
 
         **Parameters:**
-        - tool_name: The exact `tool_name` value from a single `discover_servers` result. Use it unchanged and pair it with the matching `server_id` from that same result. This exact value is forwarded as `tools/call.params.name` to the downstream MCP server.
+        - tool_name: Final downstream MCP tool name. This is the exact value that will be forwarded to downstream MCP as `tools/call.params.name`.
         - arguments: Tool-specific parameters from input_schema
         - server_id: Server ID from discovery
 
-        **Important:**
+        **How to set `tool_name`:**
+        - Case 1: the previous discovery call used `type_list=["server"]` and only `server`.
+          - The discovery response contains full server documents in `servers`.
+          - Pick one server document.
+          - Inspect that server document's `config.toolFunctions`.
+          - Choose the single tool entry that best matches the user's task.
+          - Set `server_id` to that server document's `id`.
+          - Set `tool_name` to that chosen tool entry's `mcpToolName`.
+          - Only if `mcpToolName` is missing, fall back to that chosen tool entry's key/name.
+        - Case 2: every other discovery case, including `type_list=["tool"]`.
+          - The discovery response already contains executable tool results.
+          - Set `server_id` to the returned `server_id`.
+          - Set `tool_name` to the returned `tool_name` unchanged.
+
+        **Important constraints:**
+        - `execute_tool` always runs exactly one tool.
+        - `tool_name` must always be the final downstream MCP tool name.
         - Do not invent, rename, scope, or rewrite the tool name.
-        - Do not pass a display name or registry-scoped function key.
-        - Use the `tool_name` field from discover_servers exactly as returned.
-        - Pair it with the matching `server_id` from the same discovery result.
+        - Do not pass a display label or registry-only alias.
+        - Do not pass the full server document into `execute_tool`.
+        - Pair the final `tool_name` with the matching `server_id` from the same discovery result.
 
         **Example:**
         - If discover_servers returns `{"tool_name": "tavily_search", "server_id": "abc123"}`,
           then call `execute_tool(tool_name="tavily_search", server_id="abc123", arguments={...})`.
+        - If a server result contains:
+          - `config.toolFunctions["add_numbers_mcp_minimal_mcp_iam"].mcpToolName = "add_numbers"`
+          - `config.toolFunctions["greet_mcp_minimal_mcp_iam"].mcpToolName = "greet"`
+          then first choose the correct tool entry for the task.
+          - To execute the add tool, call `execute_tool(tool_name="add_numbers", server_id="<server id>", arguments={...})`.
+          - To execute the greet tool, call `execute_tool(tool_name="greet", server_id="<server id>", arguments={...})`.
 
         ⚠️ Use after discover_servers to execute tools.
         Returns: Tool-specific results (format varies by tool)

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -131,102 +131,59 @@ def get_tools() -> list[tuple[str, Callable]]:
         ),
     ) -> list[dict[str, Any]]:
         """
-        🔍 AUTO-USE: Unified discovery for tools, resources, prompts, or servers using smart semantic search.
+        🔍 AUTO-USE: Discover tools, resources, prompts, or full server documents.
 
-        **⚡ TOKEN OPTIMIZATION STRATEGY (CRITICAL):**
+        **Use this search order by default:**
+        1. `type_list=["tool"]` first for executable tools
+        2. `type_list=["resource"]` or `type_list=["prompt"]` when the user needs those specifically
+        3. `type_list=["server"]` only when you need a full Mongo-style server document
 
-        **ALWAYS follow this search sequence to minimize tokens:**
-        1. **First try:** type_list=["tool"] (DEFAULT) - Returns 3 tools (~100 tokens each)
-        2. **If no tools found, try:** type_list=["resource"] or type_list=["prompt"] - Returns 3 results each
-        3. **Last resort:** type_list=["server"] - Returns 1 full server config (1000+ tokens)
+        **What each type means:**
+        - `["tool"]`: best default for action-oriented tasks such as search, API calls, automation, or data operations
+        - `["resource"]`: for reading URIs, cached data, or file-like resources
+        - `["prompt"]`: for reusable prompt workflows
+        - `["server"]`: for full server configs, including `config.toolFunctions`, resources, and prompts
 
-        **Smart Defaults:**
-        - type_list=["tool"] (default): Returns top 3 tools
-        - type_list=["resource"]: Returns top 3 resources
-        - type_list=["prompt"]: Returns top 3 prompts
-        - type_list=["server"]: Returns top 1 server (token-heavy)
+        **Search strategies:**
+        - `hybrid`: best default, combines semantic and keyword search
+        - `near_text`: semantic/concept matching
+        - `bm25`: exact keyword matching
+        - `similarity_store`: alternative retrieval path
 
-        **Why this matters:**
-        - type_list=["tool"]: Returns just executable tools with input schemas (efficient ✅)
-        - type_list=["resource"]: Returns just data sources/URIs (efficient ✅)
-        - type_list=["prompt"]: Returns just prompt templates (efficient ✅)
-        - type_list=["server"]: Returns EVERYTHING - all tools, resources, prompts (expensive ❌)
+        **How to interpret the returned `servers` array:**
+        - Treat results as full server documents only when `type_list` is exactly `["server"]`.
+        - In every other case, including `type_list=["tool"]`, treat each result as a directly usable discovery result for execution.
 
-        **When to use each type:**
+        **If `type_list` is exactly `["server"]`:**
+        - Each item in `servers` is a full server document in MongoDB format.
+        - To execute a tool from that server:
+          1. Inspect `server.config.toolFunctions`
+          2. Choose one tool entry whose description and parameters match the user's task
+          3. Set `execute_tool.server_id` to that server document's `id`
+          4. Set `execute_tool.tool_name` to that chosen tool entry's `mcpToolName`
+          5. Only if `mcpToolName` is missing, fall back to that chosen tool entry's key/name
 
-        🔧 **type_list=["tool"]** (DEFAULT - most common)
-        - User needs to DO something: search web, get data, create/update/delete
-        - Action-oriented requests: "find news", "search GitHub", "send email"
-        - Example queries: "web search", "github operations", "database queries"
-        - Returns: tool_name, server_path, description, input_schema
+        **In every other case, including `type_list=["tool"]`:**
+        - Each result is already an executable match.
+        - Use the returned `tool_name` unchanged as `execute_tool.tool_name`.
+        - Use the returned `server_id` unchanged as `execute_tool.server_id`.
 
-        📚 **type_list=["resource"]**
-        - User needs to ACCESS data sources, caches, or URIs
-        - Data retrieval: "read cached results", "get configuration", "access files"
-        - Example queries: "cached search results", "config files", "data exports"
-        - Returns: resource URIs and descriptions
+        **Examples:**
+        - News or web search: `discover_servers(query="web search news", type_list=["tool"])`
+        - GitHub operations: `discover_servers(query="github repositories", type_list=["tool"])`
+        - Cached data: `discover_servers(query="cached data", type_list=["resource"])`
+        - Full capability inspection: `discover_servers(query="github", type_list=["server"])`
 
-        💬 **type_list=["prompt"]**
-        - User needs pre-configured workflows or expert guidance
-        - Complex workflows: "research assistant", "fact checker", "code reviewer"
-        - Example queries: "research workflow", "analysis templates"
-        - Returns: prompt templates with argument schemas
+        **Execution examples:**
+        - Tool result:
+          - If discovery returns `{"tool_name": "tavily_search", "server_id": "abc123", ...}`,
+            call `execute_tool(tool_name="tavily_search", server_id="abc123", arguments={...})`.
+        - Server result:
+          - If `server.config.toolFunctions["add_numbers_mcp_minimal_mcp_iam"].mcpToolName = "add_numbers"`,
+            call `execute_tool(tool_name="add_numbers", server_id="<server id>", arguments={...})`.
 
-        🖥️ **type_list=["server"]** (use sparingly - high token cost)
-        - User asks "what can you do?" or wants to explore ALL capabilities
-        - Need complete server catalog with all tools/resources/prompts
-        - Failed to find specific tools and need full context
-        - Example: "show me all github capabilities" (not "search github repos")
-        - Returns: FULL server configs (expensive - use only when necessary)
-
-        **Search Type Strategies:**
-        - **"hybrid"** (default): Best overall accuracy, combines semantic + keyword + AI reranking
-        - **"near_text"**: Pure semantic for concept matching ("find info online" → search engines)
-        - **"bm25"**: Pure keyword for exact terms ("github" → finds "github" literally)
-        - **"similarity_store"**: Alternative algorithm if others fail
-
-        **Real-World Examples:**
-
-        ✅ GOOD (token-efficient):
-        ```
-        # User: "search for Donald Trump news"
-        discover_servers(query="web search news", type_list=["tool"])  # Returns tavily_search tool only
-
-        # User: "list GitHub repos"
-        discover_servers(query="github repositories", type_list=["tool"])  # Returns list_repos tool
-
-        # User: "get cached results"
-        discover_servers(query="cached data", type_list=["resource"])  # Returns resource URIs
-        ```
-
-        ❌ BAD (token-wasteful):
-        ```
-        # User: "search for news"
-        discover_servers(query="news", type_list=["server"])  # Returns ENTIRE server configs (wasteful!)
-        ```
-
-        **Fallback Strategy:**
-        ```
-        # Try tools first (efficient, returns 3 tools by default)
-        results = discover_servers(query="github operations", type_list=["tool"])
-        if not results:
-            # Try resources if applicable
-            results = discover_servers(query="github operations", type_list=["resource"])
-        if not results:
-            # Last resort: full server (returns 1 server by default)
-            results = discover_servers(query="github operations", type_list=["server"])
-        ```
-
-        **Returns:**
-        - For type_list=["tool"]: {tool_name, server_path, description, input_schema, server_id}
-        - For type_list=["resource"]: {resource_uri, description, server_path}
-        - For type_list=["prompt"]: {prompt_name, description, arguments, server_path}
-        - For type_list=["server"]: {serverName, path, config{tools, resources, prompts}, tags, numTools}
-
-        **After discovery, use:**
-        - For tool results, pass the returned `tool_name` and matching `server_id` unchanged into `execute_tool`
-        - read_resource(server_id, resource_uri) for resources
-        - execute_prompt(server_id, prompt_name, arguments) for prompts
+        Use `read_resource(server_id, resource_uri)` for resources.
+        Use `execute_prompt(server_id, prompt_name, arguments)` for prompts.
         """
         return await discover_servers_impl(ctx, query, top_n, search_type, type_list)
 

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -66,9 +66,13 @@ async def discover_servers_impl(
     logger.info(f"🔍 Discovering {type_list} for query: '{query}' (search_type={search_type})")
 
     try:
-        search_request = SearchRequest.model_validate(
-            {"query": query, "top_n": top_n, "search_type": search_type, "type_list": type_list}
-        )
+        payload: dict[str, Any] = {"search_type": search_type, "type_list": type_list}
+        if query:
+            payload["query"] = query
+        if top_n is not None:
+            payload["top_n"] = top_n
+
+        search_request = SearchRequest.model_validate(payload)
         user_context: UserContextDict = ctx.request_context.request.state.user  # type: ignore[union-attr]
 
         result = await search_servers(search_request, user_context)
@@ -104,9 +108,9 @@ def get_tools() -> list[tuple[str, Callable]]:
         query: Annotated[
             str,
             Field(
-                min_length=1,
+                min_length=0,
                 max_length=512,
-                description="Natural language query or keywords (e.g., 'web search', 'github', 'email automation') - leave empty to see all",
+                description="Natural language query or keywords (e.g., 'web search', 'github', 'email automation'). May be omitted or empty. For `type_list=[\"server\"]`, an empty query means list available servers.",
             ),
         ] = "",
         top_n: Annotated[

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -224,7 +224,7 @@ def get_tools() -> list[tuple[str, Callable]]:
         - For type_list=["server"]: {serverName, path, config{tools, resources, prompts}, tags, numTools}
 
         **After discovery, use:**
-        - execute_tool(server_path, tool_name, arguments) for tools
+        - For tool results, pass the returned `tool_name` and matching `server_id` unchanged into `execute_tool`
         - read_resource(server_id, resource_uri) for resources
         - execute_prompt(server_id, prompt_name, arguments) for prompts
         """

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -161,10 +161,10 @@ def get_tools() -> list[tuple[str, Callable]]:
         **If `type_list` is exactly `["server"]`:**
         - Each item in `servers` is a full server document in MongoDB format.
         - To execute a tool from that server:
-          1. Inspect `server.config.toolFunctions`
+          1. Inspect the `$.config.toolFunctions` field of the server document.
           2. Choose one tool entry whose description and parameters match the user's task
-          3. Set `execute_tool.server_id` to that server document's `id`
-          4. Set `execute_tool.tool_name` to that chosen tool entry's `mcpToolName`
+          3. Set the `server_id` parameter of the `execute_tool` call to that server document's `id`
+          4. Set the `tool_name` parameter of the `execute_tool` call to that chosen tool entry's `mcpToolName`
           5. Only if `mcpToolName` is missing, fall back to that chosen tool entry's key/name
 
         **In every other case, including `type_list=["tool"]`:**
@@ -183,7 +183,7 @@ def get_tools() -> list[tuple[str, Callable]]:
           - If discovery returns `{"tool_name": "tavily_search", "server_id": "abc123", ...}`,
             call `execute_tool(tool_name="tavily_search", server_id="abc123", arguments={...})`.
         - Server result:
-          - If `server.config.toolFunctions["add_numbers_mcp_minimal_mcp_iam"].mcpToolName = "add_numbers"`,
+          - If `$.config.toolFunctions["add_numbers_mcp_minimal_mcp_iam"].mcpToolName = "add_numbers"`,
             call `execute_tool(tool_name="add_numbers", server_id="<server id>", arguments={...})`.
 
         Use `read_resource(server_id, resource_uri)` for resources.

--- a/registry/tests/integration/test_search_routes.py
+++ b/registry/tests/integration/test_search_routes.py
@@ -341,12 +341,19 @@ class TestServerSearchRoutes:
         assert call_kwargs["candidate_k"] == 100
 
     def test_search_servers_empty_query(self, test_client: TestClient):
-        """Server search rejects empty query string."""
-        response = test_client.post("/api/v1/search/servers", json={"query": "", "top_n": 10})
+        """Server search accepts empty query and returns a valid response."""
+        with patch("registry.api.v1.search_routes.mcp_server_repo.afilter", new_callable=AsyncMock) as mock_filter:
+            mock_filter.return_value = []
+            response = test_client.post("/api/v1/search/servers", json={"query": "", "top_n": 10})
 
-        # Query has min_length=1, so empty string returns validation error
-        assert response.status_code == 422
-        assert "query" in response.json()["detail"]
+        assert response.status_code == 200
+        mock_filter.assert_awaited_once()
+        assert response.json() == {
+            "query": "",
+            "type_list": ["server", "tool", "resource", "prompt"],
+            "total": 0,
+            "servers": [],
+        }
 
     def test_search_servers_returns_results(self, test_client: TestClient):
         """Server search returns search results."""

--- a/registry/tests/unit/api/v1/test_search_routes.py
+++ b/registry/tests/unit/api/v1/test_search_routes.py
@@ -111,3 +111,63 @@ async def test_search_servers_serializes_server_models_to_dicts():
 
     assert response["total"] == 1
     assert response["servers"] == [{"serverName": "server-1", "path": "/server-1"}]
+
+
+@pytest.mark.asyncio
+async def test_search_servers_lists_servers_when_query_is_empty():
+    fake_server = _FakeServerModel(serverName="server-1", path="/server-1")
+    list_servers = AsyncMock(return_value=([fake_server], 1))
+
+    with (
+        patch("registry.api.v1.search_routes.server_service_v1.list_servers", new=list_servers),
+        patch(
+            "registry.api.v1.search_routes.mcp_server_repo.asearch_with_rerank",
+            new=AsyncMock(side_effect=AssertionError("vector search should not run for empty server query")),
+        ),
+    ):
+        response = await search_servers(
+            search=SearchRequest(
+                query="",
+                top_n=5,
+                search_type=SearchType.HYBRID,
+                type_list=[ServerEntityType.SERVER],
+                include_disabled=False,
+            ),
+            user_context={"username": "tester"},
+        )
+
+    list_servers.assert_awaited_once_with(query=None, status="active", page=1, per_page=5)
+    assert response["query"] == ""
+    assert response["total"] == 1
+    assert response["servers"] == [{"serverName": "server-1", "path": "/server-1"}]
+
+
+@pytest.mark.asyncio
+async def test_search_servers_filters_metadata_when_non_server_query_is_empty():
+    filter_results = [{"server_id": "id-1", "server_name": "server-1", "entity_type": "tool", "tool_name": "search"}]
+
+    with (
+        patch(
+            "registry.api.v1.search_routes.mcp_server_repo.afilter",
+            new=AsyncMock(return_value=filter_results),
+        ) as afilter,
+        patch(
+            "registry.api.v1.search_routes.mcp_server_repo.asearch_with_rerank",
+            new=AsyncMock(side_effect=AssertionError("vector search should not run for empty non-server query")),
+        ),
+    ):
+        response = await search_servers(
+            search=SearchRequest(
+                query="",
+                top_n=5,
+                search_type=SearchType.HYBRID,
+                type_list=[ServerEntityType.TOOL],
+                include_disabled=False,
+            ),
+            user_context={"username": "tester"},
+        )
+
+    afilter.assert_awaited_once_with(filters={"enabled": True, "entity_type": ["tool"]}, limit=5)
+    assert response["query"] == ""
+    assert response["total"] == 1
+    assert response["servers"] == filter_results

--- a/registry/tests/unit/api/v1/test_search_routes.py
+++ b/registry/tests/unit/api/v1/test_search_routes.py
@@ -1,0 +1,113 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from registry.api.v1.search_routes import SearchRequest, SemanticSearchRequest, search_servers, semantic_search
+from registry_pkgs.models.enums import ServerEntityType
+from registry_pkgs.vector.enum.enums import SearchType
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_uses_injected_vector_service():
+    request = SimpleNamespace(
+        state=SimpleNamespace(
+            is_authenticated=True,
+            user={"username": "tester"},
+        )
+    )
+    vector_service = MagicMock()
+    vector_service.search_mixed = AsyncMock(
+        return_value={
+            "servers": [
+                {
+                    "path": "/test-server",
+                    "server_name": "test-server",
+                    "description": "Test server",
+                    "tags": ["test"],
+                    "num_tools": 1,
+                    "is_enabled": True,
+                    "relevance_score": 0.9,
+                    "matching_tools": [],
+                }
+            ],
+            "tools": [],
+        }
+    )
+
+    with patch("registry.api.v1.search_routes.faiss_service", new=vector_service):
+        response = await semantic_search(
+            request=request,
+            search_request=SemanticSearchRequest(query="test", entityTypes=["mcp_server"], maxResults=5),
+        )
+
+    vector_service.search_mixed.assert_awaited_once_with(
+        query="test",
+        entity_types=["mcp_server"],
+        max_results=5,
+    )
+    assert response.totalServers == 1
+    assert response.servers[0].serverName == "test-server"
+
+
+@pytest.mark.asyncio
+async def test_search_servers_uses_injected_server_service():
+    server_service = MagicMock()
+    server_service.get_server_by_id = AsyncMock(side_effect=[{"serverName": "server-1"}, {"serverName": "server-2"}])
+
+    with (
+        patch(
+            "registry.api.v1.search_routes.mcp_server_repo.asearch_with_rerank",
+            new=AsyncMock(return_value=[{"server_id": "id-1"}, {"server_id": "id-2"}]),
+        ),
+        patch("registry.api.v1.search_routes.server_service_v1", new=server_service),
+    ):
+        response = await search_servers(
+            search=SearchRequest(
+                query="test",
+                top_n=2,
+                search_type=SearchType.HYBRID,
+                type_list=[ServerEntityType.SERVER],
+                include_disabled=False,
+            ),
+            user_context={"username": "tester"},
+        )
+
+    assert server_service.get_server_by_id.await_count == 2
+    assert response["total"] == 2
+    assert len(response["servers"]) == 2
+
+
+class _FakeServerModel(BaseModel):
+    serverName: str
+    path: str
+
+
+@pytest.mark.asyncio
+async def test_search_servers_serializes_server_models_to_dicts():
+    fake_server = _FakeServerModel(serverName="server-1", path="/server-1")
+
+    with (
+        patch(
+            "registry.api.v1.search_routes.mcp_server_repo.asearch_with_rerank",
+            new=AsyncMock(return_value=[{"server_id": "id-1"}]),
+        ),
+        patch(
+            "registry.api.v1.search_routes.server_service_v1.get_server_by_id",
+            new=AsyncMock(return_value=fake_server),
+        ),
+    ):
+        response = await search_servers(
+            search=SearchRequest(
+                query="github",
+                top_n=1,
+                search_type=SearchType.HYBRID,
+                type_list=[ServerEntityType.SERVER],
+                include_disabled=False,
+            ),
+            user_context={"username": "tester"},
+        )
+
+    assert response["total"] == 1
+    assert response["servers"] == [{"serverName": "server-1", "path": "/server-1"}]

--- a/registry/tests/unit/mcpgw/test_proxied_tools.py
+++ b/registry/tests/unit/mcpgw/test_proxied_tools.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from registry.mcpgw.tools import proxied
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_wrapper_uses_tool_name_as_downstream_name(monkeypatch):
+    execute_tool = dict(proxied.get_tools())["execute_tool"]
+    execute_mock = AsyncMock(return_value=SimpleNamespace(result="ok"))
+    monkeypatch.setattr(proxied, "execute_tool_impl", execute_mock)
+
+    ctx = SimpleNamespace()
+    arguments = {"query": "ai"}
+
+    await execute_tool(
+        ctx=ctx,
+        tool_name="tavily_search",
+        arguments=arguments,
+        server_id="server-123",
+    )
+
+    execute_mock.assert_awaited_once_with(ctx, "tavily_search", arguments, "server-123")


### PR DESCRIPTION
 - store only downstream MCP tool_name from toolFunctions[*].mcpToolName
 - simplify proxied execute_tool signature to accept only downstream tool_name