### PR TITLE
Feature: SameSite cookies and token endpoint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,7 @@ image-manifest.json
 
 # Misc. files
 /docker-compose.*.yml
+
+# Claude spec and plan files
+/.spec
+/.plan

--- a/auth-server/src/auth_server/core/config.py
+++ b/auth-server/src/auth_server/core/config.py
@@ -8,6 +8,7 @@ All environment variables are loaded here and accessed through the global `setti
 import logging
 import secrets
 from functools import cached_property
+from typing import Literal
 
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -51,6 +52,9 @@ class AuthSettings(BaseSettings):
 
     # ==================== CORS Configuration ====================
     cors_origins: str = "*"  # Comma-separated list of allowed origins, or "*" for all
+
+    # ==================== Cookies Configuration ====================
+    cookie_same_site: Literal["lax", "strict"] = "lax"
 
     # ==================== Auth Provider ====================
     auth_provider: str = "keycloak"  # cognito, keycloak, entra

--- a/auth-server/src/auth_server/routes/oauth_flow.py
+++ b/auth-server/src/auth_server/routes/oauth_flow.py
@@ -560,7 +560,7 @@ async def oauth2_login(
             value=temp_session,
             max_age=settings.oauth_session_ttl_seconds,
             httponly=True,
-            samesite="lax",
+            samesite=settings.cookie_same_site,
         )
         return response
     except HTTPException:

--- a/auth-server/src/auth_server/routes/oauth_flow.py
+++ b/auth-server/src/auth_server/routes/oauth_flow.py
@@ -309,17 +309,55 @@ async def approve_device(request: DeviceApprovalRequest):
     return {"status": "approved", "message": "Device verified successfully"}
 
 
+async def _parse_device_token_params(request: Request) -> dict:
+    content_type = request.headers.get("content-type", "")
+
+    if content_type == "application/json":
+        body = await request.json()
+
+        return {
+            "grant_type": body.get("grant_type"),
+            "device_code": body.get("device_code"),
+            "client_id": body.get("client_id"),
+            "code": body.get("code"),
+            "code_verifier": body.get("code_verifier"),
+            "refresh_token": body.get("refresh_token"),
+            "redirect_uri": body.get("redirect_uri"),
+        }
+    elif content_type == "application/x-www-form-urlencoded":
+        form = await request.form()
+
+        return {
+            "grant_type": form.get("grant_type"),
+            "device_code": form.get("device_code"),
+            "client_id": form.get("client_id"),
+            "code": form.get("code"),
+            "code_verifier": form.get("code_verifier"),
+            "refresh_token": form.get("refresh_token"),
+            "redirect_uri": form.get("redirect_uri"),
+        }
+    else:
+        raise HTTPException(
+            status_code=415, detail="content-type must be application/json or application/x-www-form-urlencoded"
+        )
+
+
 @router.post("/oauth2/token", response_model=DeviceTokenResponse)
-async def device_token(
-    request: Request,
-    grant_type: str = Form(...),
-    device_code: str = Form(None),
-    client_id: str = Form(...),
-    code: str = Form(None),
-    code_verifier: str = Form(None),
-    refresh_token: str = Form(None),
-    redirect_uri: str = Form(None),
-):
+async def device_token(request: Request):
+    params = await _parse_device_token_params(request)
+    grant_type: str | None = params["grant_type"]
+    device_code: str | None = params["device_code"]
+    client_id: str | None = params["client_id"]
+    code: str | None = params["code"]
+    code_verifier: str | None = params["code_verifier"]
+    refresh_token: str | None = params["refresh_token"]
+    redirect_uri: str | None = params["redirect_uri"]
+
+    if not grant_type:
+        return oauth_error_response("invalid_request", "grant_type is required")
+    if not client_id:
+        return oauth_error_response("invalid_request", "client_id is required")
+
     logger.info("TOKEN ENDPOINT CALLED")
     logger.info(f"grant_type: {grant_type}")
     user_service = _get_user_service(request)

--- a/auth-server/tests/integration/test_oauth_callback_token_flow.py
+++ b/auth-server/tests/integration/test_oauth_callback_token_flow.py
@@ -387,8 +387,9 @@ class TestOAuth2CallbackStandardFlow:
 class TestOAuth2TokenEndpoint:
     """Test /oauth2/token endpoint with authorization code grant."""
 
+    @pytest.mark.parametrize("content_type", ["form", "json"])
     def test_token_endpoint_with_authorization_code(
-        self, test_client_oauth_callback, clear_device_storage, mock_user_service
+        self, test_client_oauth_callback, clear_device_storage, mock_user_service, content_type
     ):
         """Test token endpoint exchanges authorization code for JWT with user_id."""
         # Create authorization code directly
@@ -412,19 +413,19 @@ class TestOAuth2TokenEndpoint:
             "created_at": current_time,
         }
 
+        payload = {
+            "grant_type": "authorization_code",
+            "code": auth_code,
+            "client_id": "test-client",
+            "redirect_uri": "http://localhost/callback",
+        }
+
         # Exchange code for token
         with patch("auth_server.routes.oauth_flow.jwt.encode") as mock_jwt_encode:
             mock_jwt_encode.return_value = "mock-jwt-token-with-user-id"
 
-            response = test_client_oauth_callback.post(
-                f"{API_PREFIX}/oauth2/token",
-                data={
-                    "grant_type": "authorization_code",
-                    "code": auth_code,
-                    "client_id": "test-client",
-                    "redirect_uri": "http://localhost/callback",
-                },
-            )
+            kwargs = {"json": payload} if content_type == "json" else {"data": payload}
+            response = test_client_oauth_callback.post(f"{API_PREFIX}/oauth2/token", **kwargs)
 
             assert response.status_code == 200
             token_data = response.json()
@@ -444,7 +445,8 @@ class TestOAuth2TokenEndpoint:
             # Code should be deleted after successful exchange
             assert auth_code not in authorization_codes_storage
 
-    def test_token_endpoint_code_already_used(self, test_client_oauth_callback, clear_device_storage):
+    @pytest.mark.parametrize("content_type", ["form", "json"])
+    def test_token_endpoint_code_already_used(self, test_client_oauth_callback, clear_device_storage, content_type):
         """Test token endpoint rejects already-used authorization code."""
         auth_code = secrets.token_urlsafe(32)
         current_time = int(__import__("time").time())
@@ -459,15 +461,15 @@ class TestOAuth2TokenEndpoint:
             "created_at": current_time,
         }
 
-        response = test_client_oauth_callback.post(
-            f"{API_PREFIX}/oauth2/token",
-            data={
-                "grant_type": "authorization_code",
-                "code": auth_code,
-                "client_id": "test-client",
-                "redirect_uri": "http://localhost/callback",
-            },
-        )
+        payload = {
+            "grant_type": "authorization_code",
+            "code": auth_code,
+            "client_id": "test-client",
+            "redirect_uri": "http://localhost/callback",
+        }
+
+        kwargs = {"json": payload} if content_type == "json" else {"data": payload}
+        response = test_client_oauth_callback.post(f"{API_PREFIX}/oauth2/token", **kwargs)
 
         assert response.status_code == 400
         assert response.json()["error"] == "invalid_grant"
@@ -475,3 +477,13 @@ class TestOAuth2TokenEndpoint:
 
         # Code should be deleted
         assert auth_code not in authorization_codes_storage
+
+    def test_token_endpoint_unsupported_content_type(self, test_client_oauth_callback):
+        """Test token endpoint rejects unsupported content-type with 415."""
+        response = test_client_oauth_callback.post(
+            f"{API_PREFIX}/oauth2/token",
+            content="grant_type=authorization_code&client_id=test-client",
+            headers={"Content-Type": "text/plain"},
+        )
+
+        assert response.status_code == 415

--- a/registry/src/registry/api/redirect_routes.py
+++ b/registry/src/registry/api/redirect_routes.py
@@ -189,7 +189,7 @@ async def oauth2_callback(
             value=access_token,
             max_age=86400,  # 1 day in seconds
             httponly=True,
-            samesite="lax",
+            samesite=settings.cookie_same_site,
             secure=cookie_secure,
             path="/",
         )
@@ -200,7 +200,7 @@ async def oauth2_callback(
             value=refresh_token,
             max_age=604800,  # 7 days in seconds
             httponly=True,
-            samesite="lax",
+            samesite=settings.cookie_same_site,
             secure=cookie_secure,
             path="/",
         )
@@ -371,7 +371,7 @@ async def refresh_token(
                 value=new_access_token,
                 max_age=86400,  # 1 day in seconds
                 httponly=True,
-                samesite="lax",
+                samesite=settings.cookie_same_site,
                 secure=cookie_secure,
                 path="/",
             )

--- a/registry/src/registry/core/config.py
+++ b/registry/src/registry/core/config.py
@@ -2,7 +2,7 @@ import logging
 import secrets
 from functools import cached_property
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -38,6 +38,7 @@ class Settings(BaseSettings):
     session_max_age_seconds: int = 60 * 60 * 8
     session_cookie_secure: bool = True
     session_cookie_domain: str | None = None
+    cookie_same_site: Literal["lax", "strict"] = "lax"
 
     # ==================== Service URLs ====================
     auth_server_url: str = "http://localhost:8888"

--- a/registry/tests/unit/auth/test_auth_routes.py
+++ b/registry/tests/unit/auth/test_auth_routes.py
@@ -39,6 +39,7 @@ class TestAuthRoutes:
             mock_settings.session_max_age_seconds = 3600
             mock_settings.templates_dir = "/templates"
             mock_settings.registry_client_url = "http://localhost:8000/"
+            mock_settings.cookie_same_site = "lax"
             yield mock_settings
 
     @pytest.fixture


### PR DESCRIPTION
Two changes:
- Cookies default to `SameSite=Lax`. We can switch to `Strict` in PROD environment by setting the `COOKIE_SAME_SITE` env var.
- The `/oauth2/token` endpoint now also supports `application/json` content type. This is for Claude Code CLI – their agent implementation violates the MCP spec made by themselves.