### PR TITLE
fix: Install NPM packages according to `package-lock.json`.

### DIFF
--- a/docker/Dockerfile.registry-frontend
+++ b/docker/Dockerfile.registry-frontend
@@ -3,8 +3,8 @@ FROM node:22-bookworm AS builder
 
 # Copy & build Frontend
 WORKDIR /app/frontend
-COPY frontend/package.json ./
-RUN npm install
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
 COPY frontend/ ./
 RUN npm run build
 


### PR DESCRIPTION
To avoid build time version resolution to the latest version available on NPM registry, thereby reducing supply chain attack surface.