### PR TITLE
Rename: ascending org package ownership update 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mcp-gateway-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@ascending-inc/jarvis-embed": "^0.1.0",
         "@headlessui/react": "^1.7.17",
         "@heroicons/react": "^2.0.18",
         "@tailwindcss/forms": "^0.5.7",
@@ -18,7 +19,6 @@
         "autoprefixer": "^10.4.16",
         "axios": "^1.12.0",
         "clsx": "^2.0.0",
-        "jarvis-embed": "github:ascending-llc/jarvis-embed",
         "patch-package": "^8.0.1",
         "postcss": "^8.4.47",
         "react": "^18.2.0",
@@ -69,6 +69,11 @@
       "peerDependencies": {
         "ajv": ">=8"
       }
+    },
+    "node_modules/@ascending-inc/jarvis-embed": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ascending-inc/jarvis-embed/-/jarvis-embed-0.1.2.tgz",
+      "integrity": "sha512-zsdtHy01v+TMmZr4LsOkmYwfT7TGNLrGFf2EtJp36j+5px/8gqZAxTyhHMMbE92u33ZU8ZNovi1S52BI4Qz4xw=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -11667,10 +11672,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/jarvis-embed": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/ascending-llc/jarvis-embed.git#7275ad1d93e95b0c99c30c4ff72781584ab4e26e"
     },
     "node_modules/jest": {
       "version": "27.5.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "autoprefixer": "^10.4.16",
     "axios": "^1.12.0",
     "clsx": "^2.0.0",
-    "jarvis-embed": "github:ascending-llc/jarvis-embed",
+    "@ascending-inc/jarvis-embed": "^0.1.0",
     "patch-package": "^8.0.1",
     "postcss": "^8.4.47",
     "react": "^18.2.0",

--- a/frontend/src/pages/ServerRegistryOrEdit/McpPlaygroundModal.tsx
+++ b/frontend/src/pages/ServerRegistryOrEdit/McpPlaygroundModal.tsx
@@ -1,5 +1,5 @@
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import { JarvisEmbed } from 'jarvis-embed';
+import { JarvisEmbed } from '@ascending-inc/jarvis-embed';
 import { useEffect, useRef, useState } from 'react';
 
 import HELPER from '@/helper';


### PR DESCRIPTION
Updates how the `jarvis-embed` dependency is managed in the frontend project. The main change is switching from using a GitHub-linked package to the new published NPM package under the `@ascending-inc` scope. This simplifies dependency management and ensures more reliable and maintainable builds.

**Dependency management improvements:**

* Replaced the `jarvis-embed` dependency (previously installed from GitHub) with the official NPM package `@ascending-inc/jarvis-embed` in both `package.json` and `package-lock.json`. 

**Code import updates:**

* Updated import statements in `McpPlaygroundModal.tsx` to use `@ascending-inc/jarvis-embed` instead of the old `jarvis-embed` package.