### PR TITLE
feature/as-1535

### DIFF
--- a/auth-server/src/auth_server/core/config.py
+++ b/auth-server/src/auth_server/core/config.py
@@ -169,15 +169,34 @@ class AuthSettings(BaseSettings):
         This should be called once at application startup to initialize logging
         for all modules. Individual modules can then use logging.getLogger(__name__)
         without needing to call basicConfig again.
+
+        We set hanlders on two named loggers `auth_server` and `registry_pkgs` only.
+        This is to avoid the noises if we were to place the handler on the root logger.
         """
         # Convert string log level to numeric level
         numeric_level = getattr(logging, self.log_level.upper(), logging.INFO)
 
-        logging.basicConfig(
-            level=numeric_level,
-            format=self.log_format,
-            force=True,  # Override any existing configuration
-        )
+        auth_server_logger = logging.getLogger(__package__.split(".")[0])
+
+        auth_server_logger.setLevel(numeric_level)
+
+        if len(auth_server_logger.handlers) == 0:
+            handler = logging.StreamHandler()
+
+            handler.setFormatter(logging.Formatter(self.log_format))
+
+            auth_server_logger.addHandler(handler)
+
+        registry_pkgs_logger = logging.getLogger("registry_pkgs")
+
+        registry_pkgs_logger.setLevel(numeric_level)
+
+        if len(registry_pkgs_logger.handlers) == 0:
+            handler = logging.StreamHandler()
+
+            handler.setFormatter(logging.Formatter(self.log_format))
+
+            registry_pkgs_logger.addHandler(handler)
 
 
 # Global settings instance

--- a/auth-server/src/auth_server/core/config.py
+++ b/auth-server/src/auth_server/core/config.py
@@ -177,7 +177,7 @@ class AuthSettings(BaseSettings):
         numeric_level = getattr(logging, self.log_level.upper(), logging.INFO)
 
         auth_server_logger = logging.getLogger(__package__.split(".")[0])
-
+        auth_server_logger.propagate = False
         auth_server_logger.setLevel(numeric_level)
 
         if len(auth_server_logger.handlers) == 0:
@@ -188,7 +188,7 @@ class AuthSettings(BaseSettings):
             auth_server_logger.addHandler(handler)
 
         registry_pkgs_logger = logging.getLogger("registry_pkgs")
-
+        registry_pkgs_logger.propagate = False
         registry_pkgs_logger.setLevel(numeric_level)
 
         if len(registry_pkgs_logger.handlers) == 0:

--- a/auth-server/src/auth_server/server.py
+++ b/auth-server/src/auth_server/server.py
@@ -45,6 +45,11 @@ DEFAULT_TOKEN_LIFETIME_HOURS = settings.default_token_lifetime_hours
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application startup and shutdown lifecycle management."""
+
+    # Set the level on the root logger to WARNING to avoid noise. This must be done in the lifespan function
+    # because uvicorn does something about logging on start up.
+    logging.getLogger().setLevel(logging.WARNING)
+
     logger.info("🚀 Starting Auth Server...")
 
     try:

--- a/registry/src/registry/core/config.py
+++ b/registry/src/registry/core/config.py
@@ -346,8 +346,34 @@ class Settings(BaseSettings):
         return BackendConfig.from_vector_config(self.vector_config)
 
     def configure_logging(self) -> None:
+        """
+        We set hanlders on two named loggers `registry` and `registry_pkgs` only.
+        This is to avoid the noises if we were to place the handler on the root logger.
+        """
+
         numeric_level = getattr(logging, self.log_level.upper(), logging.INFO)
-        logging.basicConfig(level=numeric_level, format=self.log_format, force=True)
+
+        registry_logger = logging.getLogger(__package__.split(".")[0])
+
+        registry_logger.setLevel(numeric_level)
+
+        if len(registry_logger.handlers) == 0:
+            handler = logging.StreamHandler()
+
+            handler.setFormatter(logging.Formatter(self.log_format))
+
+            registry_logger.addHandler(handler)
+
+        registry_pkgs_logger = logging.getLogger("registry_pkgs")
+
+        registry_pkgs_logger.setLevel(numeric_level)
+
+        if len(registry_pkgs_logger.handlers) == 0:
+            handler = logging.StreamHandler()
+
+            handler.setFormatter(logging.Formatter(self.log_format))
+
+            registry_pkgs_logger.addHandler(handler)
 
     @cached_property
     def scopes_config(self) -> dict[str, Any]:

--- a/registry/src/registry/core/config.py
+++ b/registry/src/registry/core/config.py
@@ -354,7 +354,7 @@ class Settings(BaseSettings):
         numeric_level = getattr(logging, self.log_level.upper(), logging.INFO)
 
         registry_logger = logging.getLogger(__package__.split(".")[0])
-
+        registry_logger.propagate = False
         registry_logger.setLevel(numeric_level)
 
         if len(registry_logger.handlers) == 0:
@@ -365,7 +365,7 @@ class Settings(BaseSettings):
             registry_logger.addHandler(handler)
 
         registry_pkgs_logger = logging.getLogger("registry_pkgs")
-
+        registry_pkgs_logger.propagate = False
         registry_pkgs_logger.setLevel(numeric_level)
 
         if len(registry_pkgs_logger.handlers) == 0:

--- a/registry/src/registry/main.py
+++ b/registry/src/registry/main.py
@@ -6,7 +6,6 @@ import logging
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
-import uvicorn
 from fastapi import FastAPI
 
 from registry_pkgs.database import close_mongodb, init_mongodb
@@ -23,6 +22,8 @@ if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
 
     from .mcpgw.core.types import McpAppContext
+
+settings.configure_logging()
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +114,6 @@ async def _shutdown_container(app: FastAPI, resources: _RuntimeResources) -> Non
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Own the full application lifecycle around one app-scoped dependency container."""
-    settings.configure_logging()
     logger.info("Starting MCP Gateway Registry")
     resources = _RuntimeResources()
 
@@ -143,14 +143,3 @@ gateway_mcp_app = create_gateway_mcp_app(container_provider=_get_current_contain
 # The FastAPI app is exposed at module level so ASGI servers can import ``app``
 # directly while still keeping the startup and shutdown wiring in ``lifespan``.
 app = create_app(lifespan=lifespan, gateway_mcp_app=gateway_mcp_app)
-
-
-if __name__ == "__main__":
-    uvicorn.run(
-        "registry.main:app",
-        host="0.0.0.0",  # nosec B104 - it's fine to bind to 0.0.0.0 in a container.
-        port=7860,
-        reload=True,
-        log_level=settings.log_level.lower(),
-        log_config=None,  # Disable uvicorn's default logging config to use ours
-    )

--- a/registry/src/registry/main.py
+++ b/registry/src/registry/main.py
@@ -114,6 +114,11 @@ async def _shutdown_container(app: FastAPI, resources: _RuntimeResources) -> Non
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Own the full application lifecycle around one app-scoped dependency container."""
+
+    # Set the level on the root logger to WARNING to avoid noise. This must be done in the lifespan function
+    # because uvicorn does something about logging on start up.
+    logging.getLogger().setLevel(logging.WARNING)
+
     logger.info("Starting MCP Gateway Registry")
     resources = _RuntimeResources()
 

--- a/registry/src/registry/main.py
+++ b/registry/src/registry/main.py
@@ -24,8 +24,6 @@ if TYPE_CHECKING:
 
     from .mcpgw.core.types import McpAppContext
 
-settings.configure_logging()
-
 logger = logging.getLogger(__name__)
 
 app: FastAPI
@@ -148,9 +146,6 @@ app = create_app(lifespan=lifespan, gateway_mcp_app=gateway_mcp_app)
 
 
 if __name__ == "__main__":
-    # Configure logging before starting server
-    settings.configure_logging()
-
     uvicorn.run(
         "registry.main:app",
         host="0.0.0.0",  # nosec B104 - it's fine to bind to 0.0.0.0 in a container.

--- a/registry/src/registry/schemas/enums.py
+++ b/registry/src/registry/schemas/enums.py
@@ -47,6 +47,6 @@ class HealthStatus(StrEnum):
 class TokenType(StrEnum):
     """Token type enumeration"""
 
-    MCP_OAUTH = "mcp_oauth"  # Access token
+    MCP_OAUTH_ACCESS = "mcp_oauth"  # Access token (renamed from MCP_OAUTH, value unchanged for DB compatibility)
     MCP_OAUTH_REFRESH = "mcp_oauth_refresh"  # Refresh token
     MCP_OAUTH_CLIENT = "mcp_oauth_client"  # Client credentials (client_id, client_secret)

--- a/registry/src/registry/schemas/enums.py
+++ b/registry/src/registry/schemas/enums.py
@@ -47,6 +47,7 @@ class HealthStatus(StrEnum):
 class TokenType(StrEnum):
     """Token type enumeration"""
 
-    MCP_OAUTH_ACCESS = "mcp_oauth"  # Access token (renamed from MCP_OAUTH, value unchanged for DB compatibility)
+    MCP_OAUTH_ACCESS = "mcp_oauth"  # Access token (canonical name, value unchanged for DB compatibility)
+    MCP_OAUTH = MCP_OAUTH_ACCESS  # Deprecated: backward-compatible alias, use MCP_OAUTH_ACCESS instead
     MCP_OAUTH_REFRESH = "mcp_oauth_refresh"  # Refresh token
     MCP_OAUTH_CLIENT = "mcp_oauth_client"  # Client credentials (client_id, client_secret)

--- a/registry/src/registry/schemas/oauth_schema.py
+++ b/registry/src/registry/schemas/oauth_schema.py
@@ -26,6 +26,11 @@ class OAuthTokens(BaseModel):
             return int(time.time()) + info.data["expires_in"]
         return v
 
+    def model_post_init(self, __context: Any) -> None:
+        """Validate that at least one token (access or refresh) is present"""
+        if not self.access_token and not self.refresh_token:
+            raise ValueError("At least one of access_token or refresh_token must be provided")
+
 
 class OAuthClientInformation(BaseModel):
     """OAuth client information"""

--- a/registry/src/registry/schemas/oauth_schema.py
+++ b/registry/src/registry/schemas/oauth_schema.py
@@ -10,7 +10,7 @@ from .enums import OAuthFlowStatus
 class OAuthTokens(BaseModel):
     """OAuth tokens"""
 
-    access_token: str = Field(..., description="Access token")
+    access_token: str | None = Field(None, description="Access token (can be None if expired/deleted)")
     token_type: str = Field("Bearer", description="Token type")
     expires_in: int | None = Field(None, description="Expiration time (seconds)")
     refresh_token: str | None = Field(None, description="Refresh token")

--- a/registry/src/registry/services/oauth/token_service.py
+++ b/registry/src/registry/services/oauth/token_service.py
@@ -29,9 +29,16 @@ class TokenService:
         user = await self.get_user(user_id)
         return str(user.id)
 
-    def _get_client_identifier(self, service_name: str) -> str:
+    def _get_access_identifier(self, service_name: str) -> str:
         """Build access token identifier"""
         return f"mcp:{service_name}"
+
+    def _get_client_identifier(self, service_name: str) -> str:
+        """
+        Deprecated: Use _get_access_identifier instead.
+        This method is kept for backward compatibility.
+        """
+        return self._get_access_identifier(service_name)
 
     def _get_refresh_identifier(self, service_name: str) -> str:
         """Build refresh token identifier"""
@@ -41,22 +48,22 @@ class TokenService:
         """Build client credentials identifier"""
         return f"mcp:{service_name}:client"
 
-    async def store_oauth_client_token(
+    async def store_oauth_access_token(
         self, user_id: str, service_name: str, tokens: OAuthTokens, metadata: dict[str, Any] | None = None
     ) -> Token:
         """
-        Store OAuth client token (access token)
+        Store OAuth access token
 
         Args:
             user_id: User ID
-            service_name: Service name (e.g., notion, agentcore, etc.)
+            service_name: Service name (e.g., notion, github, etc.)
             tokens: OAuth tokens object
             metadata: Additional metadata (e.g., OAuth configuration)
 
         Returns:
             Created or updated Token document
         """
-        identifier = self._get_client_identifier(service_name)
+        identifier = self._get_access_identifier(service_name)
         user = await self.get_user(user_id)
         user_obj_id = str(user.id)
 
@@ -67,7 +74,7 @@ class TokenService:
         existing_token = await Token.find_one(
             {
                 "userId": PydanticObjectId(user_obj_id),
-                "type": TokenType.MCP_OAUTH.value,
+                "type": TokenType.MCP_OAUTH_ACCESS.value,
                 "identifier": identifier,
             }
         )
@@ -86,7 +93,7 @@ class TokenService:
             # Create new token
             token_doc = Token(
                 userId=PydanticObjectId(user_obj_id),
-                type=TokenType.MCP_OAUTH.value,
+                type=TokenType.MCP_OAUTH_ACCESS.value,
                 identifier=identifier,
                 token=tokens.access_token,
                 expiresAt=expires_at,
@@ -96,6 +103,15 @@ class TokenService:
             await token_doc.insert()
             logger.info(f"Created OAuth access token for user={user_id}, service={service_name}")
             return token_doc
+
+    async def store_oauth_client_token(
+        self, user_id: str, service_name: str, tokens: OAuthTokens, metadata: dict[str, Any] | None = None
+    ) -> Token:
+        """
+        Deprecated: Use store_oauth_access_token instead.
+        This method is kept for backward compatibility.
+        """
+        return await self.store_oauth_access_token(user_id, service_name, tokens, metadata)
 
     async def store_oauth_refresh_token(
         self, user_id: str, service_name: str, tokens: OAuthTokens, metadata: dict[str, Any] | None = None
@@ -170,11 +186,11 @@ class TokenService:
             metadata: Additional metadata (e.g., OAuth configuration)
 
         Returns:
-            Dictionary containing client and refresh tokens
+            Dictionary containing access and refresh tokens
         """
         try:
             # Store access token
-            client_token = await self.store_oauth_client_token(
+            access_token = await self.store_oauth_access_token(
                 user_id=user_id, service_name=service_name, tokens=tokens, metadata=metadata
             )
 
@@ -183,15 +199,15 @@ class TokenService:
                 user_id=user_id, service_name=service_name, tokens=tokens, metadata=metadata
             )
 
-            return {"client": client_token, "refresh": refresh_token}
+            return {"access": access_token, "refresh": refresh_token}
 
         except Exception as e:
             logger.error(f"Failed to store OAuth tokens: {e}", exc_info=True)
             raise
 
-    async def get_oauth_client_token(self, user_id: str, service_name: str) -> Token | None:
+    async def get_oauth_access_token(self, user_id: str, service_name: str) -> Token | None:
         """
-        Get OAuth client token
+        Get OAuth access token
 
         Args:
             user_id: User ID
@@ -200,13 +216,13 @@ class TokenService:
         Returns:
             Token document or None
         """
-        identifier = self._get_client_identifier(service_name)
+        identifier = self._get_access_identifier(service_name)
         user_obj_id = await self.get_user_by_user_id(user_id)
 
         token = await Token.find_one(
             {
                 "userId": PydanticObjectId(user_obj_id),
-                "type": TokenType.MCP_OAUTH.value,
+                "type": TokenType.MCP_OAUTH_ACCESS.value,
                 "identifier": identifier,
             }
         )
@@ -218,6 +234,13 @@ class TokenService:
             return None
 
         return token
+
+    async def get_oauth_client_token(self, user_id: str, service_name: str) -> Token | None:
+        """
+        Deprecated: Use get_oauth_access_token instead.
+        This method is kept for backward compatibility.
+        """
+        return await self.get_oauth_access_token(user_id, service_name)
 
     async def get_oauth_refresh_token(self, user_id: str, service_name: str) -> Token | None:
         """
@@ -257,22 +280,23 @@ class TokenService:
             service_name: Service name
 
         Returns:
-            OAuthTokens object or None
+            OAuthTokens object or None (only if both access and refresh tokens are missing)
         """
-        client_token = await self.get_oauth_client_token(user_id, service_name)
-
-        if not client_token:
-            return None
-
+        access_token = await self.get_oauth_access_token(user_id, service_name)
         refresh_token = await self.get_oauth_refresh_token(user_id, service_name)
 
+        # Return None only if both tokens are missing
+        if not access_token and not refresh_token:
+            return None
+
         # Convert to OAuthTokens object
+        # Even if access token is missing, we return the refresh token so it can be used to get a new access token
         return OAuthTokens(  # nosec B106 - "Bearer" is token type, not token value
-            access_token=client_token.token,
+            access_token=access_token.token if access_token else None,
             refresh_token=refresh_token.token if refresh_token else None,
             token_type="Bearer",
-            expires_in=self._calculate_expires_in(client_token.expiresAt),
-            expires_at=int(client_token.expiresAt.timestamp()) if client_token.expiresAt else None,
+            expires_in=self._calculate_expires_in(access_token.expiresAt) if access_token else 0,
+            expires_at=int(access_token.expiresAt.timestamp()) if access_token and access_token.expiresAt else None,
         )
 
     async def delete_oauth_tokens(self, user_id: str, service_name: str) -> bool:
@@ -288,13 +312,13 @@ class TokenService:
         """
         user_obj_id = await self.get_user_by_user_id(user_id)
 
-        # Delete access token (mcp_oauth)
-        client_identifier = self._get_client_identifier(service_name)
+        # Delete access token (mcp_oauth_access)
+        access_identifier = self._get_access_identifier(service_name)
         client_result = await Token.find_one(
             {
                 "userId": PydanticObjectId(user_obj_id),
-                "type": TokenType.MCP_OAUTH.value,
-                "identifier": client_identifier,
+                "type": TokenType.MCP_OAUTH_ACCESS.value,
+                "identifier": access_identifier,
             }
         )
 
@@ -391,12 +415,12 @@ class TokenService:
         Returns:
             True if expired/missing, False if valid
         """
-        client_token = await self.get_oauth_client_token(user_id, service_name)
+        access_token = await self.get_oauth_access_token(user_id, service_name)
 
-        if not client_token:
+        if not access_token:
             return True
 
-        return self._is_token_expired(client_token)
+        return self._is_token_expired(access_token)
 
     async def has_refresh_token(self, user_id: str, service_name: str) -> bool:
         """
@@ -421,13 +445,13 @@ class TokenService:
                 - token_doc: Token document or None if not exists
                 - is_valid: True if token exists and not expired, False otherwise
         """
-        identifier = self._get_client_identifier(service_name)
+        identifier = self._get_access_identifier(service_name)
         user_obj_id = await self.get_user_by_user_id(user_id)
 
         token = await Token.find_one(
             {
                 "userId": PydanticObjectId(user_obj_id),
-                "type": TokenType.MCP_OAUTH.value,
+                "type": TokenType.MCP_OAUTH_ACCESS.value,
                 "identifier": identifier,
             }
         )

--- a/registry/src/registry/services/oauth/token_service.py
+++ b/registry/src/registry/services/oauth/token_service.py
@@ -10,7 +10,7 @@ from registry_pkgs.models import IUser, Token
 from ...schemas.enums import TokenType
 from ...schemas.oauth_schema import OAuthClientInformation, OAuthTokens
 from ...services.user_service import UserService
-from ...utils.crypto_utils import decrypt_auth_fields, encrypt_value
+from ...utils.crypto_utils import decrypt_value, encrypt_value
 
 logger = logging.getLogger(__name__)
 
@@ -578,7 +578,7 @@ class TokenService:
         user_obj_id = str(user.id)
 
         # 1. Serialize client_info to JSON
-        client_info_json = json.dumps(client_info.dict())
+        client_info_json = json.dumps(client_info.model_dump())
 
         # 2. Encrypt the JSON directly (not using encrypt_auth_fields which only handles specific fields)
         encrypted = encrypt_value(client_info_json)
@@ -644,12 +644,12 @@ class TokenService:
             }
         )
 
-        if not token_doc:
+        if token_doc is None:
             logger.debug(f"No client credentials found for user={user_id}, service={service_name}")
             return None, None
 
         # Decrypt
-        decrypted = decrypt_auth_fields({"token": token_doc.token})["token"]
+        decrypted = decrypt_value(token_doc.token)
 
         # Parse JSON to OAuthClientInformation
         client_info_dict = json.loads(decrypted)

--- a/registry/src/registry/services/oauth/token_service.py
+++ b/registry/src/registry/services/oauth/token_service.py
@@ -62,7 +62,15 @@ class TokenService:
 
         Returns:
             Created or updated Token document
+
+        Raises:
+            ValueError: If tokens.access_token is None
         """
+        if not tokens.access_token:
+            raise ValueError(
+                f"Cannot store access token: access_token is missing for user={user_id}, service={service_name}"
+            )
+
         identifier = self._get_access_identifier(service_name)
         user = await self.get_user(user_id)
         user_obj_id = str(user.id)
@@ -295,7 +303,7 @@ class TokenService:
             access_token=access_token.token if access_token else None,
             refresh_token=refresh_token.token if refresh_token else None,
             token_type="Bearer",
-            expires_in=self._calculate_expires_in(access_token.expiresAt) if access_token else 0,
+            expires_in=self._calculate_expires_in(access_token.expiresAt) if access_token else None,
             expires_at=int(access_token.expiresAt.timestamp()) if access_token and access_token.expiresAt else None,
         )
 

--- a/registry/tests/unit/services/test_federation_sync_service.py
+++ b/registry/tests/unit/services/test_federation_sync_service.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -293,12 +294,18 @@ async def test_sync_vector_index_after_commit_logs_summary_when_nothing_to_rebui
     federation_sync_service._sync_mcp_vectors_for_runtime = AsyncMock()
     federation_sync_service._sync_a2a_vectors_for_runtime = AsyncMock()
 
-    with caplog.at_level("INFO"):
-        await federation_sync_service._sync_vector_index_after_commit(
-            federation=federation,
-            job=job,
-            mutation_result=mutation_result,
-        )
+    registry_logger = logging.getLogger("registry")
+    registry_logger.addHandler(caplog.handler)
+
+    try:
+        with caplog.at_level("INFO", logger="registry"):
+            await federation_sync_service._sync_vector_index_after_commit(
+                federation=federation,
+                job=job,
+                mutation_result=mutation_result,
+            )
+    finally:
+        registry_logger.removeHandler(caplog.handler)
 
     assert "Federation vector sync plan" in caplog.text
     assert "mcp_rebuild=0" in caplog.text

--- a/registry/tests/unit/services/test_token_service.py
+++ b/registry/tests/unit/services/test_token_service.py
@@ -583,7 +583,7 @@ class TestTokenServiceClientCredentials:
         service_name = "test_service"
 
         # Mock stored token with encrypted data
-        client_info_json = json.dumps(mock_client_info.dict())
+        client_info_json = json.dumps(mock_client_info.model_dump())
 
         mock_token = Mock(spec=Token)
         mock_token.token = "encrypted_iv:encrypted_ciphertext"
@@ -594,15 +594,15 @@ class TestTokenServiceClientCredentials:
             # Mock Token.find_one
             with patch.object(Token, "find_one", AsyncMock(return_value=mock_token)):
                 # Mock decrypt_auth_fields to return decrypted JSON
-                with patch("registry.services.oauth.token_service.decrypt_auth_fields") as mock_decrypt:
-                    mock_decrypt.return_value = {"token": client_info_json}
+                with patch("registry.services.oauth.token_service.decrypt_value") as mock_decrypt:
+                    mock_decrypt.return_value = client_info_json
 
                     client_info, metadata = await token_service.get_oauth_client_credentials(
                         user_id=user_id, service_name=service_name
                     )
 
                     # Verify decryption was called
-                    mock_decrypt.assert_called_once_with({"token": "encrypted_iv:encrypted_ciphertext"})
+                    mock_decrypt.assert_called_once_with(mock_token.token)
 
                     # Verify result
                     assert isinstance(client_info, OAuthClientInformation)

--- a/registry/tests/unit/services/test_token_service.py
+++ b/registry/tests/unit/services/test_token_service.py
@@ -264,7 +264,8 @@ class TestTokenServiceGetTokens:
                 assert isinstance(result, OAuthTokens)
                 assert result.access_token is None
                 assert result.refresh_token == "test_refresh_token"
-                assert result.expires_in == 0
+                assert result.expires_in is None
+                assert result.expires_at is None
 
 
 class TestTokenServiceDeleteTokens:

--- a/registry/tests/unit/services/test_token_service.py
+++ b/registry/tests/unit/services/test_token_service.py
@@ -114,7 +114,7 @@ class TestTokenServiceStoreTokens:
     async def test_store_oauth_client_token_new(self, token_service, mock_user, mock_oauth_tokens):
         """Test storing new access token"""
         mock_token = Mock(spec=Token)
-        mock_token.type = TokenType.MCP_OAUTH.value
+        mock_token.type = TokenType.MCP_OAUTH_ACCESS.value
         mock_token.identifier = "mcp:notion"
         mock_token.token = "test_access_token"
         mock_token.insert = AsyncMock()
@@ -178,7 +178,7 @@ class TestTokenServiceStoreTokens:
     @pytest.mark.asyncio
     async def test_store_oauth_tokens(self, token_service, mock_user, mock_oauth_tokens):
         """Test storing complete OAuth tokens (access + refresh)"""
-        with patch.object(token_service, "store_oauth_client_token", AsyncMock()) as mock_client:
+        with patch.object(token_service, "store_oauth_access_token", AsyncMock()) as mock_access:
             with patch.object(token_service, "store_oauth_refresh_token", AsyncMock()) as mock_refresh:
                 await token_service.store_oauth_tokens(
                     user_id="test_user",
@@ -186,7 +186,7 @@ class TestTokenServiceStoreTokens:
                     tokens=mock_oauth_tokens,
                 )
 
-                mock_client.assert_awaited_once()
+                mock_access.assert_awaited_once()
                 mock_refresh.assert_awaited_once()
 
 
@@ -204,7 +204,7 @@ class TestTokenServiceGetTokens:
         token = Mock(spec=Token)
         token.token = "test_access_token"
         token.expiresAt = datetime.now(UTC) + timedelta(hours=1)
-        token.type = TokenType.MCP_OAUTH.value
+        token.type = TokenType.MCP_OAUTH_ACCESS.value
         return token
 
     @pytest.fixture
@@ -237,7 +237,7 @@ class TestTokenServiceGetTokens:
     @pytest.mark.asyncio
     async def test_get_oauth_tokens(self, token_service, mock_access_token, mock_refresh_token):
         """Test retrieving complete OAuth tokens as OAuthTokens object"""
-        with patch.object(token_service, "get_oauth_client_token", AsyncMock(return_value=mock_access_token)):
+        with patch.object(token_service, "get_oauth_access_token", AsyncMock(return_value=mock_access_token)):
             with patch.object(token_service, "get_oauth_refresh_token", AsyncMock(return_value=mock_refresh_token)):
                 result = await token_service.get_oauth_tokens("test_user", "notion")
 
@@ -246,12 +246,25 @@ class TestTokenServiceGetTokens:
                 assert result.refresh_token == "test_refresh_token"
 
     @pytest.mark.asyncio
-    async def test_get_oauth_tokens_no_access_token(self, token_service):
-        """Test get_oauth_tokens returns None when no access token"""
-        with patch.object(token_service, "get_oauth_client_token", AsyncMock(return_value=None)):
-            result = await token_service.get_oauth_tokens("test_user", "notion")
+    async def test_get_oauth_tokens_no_tokens(self, token_service):
+        """Test get_oauth_tokens returns None when both access and refresh tokens are missing"""
+        with patch.object(token_service, "get_oauth_access_token", AsyncMock(return_value=None)):
+            with patch.object(token_service, "get_oauth_refresh_token", AsyncMock(return_value=None)):
+                result = await token_service.get_oauth_tokens("test_user", "notion")
 
-            assert result is None
+                assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_tokens_only_refresh_token(self, token_service, mock_refresh_token):
+        """Test get_oauth_tokens returns OAuthTokens with only refresh token when access token is missing"""
+        with patch.object(token_service, "get_oauth_access_token", AsyncMock(return_value=None)):
+            with patch.object(token_service, "get_oauth_refresh_token", AsyncMock(return_value=mock_refresh_token)):
+                result = await token_service.get_oauth_tokens("test_user", "notion")
+
+                assert isinstance(result, OAuthTokens)
+                assert result.access_token is None
+                assert result.refresh_token == "test_refresh_token"
+                assert result.expires_in == 0
 
 
 class TestTokenServiceDeleteTokens:
@@ -276,7 +289,7 @@ class TestTokenServiceDeleteTokens:
 
             async def mock_find_one(query):
                 token_type = query.get("type")
-                if token_type == TokenType.MCP_OAUTH.value:
+                if token_type == TokenType.MCP_OAUTH_ACCESS.value:
                     return access_token
                 elif token_type == TokenType.MCP_OAUTH_REFRESH.value:
                     return refresh_token
@@ -316,7 +329,7 @@ class TestTokenServiceTokenStatus:
         expired_token = Mock(spec=Token)
         expired_token.expiresAt = datetime.now(UTC) - timedelta(hours=1)
 
-        with patch.object(token_service, "get_oauth_client_token", AsyncMock(return_value=expired_token)):
+        with patch.object(token_service, "get_oauth_access_token", AsyncMock(return_value=expired_token)):
             result = await token_service.is_access_token_expired("test_user", "notion")
 
             assert result is True
@@ -327,7 +340,7 @@ class TestTokenServiceTokenStatus:
         valid_token = Mock(spec=Token)
         valid_token.expiresAt = datetime.now(UTC) + timedelta(hours=1)
 
-        with patch.object(token_service, "get_oauth_client_token", AsyncMock(return_value=valid_token)):
+        with patch.object(token_service, "get_oauth_access_token", AsyncMock(return_value=valid_token)):
             result = await token_service.is_access_token_expired("test_user", "notion")
 
             assert result is False
@@ -642,7 +655,7 @@ class TestTokenServiceClientCredentials:
             # Mock Token.find_one to return all three token types
             async def mock_find_one(query):
                 token_type = query.get("type")
-                if token_type == TokenType.MCP_OAUTH.value:
+                if token_type == TokenType.MCP_OAUTH_ACCESS.value:
                     return access_token
                 elif token_type == TokenType.MCP_OAUTH_REFRESH.value:
                     return refresh_token


### PR DESCRIPTION
Fix OAuth refresh token not retrieved when access token is deleted by TTL

Modified get_oauth_tokens() to return refresh token even when access 
token is missing, fixing daily re-auth issue caused by MongoDB TTL 
deletion. Renamed TokenType.MCP_OAUTH to MCP_OAUTH_ACCESS and updated 
related methods for clarity while maintaining backward compatibility.