### PR TITLE
fix: add missing permission for well-known agent cards endpoint

### DIFF
--- a/registry-pkgs/src/registry_pkgs/scopes.yml
+++ b/registry-pkgs/src/registry_pkgs/scopes.yml
@@ -84,6 +84,9 @@ agents-read:
   - action: check_agent_health
     method: POST
     endpoint: /agents/{agent_id}/health
+  - action: get_agent_wellknown_card
+    method: GET
+    endpoint: /agents/.well-known/agent-cards
 
 agents-write:
   - action: create_agent


### PR DESCRIPTION
Added GET /agents/.well-known/agent-cards to agents-read scope in scopes.yml to fix 403 Forbidden error.