### PR TITLE
feat: add config field and refactor A2A agent data structure

### DIFF
--- a/.github/prompts/registry.prompt.md
+++ b/.github/prompts/registry.prompt.md
@@ -1,0 +1,64 @@
+---
+alwaysApply: true
+---
+This MCP Gateway provides unified access to registered MCP servers through centralized discovery and execution.
+
+KEY CAPABILITIES:
+- Discover tools, resources, prompts, or full server documents across registered MCP servers
+- Execute downstream MCP tools through a unified proxy
+- Access downstream resources and prompts through the same registry
+- Route requests with the server's configured authentication and connection settings
+
+GLOBAL WORKFLOW RULES:
+1. If you do not already have a suitable tool for the user's request, call `discover_servers` first.
+2. Do not respond that you lack capability until you have attempted discovery.
+3. If a native fetch or direct access attempt fails with authentication, permission, or access errors, fall back to `discover_servers`.
+4. Prefer `type_list=["tool"]` first. Use `type_list=["server"]` only when you need a full server document to inspect all capabilities on that server.
+
+AUTHENTICATION ELICITATION RULES:
+- If `execute_tool` returns an authentication challenge, OAuth URL, or elicitation request, do NOT fall back to `discover_servers`. The server and tool are already known.
+- Inform the user that authentication is required and present the auth URL or prompt if provided by the tool response.
+- Wait for the user to confirm they have completed authentication (e.g., "done", "authenticated", "completed").
+- After confirmation, immediately retry `execute_tool` with the exact same `tool_name`, `server_id`, and `arguments` as before — do not re-discover.
+- Only fall back to `discover_servers` on auth failure if you do not already have a valid `server_id` and `tool_name`.
+
+WHEN TO FALL BACK TO DISCOVERY:
+- Private repository or API access fails
+- Authentication or authorization fails (401, 403, permission denied) AND you do not already have a `server_id` and `tool_name` — if you do, retry `execute_tool` directly after auth completes (see AUTHENTICATION ELICITATION RULES)
+- A specialized external service is likely needed
+- The user asks what capabilities exist for a domain or service
+
+TOKEN-EFFICIENT DISCOVERY:
+- `type_list=["tool"]`: default and preferred for executable tools
+- `type_list=["resource"]`: for data sources or URIs
+- `type_list=["prompt"]`: for reusable prompt workflows
+- `type_list=["server"]`: only when you need the full Mongo-style server document
+
+CRITICAL RESULT INTERPRETATION RULE:
+- Treat discovery results as full server documents only when `type_list` is exactly `["server"]`.
+- In every other case, including `type_list=["tool"]`, treat each returned item as a directly usable result for execution purposes.
+
+EXECUTION RULES:
+- `execute_tool` always runs exactly one downstream MCP tool.
+- The `tool_name` parameter of the `execute_tool` call must always be the final downstream MCP tool name.
+- If the previous discovery call used exactly `type_list=["server"]`, first inspect the `$.config.toolFunctions` field of the server document, choose one tool entry, and pass that chosen entry's `mcpToolName` as `tool_name`. Only if `mcpToolName` is missing may you fall back to that tool entry's key or name.
+- In every other discovery case, pass the returned `tool_name` unchanged into the `tool_name` parameter of the `execute_tool` call.
+- Pair the chosen `tool_name` with the matching `server_id` from the same discovery result or chosen server document.
+
+EXAMPLES:
+- Weather or current events → `discover_servers(query="weather forecast", type_list=["tool"])`
+- Web search → `discover_servers(query="web search news", type_list=["tool"])`
+- Stock prices → `discover_servers(query="financial data stock market", type_list=["tool"])`
+- Explore full capabilities of a server domain → `discover_servers(query="github", type_list=["server"])`
+- Access failure on a protected service → `discover_servers(query="<service> authenticated", type_list=["tool"])`
+
+SERVER-DOCUMENT EXAMPLE:
+- If `discover_servers(..., type_list=["server"])` returns a server whose `$.config.toolFunctions` contains:
+  - `add_numbers_mcp_minimal_mcp_iam -> mcpToolName="add_numbers"`
+  - `greet_mcp_minimal_mcp_iam -> mcpToolName="greet"`
+- Then first choose the single tool entry that matches the task.
+- To execute the add tool, call `execute_tool(tool_name="add_numbers", server_id="<server id>", arguments={...})`.
+- To execute the greet tool, call `execute_tool(tool_name="greet", server_id="<server id>", arguments={...})`.
+
+TOOL-RESULT EXAMPLE:
+- If discovery returns `{"tool_name": "tavily_search", "server_id": "abc123", ...}`, call `execute_tool(tool_name="tavily_search", server_id="abc123", arguments={...})`.

--- a/docs/design/a2a-agent-api-design.md
+++ b/docs/design/a2a-agent-api-design.md
@@ -59,6 +59,11 @@
       ],
       "enabled": true,
       "status": "active",
+      "config": {
+        "title": "Code Review Agent",
+        "description": "AI-powered code review assistant",
+        "type": "jsonrpc"
+      },
       "permissions": {
         "VIEW": true,
         "EDIT": true,
@@ -82,6 +87,7 @@
 **Note:**
 - Uses `AgentListItem` schema for list items
 - All field names use camelCase convention
+- Each agent includes `config` field with user-provided metadata
 
 ---
 
@@ -159,6 +165,11 @@
   "tags": ["code", "review"],
   "status": "active",
   "enabled": true,
+  "config": {
+    "title": "Code Review Agent",
+    "description": "AI-powered code review assistant",
+    "type": "jsonrpc"
+  },
   "permissions": {
     "VIEW": true,
     "EDIT": true,
@@ -181,6 +192,7 @@
 **Note:**
 - Uses `AgentDetailResponse` schema
 - All field names use camelCase convention
+- Includes `config` field with user-provided metadata
 
 **Error**: `404` Agent not found, `403` Access denied
 
@@ -190,29 +202,35 @@
 
 **Endpoint**: `POST /api/v1/agents`
 
-**Description**: Register a new A2A agent. Only 4 fields are required in the request body. All other agent information (version, capabilities, skills, etc.) is automatically fetched from the agent's `.well-known/agent-card.json` endpoint using the A2A SDK.
+**Description**: Register a new A2A agent. Only 5 fields are required in the request body. All other agent information (version, capabilities, skills, etc.) is automatically fetched from the agent's `.well-known/agent-card.json` endpoint using the A2A SDK. The fetched agent card is stored as-is without modification in the `card` field.
 
 **Request Body**:
 ```json
 {
   "path": "/code-reviewer",
-  "name": "Code Review Agent",
+  "title": "Code Review Agent",
   "description": "AI-powered code review assistant",
-  "url": "https://example.com/agents/code-reviewer"
+  "url": "https://example.com/agents/code-reviewer",
+  "type": "jsonrpc"
 }
 ```
 
 **Request Fields**:
 - `path` (required, string): Unique registry path identifier (e.g., `/code-reviewer`)
-- `name` (required, string): Display name for the agent in the registry
-- `description` (optional, string): Description of the agent for the registry
+- `title` (required, string): Display title for the agent in the registry (stored in `config.title`)
+- `description` (optional, string): Description of the agent for the registry (stored in `config.description`)
 - `url` (required, string): Agent endpoint URL - the agent card will be automatically fetched from `{url}/.well-known/agent-card.json`
+- `type` (required, string): Transport type - must be one of: `jsonrpc`, `grpc`, `http_json`
+
+**Data Storage Structure**:
+- `card`: Original agent card from third-party URL (unmodified)
+- `config`: Registry-specific configuration containing user-provided `title`, `description`, and `type`
 
 **Auto-Fetch Behavior**:
 1. System fetches agent card from `{url}/.well-known/agent-card.json` using A2A SDK
 2. Validates the fetched agent card structure
-3. Uses fetched data for: `version`, `protocolVersion`, `capabilities`, `skills`, `securitySchemes`, `preferredTransport`, `defaultInputModes`, `defaultOutputModes`, `provider`
-4. Overrides `name` and `description` with values from request if provided
+3. **Stores the original card data without any modifications in the `card` field**
+4. User-provided `title`, `description`, and `type` are stored separately in the `config` field
 5. Enables wellKnown sync automatically for future updates
 6. **Tags field**: Initialized as empty array `[]` - tags are registry-level metadata separate from skill tags, and can be managed manually if needed
 
@@ -242,6 +260,11 @@
   "tags": [],
   "status": "active",
   "enabled": false,
+  "config": {
+    "title": "Code Review Agent",
+    "description": "AI-powered code review assistant",
+    "type": "jsonrpc"
+  },
   "permissions": {
     "VIEW": true,
     "EDIT": true,
@@ -266,10 +289,11 @@
 - Automatically grants OWNER permission to creator
 - ACL resource type is `ResourceType.AGENT`
 - Agent is created with `enabled: false` by default for safety
-- All agent metadata is auto-fetched from the provided URL
+- All agent metadata is auto-fetched from the provided URL and stored in `card` field without modification
+- User-provided configuration is stored separately in `config` field
 
 **Error**:
-- `400` Validation error or failed to fetch agent card from URL
+- `400` Validation error, invalid transport type, or failed to fetch agent card from URL
 - `409` Path already exists
 
 ---
@@ -278,40 +302,47 @@
 
 **Endpoint**: `PATCH /api/v1/agents/{agent_id}`
 
-**Description**: Update an existing agent. Only 4 fields can be updated via this endpoint. When the `url` field is updated, all other agent information is automatically fetched from the new URL's `.well-known/agent-card.json` endpoint.
+**Description**: Update an existing agent. Multiple fields can be updated via this endpoint. When the `url` field is updated, all other agent information is automatically fetched from the new URL's `.well-known/agent-card.json` endpoint and stored as-is in the `card` field.
 
 **Request Body** (all fields optional):
 ```json
 {
   "path": "/new-code-reviewer",
-  "name": "Updated Agent Name",
+  "title": "Updated Agent Name",
   "description": "Updated description",
-  "url": "https://example.com/agents/new-code-reviewer"
+  "url": "https://example.com/agents/new-code-reviewer",
+  "type": "grpc",
+  "enabled": true
 }
 ```
 
 **Request Fields** (all optional):
 - `path` (string): Update the registry path
-- `name` (string): Update the display name
-- `description` (string): Update the description
+- `title` (string): Update the display title (stored in `config.title`)
+- `description` (string): Update the description (stored in `config.description`)
 - `url` (string): Update the agent endpoint URL
+- `type` (string): Update the transport type - must be one of: `jsonrpc`, `grpc`, `http_json`
+- `enabled` (boolean): Update the enabled state
 
 **Auto-Fetch Behavior**:
 1. **If `url` is updated**:
    - System fetches new agent card from `{new_url}/.well-known/agent-card.json`
-   - All card fields (version, capabilities, skills, etc.) are updated from fetched data
-   - `name` and `description` from request override the fetched values if provided
-   - Tags are re-extracted from new skills
+   - **Stores the original card data without any modifications in the `card` field**
+   - User-provided fields (`title`, `description`, `type`) are updated in the `config` field separately
    - wellKnown sync is updated with new URL and sync status
 
-2. **If only `name` or `description` is updated** (no URL change):
-   - Only these fields are updated in the existing agent card
+2. **If only `title`, `description`, or `type` is updated** (no URL change):
+   - Only these fields are updated in the `config` field
    - No agent card re-fetch occurs
-   - Other fields remain unchanged
+   - The `card` field remains unchanged
 
 3. **If only `path` is updated**:
    - Registry path is updated (must be unique)
-   - Agent card remains unchanged
+   - Agent card and config remain unchanged
+
+4. **If only `enabled` is updated**:
+   - Agent enabled state is toggled
+   - No other fields are changed
 
 **Response**: `200 OK`
 ```json
@@ -333,6 +364,11 @@
   "tags": ["new", "tags"],
   "status": "active",
   "enabled": true,
+  "config": {
+    "title": "Updated Agent Name",
+    "description": "Updated description",
+    "type": "grpc"
+  },
   "permissions": {
     "VIEW": true,
     "EDIT": true,
@@ -355,10 +391,11 @@
 **Note:**
 - Uses `AgentDetailResponse` schema (not a separate update response)
 - Returns complete agent details after update
-- If URL is changed, automatically re-fetches all agent metadata from new URL
+- If URL is changed, automatically re-fetches all agent metadata from new URL and stores in `card` field
+- User-provided configuration is stored separately in `config` field
 
 **Error**:
-- `400` Validation error or failed to fetch agent card from new URL
+- `400` Validation error, invalid transport type, or failed to fetch agent card from new URL
 - `404` Agent not found
 - `403` Access denied
 - `409` New path conflicts with existing agent
@@ -412,6 +449,11 @@
   "tags": ["code", "review"],
   "status": "active",
   "enabled": true,
+  "config": {
+    "title": "Code Review Agent",
+    "description": "AI-powered code review assistant",
+    "type": "jsonrpc"
+  },
   "permissions": {
     "VIEW": true,
     "EDIT": true,
@@ -428,6 +470,7 @@
 **Note:**
 - Uses `AgentDetailResponse` schema (not a separate toggle response)
 - Returns complete agent details after toggle
+- Includes `config` field with user-provided metadata
 
 **Error**: `404` Agent not found, `403` Access denied
 

--- a/docs/design/a2a-agent-api-design.md
+++ b/docs/design/a2a-agent-api-design.md
@@ -287,7 +287,7 @@
 **Note:**
 - Uses `AgentDetailResponse` schema (not a separate create response)
 - Automatically grants OWNER permission to creator
-- ACL resource type is `ResourceType.AGENT`
+- ACL resource type is `ResourceType.REMOTE_AGENT`
 - Agent is created with `enabled: false` by default for safety
 - All agent metadata is auto-fetched from the provided URL and stored in `card` field without modification
 - User-provided configuration is stored separately in `config` field

--- a/registry-pkgs/src/registry_pkgs/models/a2a_agent.py
+++ b/registry-pkgs/src/registry_pkgs/models/a2a_agent.py
@@ -386,12 +386,6 @@ class A2AAgent(Document):
         if not isinstance(config, AgentConfig):
             raise ValueError("'config' must be an AgentConfig instance")
 
-        # Validate transport type
-        if config.type not in VALID_TRANSPORT_TYPES:
-            raise ValueError(
-                f"Invalid transport type '{config.type}'. Must be one of: {', '.join(sorted(VALID_TRANSPORT_TYPES))}"
-            )
-
         # Create MongoDB document
         return cls(
             path=path,

--- a/registry-pkgs/src/registry_pkgs/models/a2a_agent.py
+++ b/registry-pkgs/src/registry_pkgs/models/a2a_agent.py
@@ -141,7 +141,9 @@ class A2AAgent(Document):
     card: AgentCard = Field(description="A2A protocol-compliant agent card (validated by SDK, unmodified)")
 
     # ========== Registry-specific Configuration ==========
-    config: AgentConfig = Field(description="User-provided agent configuration (name, description, transport type)")
+    config: AgentConfig | None = Field(
+        default=None, description="User-provided agent configuration (title, description, transport type)"
+    )
 
     # ========== Registry Metadata ==========
     tags: list[str] = Field(default_factory=list, description="Registry categorization tags")
@@ -198,11 +200,18 @@ class A2AAgent(Document):
         Returns:
             Combined text representation of agent for embedding
         """
+        # Backward compatibility: if config is None, use card data
+        title = self.config.title if self.config else self.card.name
+        description = self.config.description if self.config else self.card.description
+        transport = self.config.type if self.config else "unknown"
+
         parts = [
-            f"Title: {self.config.title}",
-            f"Description: {self.config.description}",
+            f"Title: {title}",
+            f"Card Name: {self.card.name}",
+            f"Description: {description}",
+            f"Card Description: {self.card.description}",
             f"Path: {self.path}",
-            f"Transport: {self.config.type}",
+            f"Transport: {transport}",
         ]
 
         # Add skill information
@@ -234,10 +243,13 @@ class A2AAgent(Document):
         - N skill documents (one per skill)
         """
         agent_id = str(self.id) if self.id else None
+        # Backward compatibility: if config is None, use card data
+        agent_name = self.config.title if self.config else self.card.name
+
         base_metadata = {
             "collection": self.COLLECTION_NAME,
             "agent_id": agent_id,
-            "agent_title": self.config.title,
+            "agent_name": agent_name,  # Keep key stable for backward compatibility
             "path": self.path,
             "status": self.status,
             "is_enabled": self.isEnabled,
@@ -268,8 +280,10 @@ class A2AAgent(Document):
             skill_name = getattr(skill, "name", "") or ""
             skill_desc = getattr(skill, "description", "") or ""
             skill_tags = getattr(skill, "tags", None) or []
+            # Backward compatibility: if config is None, use card data
+            agent_display_name = self.config.title if self.config else self.card.name
             content = (
-                f"Agent: {self.config.title}\n"
+                f"Agent: {agent_display_name}\n"
                 f"Skill: {skill_name}\n"
                 f"Description: {skill_desc}\n"
                 f"Tags: {', '.join(skill_tags)}"
@@ -337,7 +351,7 @@ class A2AAgent(Document):
             path: Registry path (required, e.g., /deep-intel)
             **registry_fields: Additional registry metadata such as:
                 - author: User ID who created this agent (required for ACL)
-                - config: AgentConfig with name, description, type (required)
+                - config: AgentConfig with title, description, type (required; registry display metadata, distinct from the protocol card `name`)
                 - isEnabled: Enabled state (default: False)
                 - registeredBy: Username or service account
                 - tags: List of tags
@@ -375,7 +389,7 @@ class A2AAgent(Document):
         # Validate transport type
         if config.type not in VALID_TRANSPORT_TYPES:
             raise ValueError(
-                f"Invalid transport type '{config.type}'. Must be one of: {', '.join(VALID_TRANSPORT_TYPES)}"
+                f"Invalid transport type '{config.type}'. Must be one of: {', '.join(sorted(VALID_TRANSPORT_TYPES))}"
             )
 
         # Create MongoDB document

--- a/registry-pkgs/src/registry_pkgs/models/a2a_agent.py
+++ b/registry-pkgs/src/registry_pkgs/models/a2a_agent.py
@@ -11,7 +11,7 @@ Storage Structure:
   # Registry-specific Fields
   "path": "/deep-intel",  # Registry path (not part of SDK AgentCard)
 
-  # A2A Protocol Card (validated by SDK)
+  # A2A Protocol Card (validated by SDK - ORIGINAL DATA, DO NOT MODIFY)
   "card": {
     "name": "Deep Intel Agent",
     "description": "Orchestrates AWS research and BI into full report",
@@ -25,6 +25,13 @@ Storage Structure:
     "defaultInputModes": ["text/plain"],
     "defaultOutputModes": ["application/json"],
     "provider": {"organization": "Strands AI", "url": "https://..."}
+  },
+
+  # Registry-specific Configuration (user-provided metadata)
+  "config": {
+    "title": "My Custom Agent Name",  # User-provided display title
+    "description": "My custom description",  # User-provided description
+    "type": "jsonrpc"  # Transport type: jsonrpc, grpc, http_json
   },
 
   # Registry Metadata
@@ -69,8 +76,24 @@ STATUS_INACTIVE = "inactive"
 STATUS_ERROR = "error"
 VALID_STATUSES: set[str] = {STATUS_ACTIVE, STATUS_INACTIVE, STATUS_ERROR}
 
+# Transport Type Values
+TRANSPORT_JSONRPC = "jsonrpc"
+TRANSPORT_GRPC = "grpc"
+TRANSPORT_HTTP_JSON = "http_json"
+VALID_TRANSPORT_TYPES: set[str] = {TRANSPORT_JSONRPC, TRANSPORT_GRPC, TRANSPORT_HTTP_JSON}
+
 
 # ========== Registry-Specific Models ==========
+
+
+class AgentConfig(BaseModel):
+    """Registry-specific agent configuration (user-provided metadata)."""
+
+    title: str = Field(description="User-provided display title for the agent")
+    description: str = Field(default="", description="User-provided description of the agent")
+    type: str = Field(description="Transport type: jsonrpc, grpc, http_json")
+
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class WellKnownConfig(BaseModel):
@@ -114,8 +137,11 @@ class A2AAgent(Document):
     # ========== Registry-specific Fields ==========
     path: str = Field(..., description="Registry path (e.g., /deep-intel)")
 
-    # ========== A2A Protocol Card (SDK) ==========
-    card: AgentCard = Field(description="A2A protocol-compliant agent card (validated by SDK)")
+    # ========== A2A Protocol Card (SDK - ORIGINAL DATA) ==========
+    card: AgentCard = Field(description="A2A protocol-compliant agent card (validated by SDK, unmodified)")
+
+    # ========== Registry-specific Configuration ==========
+    config: AgentConfig = Field(description="User-provided agent configuration (name, description, transport type)")
 
     # ========== Registry Metadata ==========
     tags: list[str] = Field(default_factory=list, description="Registry categorization tags")
@@ -173,9 +199,10 @@ class A2AAgent(Document):
             Combined text representation of agent for embedding
         """
         parts = [
-            f"Name: {self.card.name}",
-            f"Description: {self.card.description}",
+            f"Title: {self.config.title}",
+            f"Description: {self.config.description}",
             f"Path: {self.path}",
+            f"Transport: {self.config.type}",
         ]
 
         # Add skill information
@@ -210,7 +237,7 @@ class A2AAgent(Document):
         base_metadata = {
             "collection": self.COLLECTION_NAME,
             "agent_id": agent_id,
-            "agent_name": self.card.name,
+            "agent_title": self.config.title,
             "path": self.path,
             "status": self.status,
             "is_enabled": self.isEnabled,
@@ -242,7 +269,7 @@ class A2AAgent(Document):
             skill_desc = getattr(skill, "description", "") or ""
             skill_tags = getattr(skill, "tags", None) or []
             content = (
-                f"Agent: {self.card.name}\n"
+                f"Agent: {self.config.title}\n"
                 f"Skill: {skill_name}\n"
                 f"Description: {skill_desc}\n"
                 f"Tags: {', '.join(skill_tags)}"
@@ -310,6 +337,7 @@ class A2AAgent(Document):
             path: Registry path (required, e.g., /deep-intel)
             **registry_fields: Additional registry metadata such as:
                 - author: User ID who created this agent (required for ACL)
+                - config: AgentConfig with name, description, type (required)
                 - isEnabled: Enabled state (default: False)
                 - registeredBy: Username or service account
                 - tags: List of tags
@@ -318,7 +346,7 @@ class A2AAgent(Document):
             A2AAgent instance
 
         Raises:
-            ValueError: If validation fails or author/path field is missing
+            ValueError: If validation fails or author/path/config field is missing
         """
         # Validate required registry fields
         if "author" not in registry_fields:
@@ -326,6 +354,9 @@ class A2AAgent(Document):
 
         if not path:
             raise ValueError("'path' is required for registry agent")
+
+        if "config" not in registry_fields:
+            raise ValueError("'config' field is required in registry_fields")
 
         # Remove path from card_data if it exists (SDK doesn't support it)
         card_data_clean = {k: v for k, v in card_data.items() if k != "path"}
@@ -336,10 +367,22 @@ class A2AAgent(Document):
         except Exception as e:
             raise ValueError(f"Invalid A2A agent card: {str(e)}")
 
+        # Validate config
+        config = registry_fields["config"]
+        if not isinstance(config, AgentConfig):
+            raise ValueError("'config' must be an AgentConfig instance")
+
+        # Validate transport type
+        if config.type not in VALID_TRANSPORT_TYPES:
+            raise ValueError(
+                f"Invalid transport type '{config.type}'. Must be one of: {', '.join(VALID_TRANSPORT_TYPES)}"
+            )
+
         # Create MongoDB document
         return cls(
             path=path,
             card=agent_card,
+            config=config,
             author=registry_fields["author"],
             isEnabled=registry_fields.get("isEnabled", False),
             tags=registry_fields.get("tags", []),
@@ -384,9 +427,14 @@ __all__ = [
     "AgentCard",
     "AgentSkill",
     "AgentProvider",
+    "AgentConfig",
     "WellKnownConfig",
     "STATUS_ACTIVE",
     "STATUS_INACTIVE",
     "STATUS_ERROR",
     "VALID_STATUSES",
+    "TRANSPORT_JSONRPC",
+    "TRANSPORT_GRPC",
+    "TRANSPORT_HTTP_JSON",
+    "VALID_TRANSPORT_TYPES",
 ]

--- a/registry-pkgs/tests/unit/test_models.py
+++ b/registry-pkgs/tests/unit/test_models.py
@@ -300,6 +300,8 @@ class TestExtendedMCPServerStructure:
         assert "original_mcp_name" not in result
 
     def test_a2a_to_documents_includes_runtime_version_metadata(self):
+        from registry_pkgs.models.a2a_agent import AgentConfig
+
         agent = A2AAgent.model_construct(
             id=PydanticObjectId(),
             path="/agentcore/a2a/versioned-agent",
@@ -312,6 +314,11 @@ class TestExtendedMCPServerStructure:
                 defaultInputModes=["text/plain"],
                 defaultOutputModes=["application/json"],
                 skills=[],
+            ),
+            config=AgentConfig(
+                title="Versioned Agent",
+                description="A test A2A agent",
+                type="jsonrpc",
             ),
             tags=["agentcore"],
             status="active",

--- a/registry/src/registry/schemas/a2a_agent_api_schemas.py
+++ b/registry/src/registry/schemas/a2a_agent_api_schemas.py
@@ -82,7 +82,7 @@ class AgentCreateRequest(APIBaseModel):
 
     path: str = Field(description="Registry path (e.g., /code-reviewer)")
     title: str = Field(description="Agent title")
-    description: str = Field(default="", description="Agent description")
+    description: str | None = Field(None, description="Agent description")
     url: HttpUrl | str = Field(description="Agent endpoint URL - agent card will be fetched from this URL")
     type: str = Field(description="Transport type: jsonrpc, grpc, http_json")
 

--- a/registry/src/registry/schemas/a2a_agent_api_schemas.py
+++ b/registry/src/registry/schemas/a2a_agent_api_schemas.py
@@ -18,6 +18,14 @@ from .case_conversion import APIBaseModel
 # ==================== Nested Models ====================
 
 
+class AgentConfigOutput(APIBaseModel):
+    """Output schema for agent configuration"""
+
+    title: str
+    description: str
+    type: str
+
+
 class AgentSkillInput(APIBaseModel):
     """Input schema for agent skill"""
 
@@ -70,21 +78,24 @@ class WellKnownInfo(APIBaseModel):
 
 
 class AgentCreateRequest(APIBaseModel):
-    """Request schema for creating a new agent - only 4 required fields, other info auto-fetched from URL"""
+    """Request schema for creating a new agent - only 5 required fields, other info auto-fetched from URL"""
 
     path: str = Field(description="Registry path (e.g., /code-reviewer)")
-    name: str = Field(description="Agent name")
+    title: str = Field(description="Agent title")
     description: str = Field(default="", description="Agent description")
     url: HttpUrl | str = Field(description="Agent endpoint URL - agent card will be fetched from this URL")
+    type: str = Field(description="Transport type: jsonrpc, grpc, http_json")
 
 
 class AgentUpdateRequest(APIBaseModel):
-    """Request schema for updating an agent - only 4 fields supported, other info auto-fetched from URL"""
+    """Request schema for updating an agent - only 5 fields supported, other info auto-fetched from URL"""
 
     path: str | None = Field(None, description="Registry path (e.g., /code-reviewer)")
-    name: str | None = Field(None, description="Agent name")
+    title: str | None = Field(None, description="Agent title")
     description: str | None = Field(None, description="Agent description")
     url: HttpUrl | str | None = Field(None, description="Agent endpoint URL - agent card will be fetched from this URL")
+    type: str | None = Field(None, description="Transport type: jsonrpc, grpc, http_json")
+    enabled: bool | None = Field(None, description="Whether agent is enabled")
 
 
 class AgentToggleRequest(APIBaseModel):
@@ -120,6 +131,7 @@ class AgentListItem(APIBaseModel):
     skills: list[AgentSkillOutput]
     enabled: bool
     status: str
+    config: AgentConfigOutput
     permissions: ResourcePermissions
     author: str
     createdAt: datetime
@@ -175,6 +187,7 @@ class AgentDetailResponse(APIBaseModel):
     tags: list[str]
     status: str
     enabled: bool
+    config: AgentConfigOutput
     permissions: ResourcePermissions
     author: str
     wellKnown: WellKnownInfo | None = None
@@ -230,6 +243,12 @@ def convert_to_list_item(agent: Any, acl_permission: int | ResourcePermissions) 
         for skill in (agent.card.skills or [])
     ]
 
+    config_output = AgentConfigOutput(
+        title=agent.config.title,
+        description=agent.config.description,
+        type=agent.config.type,
+    )
+
     return AgentListItem(
         id=str(agent.id),
         path=agent.path,
@@ -243,6 +262,7 @@ def convert_to_list_item(agent: Any, acl_permission: int | ResourcePermissions) 
         skills=skills_output,
         enabled=agent.isEnabled,
         status=agent.status,
+        config=config_output,
         permissions=permissions,
         author=str(agent.author),
         createdAt=agent.createdAt,
@@ -310,6 +330,12 @@ def convert_to_detail(agent: Any, acl_permission: int | ResourcePermissions) -> 
         else:
             security_schemes_dict = dict(agent.card.security_schemes)
 
+    config_output = AgentConfigOutput(
+        title=agent.config.title,
+        description=agent.config.description,
+        type=agent.config.type,
+    )
+
     return AgentDetailResponse(
         id=str(agent.id),
         path=agent.path,
@@ -329,6 +355,7 @@ def convert_to_detail(agent: Any, acl_permission: int | ResourcePermissions) -> 
         tags=agent.tags,
         status=agent.status,
         enabled=agent.isEnabled,
+        config=config_output,
         permissions=permissions,
         author=str(agent.author),
         wellKnown=well_known_info,

--- a/registry/src/registry/schemas/a2a_agent_api_schemas.py
+++ b/registry/src/registry/schemas/a2a_agent_api_schemas.py
@@ -88,7 +88,7 @@ class AgentCreateRequest(APIBaseModel):
 
 
 class AgentUpdateRequest(APIBaseModel):
-    """Request schema for updating an agent - only 5 fields supported, other info auto-fetched from URL"""
+    """Request schema for updating an agent - supports 6 fields: path, title, description, url, type, enabled"""
 
     path: str | None = Field(None, description="Registry path (e.g., /code-reviewer)")
     title: str | None = Field(None, description="Agent title")
@@ -217,6 +217,22 @@ class WellKnownSyncResponse(APIBaseModel):
 # ==================== Converter Functions ====================
 
 
+def _convert_agent_config(agent: Any) -> AgentConfigOutput:
+    """Helper to convert agent config to output format"""
+    # Backward compatibility: if config is None, use card data
+    if agent.config is None:
+        return AgentConfigOutput(
+            title=agent.card.name,
+            description=agent.card.description,
+            type="unknown",
+        )
+    return AgentConfigOutput(
+        title=agent.config.title,
+        description=agent.config.description,
+        type=agent.config.type,
+    )
+
+
 def convert_to_list_item(agent: Any, acl_permission: int | ResourcePermissions) -> AgentListItem:
     """Convert A2AAgent document to list item"""
     from registry_pkgs.models.enums import PermissionBits
@@ -243,11 +259,7 @@ def convert_to_list_item(agent: Any, acl_permission: int | ResourcePermissions) 
         for skill in (agent.card.skills or [])
     ]
 
-    config_output = AgentConfigOutput(
-        title=agent.config.title,
-        description=agent.config.description,
-        type=agent.config.type,
-    )
+    config_output = _convert_agent_config(agent)
 
     return AgentListItem(
         id=str(agent.id),
@@ -330,11 +342,7 @@ def convert_to_detail(agent: Any, acl_permission: int | ResourcePermissions) -> 
         else:
             security_schemes_dict = dict(agent.card.security_schemes)
 
-    config_output = AgentConfigOutput(
-        title=agent.config.title,
-        description=agent.config.description,
-        type=agent.config.type,
-    )
+    config_output = _convert_agent_config(agent)
 
     return AgentDetailResponse(
         id=str(agent.id),

--- a/registry/src/registry/services/a2a_agent_service.py
+++ b/registry/src/registry/services/a2a_agent_service.py
@@ -265,7 +265,7 @@ class A2AAgentService:
         Create a new agent. Automatically fetches agent card from provided URL.
 
         Args:
-            data: Agent creation data (path, name, description, url, type)
+            data: Agent creation data (path, title, description, url, type)
             user_id: User ID who creates the agent
 
         Returns:
@@ -280,7 +280,7 @@ class A2AAgentService:
 
             if data.type not in VALID_TRANSPORT_TYPES:
                 raise ValueError(
-                    f"Invalid transport type '{data.type}'. Must be one of: {', '.join(VALID_TRANSPORT_TYPES)}"
+                    f"Invalid transport type '{data.type}'. Must be one of: {', '.join(sorted(VALID_TRANSPORT_TYPES))}"
                 )
 
             # Check if path already exists
@@ -343,7 +343,7 @@ class A2AAgentService:
 
         Args:
             agent_id: Agent ID
-            data: Agent update data (path, name, description, url, type, enabled - all optional)
+            data: Agent update data (path, title, description, url, type, enabled - all optional)
 
         Returns:
             Updated agent document
@@ -365,7 +365,7 @@ class A2AAgentService:
 
                 if update_data["type"] not in VALID_TRANSPORT_TYPES:
                     raise ValueError(
-                        f"Invalid transport type '{update_data['type']}'. Must be one of: {', '.join(VALID_TRANSPORT_TYPES)}"
+                        f"Invalid transport type '{update_data['type']}'. Must be one of: {', '.join(sorted(VALID_TRANSPORT_TYPES))}"
                     )
 
             # If URL is being updated, fetch new agent card

--- a/registry/src/registry/services/a2a_agent_service.py
+++ b/registry/src/registry/services/a2a_agent_service.py
@@ -160,8 +160,10 @@ class A2AAgentService:
             if query:
                 # Escape regex special characters to prevent regex injection attacks
                 escaped_query = re.escape(query)
-                # Search across card fields: name, description, skills
+                # Search across config fields and card fields: title, description, skills
                 filters["$or"] = [
+                    {"config.title": {"$regex": escaped_query, "$options": "i"}},
+                    {"config.description": {"$regex": escaped_query, "$options": "i"}},
                     {"card.name": {"$regex": escaped_query, "$options": "i"}},
                     {"card.description": {"$regex": escaped_query, "$options": "i"}},
                     {"tags": {"$regex": escaped_query, "$options": "i"}},
@@ -263,7 +265,7 @@ class A2AAgentService:
         Create a new agent. Automatically fetches agent card from provided URL.
 
         Args:
-            data: Agent creation data (path, name, description, url)
+            data: Agent creation data (path, name, description, url, type)
             user_id: User ID who creates the agent
 
         Returns:
@@ -273,29 +275,38 @@ class A2AAgentService:
             ValueError: If path already exists or validation fails
         """
         try:
+            # Validate transport type
+            from registry_pkgs.models.a2a_agent import VALID_TRANSPORT_TYPES
+
+            if data.type not in VALID_TRANSPORT_TYPES:
+                raise ValueError(
+                    f"Invalid transport type '{data.type}'. Must be one of: {', '.join(VALID_TRANSPORT_TYPES)}"
+                )
+
             # Check if path already exists
             existing = await A2AAgent.find_one({"path": data.path})
             if existing:
                 raise ValueError(f"Agent with path '{data.path}' already exists")
 
-            # Fetch agent card from URL using SDK
+            # Fetch agent card from URL using SDK - KEEP ORIGINAL DATA
             logger.info(f"Fetching agent card from URL for new agent: {data.url}")
             agent_card = await self._fetch_agent_card_from_url(str(data.url))
 
-            # Override name and description from request if provided
-            # This allows user to customize these fields in registry
-            card_data = agent_card.model_dump(by_alias=False)
-            card_data["name"] = data.name
-            card_data["description"] = data.description or agent_card.description
-            card_data["url"] = str(data.url)  # Ensure URL matches the request
+            # DO NOT modify the agent_card - store it as-is
+            # Store user-provided information in config field instead
+            from registry_pkgs.models.a2a_agent import AgentConfig, WellKnownConfig
 
-            # Recreate agent card with overridden values
-            agent_card = AgentCard(**card_data)
+            agent_config = AgentConfig(
+                title=data.title,
+                description=data.description or "",
+                type=data.type,
+            )
 
             # Create agent document with wellKnown config
             agent = A2AAgent(
                 path=data.path,
-                card=agent_card,
+                card=agent_card,  # Original, unmodified card from third-party
+                config=agent_config,  # User-provided configuration
                 tags=[],  # Initialize as empty list - tags are registry metadata, not derived from skills
                 isEnabled=False,  # Default to disabled for safety
                 status=STATUS_ACTIVE,
@@ -305,8 +316,6 @@ class A2AAgentService:
             )
 
             # Configure wellKnown for future syncs
-            from registry_pkgs.models.a2a_agent import WellKnownConfig
-
             agent.wellKnown = WellKnownConfig(
                 enabled=True,
                 url=str(data.url),
@@ -318,7 +327,7 @@ class A2AAgentService:
             # Save to database
             await agent.insert()
             logger.info(
-                f"Created agent: {agent.card.name} (ID: {agent.id}, path: {agent.path}) with wellKnown sync enabled"
+                f"Created agent: {agent.config.title} (ID: {agent.id}, path: {agent.path}) with wellKnown sync enabled"
             )
             return agent
 
@@ -334,7 +343,7 @@ class A2AAgentService:
 
         Args:
             agent_id: Agent ID
-            data: Agent update data (path, name, description, url - all optional)
+            data: Agent update data (path, name, description, url, type, enabled - all optional)
 
         Returns:
             Updated agent document
@@ -350,28 +359,25 @@ class A2AAgentService:
             # Check what fields are being updated
             update_data = data.model_dump(exclude_unset=True, by_alias=False)
 
+            # Validate transport type if provided
+            if "type" in update_data:
+                from registry_pkgs.models.a2a_agent import VALID_TRANSPORT_TYPES
+
+                if update_data["type"] not in VALID_TRANSPORT_TYPES:
+                    raise ValueError(
+                        f"Invalid transport type '{update_data['type']}'. Must be one of: {', '.join(VALID_TRANSPORT_TYPES)}"
+                    )
+
             # If URL is being updated, fetch new agent card
             if "url" in update_data and update_data["url"]:
                 new_url = str(update_data["url"])
                 logger.info(f"URL changed, fetching new agent card from {new_url}")
 
-                # Fetch new agent card from URL
+                # Fetch new agent card from URL - KEEP ORIGINAL DATA
                 agent_card = await self._fetch_agent_card_from_url(new_url)
 
-                # Override with request fields if provided
-                card_data = agent_card.model_dump(by_alias=False)
-                card_data["url"] = new_url
-
-                if "name" in update_data:
-                    card_data["name"] = update_data["name"]
-                if "description" in update_data:
-                    card_data["description"] = update_data["description"]
-
-                # Recreate agent card
-                agent.card = AgentCard(**card_data)
-
-                # Note: tags are not updated from skills - they are separate registry metadata
-                # agent.tags remains unchanged during URL update
+                # DO NOT modify the agent_card - store it as-is
+                agent.card = agent_card
 
                 # Update wellKnown configuration
                 from registry_pkgs.models.a2a_agent import WellKnownConfig
@@ -389,18 +395,15 @@ class A2AAgentService:
                 agent.wellKnown.lastSyncStatus = "success"
                 agent.wellKnown.lastSyncVersion = agent.card.version
 
-            else:
-                # Only update name/description without fetching card
-                # This allows minor tweaks without re-fetching
-                card_data = agent.card.model_dump(by_alias=False)
-
-                if "name" in update_data:
-                    card_data["name"] = update_data["name"]
+            # Update config fields (title, description, type)
+            # These are stored separately in the config field
+            if "title" in update_data or "description" in update_data or "type" in update_data:
+                if "title" in update_data:
+                    agent.config.title = update_data["title"]
                 if "description" in update_data:
-                    card_data["description"] = update_data["description"]
-
-                # Recreate agent card with updated fields
-                agent.card = AgentCard(**card_data)
+                    agent.config.description = update_data["description"]
+                if "type" in update_data:
+                    agent.config.type = update_data["type"]
 
             # Update path if provided
             if "path" in update_data:
@@ -410,12 +413,16 @@ class A2AAgentService:
                     raise ValueError(f"Agent with path '{update_data['path']}' already exists")
                 agent.path = update_data["path"]
 
+            # Update enabled state if provided
+            if "enabled" in update_data:
+                agent.isEnabled = update_data["enabled"]
+
             # Update timestamp
             agent.updatedAt = datetime.now(UTC)
 
             # Save changes
             await agent.save()
-            logger.info(f"Updated agent: {agent.card.name} (ID: {agent_id})")
+            logger.info(f"Updated agent: {agent.config.title} (ID: {agent_id})")
             return agent
 
         except ValueError:
@@ -536,7 +543,7 @@ class A2AAgentService:
             if old_card.capabilities != updated_card.capabilities:
                 changes.append("Updated capabilities")
 
-            # Update agent card with SDK-validated card
+            # Update agent card with SDK-validated card (DO NOT modify - keep original)
             agent.card = updated_card
 
             # Update well-known sync metadata

--- a/registry/tests/unit/api/v1/test_agent_routes.py
+++ b/registry/tests/unit/api/v1/test_agent_routes.py
@@ -6,7 +6,7 @@ import pytest
 from beanie import PydanticObjectId
 
 from registry.api.v1.a2a.agent_routes import create_agent, get_agent_stats, list_agents
-from registry.schemas.a2a_agent_api_schemas import AgentCreateRequest, AgentSkillInput
+from registry.schemas.a2a_agent_api_schemas import AgentCreateRequest
 from registry_pkgs.models import PrincipalType, ResourceType
 from registry_pkgs.models.enums import RoleBits
 
@@ -29,6 +29,11 @@ def _build_agent(agent_id: PydanticObjectId | None = None):
             default_input_modes=["text/plain"],
             default_output_modes=["application/json"],
             provider=None,
+        ),
+        config=SimpleNamespace(
+            title="Test Agent",
+            description="Agent description",
+            type="jsonrpc",
         ),
         tags=["test"],
         isEnabled=True,
@@ -117,13 +122,10 @@ async def test_create_agent_uses_injected_services(sample_user_context):
 
     request = AgentCreateRequest(
         path="/test-agent",
-        name="Test Agent",
+        title="Test Agent",
         description="Agent description",
         url="https://agent.example.com",
-        version="1.0.0",
-        skills=[AgentSkillInput(id="skill-1", name="Skill 1", description="desc")],
-        tags=["test"],
-        enabled=True,
+        type="jsonrpc",
     )
 
     with patch("registry_pkgs.database.decorators.MongoDB.get_client") as mock_get_client:

--- a/registry/tests/unit/api/v1/test_agent_routes.py
+++ b/registry/tests/unit/api/v1/test_agent_routes.py
@@ -84,6 +84,10 @@ async def test_list_agents_uses_injected_services(sample_user_context):
     a2a_agent_service.list_agents.assert_awaited_once()
     assert result.pagination.total == 1
     assert result.agents[0].name == "Test Agent"
+    # Assert config field is returned
+    assert result.agents[0].config is not None
+    assert result.agents[0].config.title == "Test Agent"
+    assert result.agents[0].config.type == "jsonrpc"
 
 
 @pytest.mark.asyncio
@@ -149,3 +153,8 @@ async def test_create_agent_uses_injected_services(sample_user_context):
     assert call_args.kwargs["resource_type"] == ResourceType.REMOTE_AGENT
     assert call_args.kwargs["perm_bits"] == RoleBits.OWNER
     assert result.name == "Test Agent"
+    # Assert config field is returned with correct values
+    assert result.config is not None
+    assert result.config.title == "Test Agent"
+    assert result.config.description == "Agent description"
+    assert result.config.type == "jsonrpc"


### PR DESCRIPTION
feat: add config field and refactor A2A agent data structure

- Add config field (title, description, type) for user-provided metadata
- Keep agent card original data unmodified from third-party source
- Add transport type validation (jsonrpc/grpc/http_json)
- Support enabled field in PATCH endpoint
- Return config in all API responses