### PR TITLE
Hotfix: Use `X_JARVIS_REGISTRY_IMPORT_CHECKS` to bypass validation in CI import checks

### DIFF
--- a/.github/workflows/build-images-reusable.yaml
+++ b/.github/workflows/build-images-reusable.yaml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Guard the Docker image against import exceptions
         run: >
-          docker run --rm --entrypoint='' -e BUILD_VERSION=dummy -e X_JARVIS_REGISTRY_IMPORT_CHECKS="true"
+          docker run --rm --entrypoint='' -e BUILD_VERSION=dummy -e X_JARVIS_REGISTRY_IMPORT_CHECKS="disabled"
           "ghcr.io/${{ github.repository_owner }}/jarvis/registry:${{ github.sha }}"
           python -c "from registry.main import app; print(type(app))"
 
@@ -240,6 +240,6 @@ jobs:
 
       - name: Guard the Docker image against import exceptions
         run: >
-          docker run --rm --entrypoint='' -e X_JARVIS_REGISTRY_IMPORT_CHECKS="true"
+          docker run --rm --entrypoint='' -e X_JARVIS_REGISTRY_IMPORT_CHECKS="disabled"
           "ghcr.io/${{ github.repository_owner }}/jarvis/auth-server:${{ github.sha }}"
           python -c "from auth_server.server import app; print(type(app))"

--- a/.github/workflows/build-images-reusable.yaml
+++ b/.github/workflows/build-images-reusable.yaml
@@ -134,8 +134,7 @@ jobs:
 
       - name: Guard the Docker image against import exceptions
         run: >
-          docker run --rm --entrypoint='' -e BUILD_VERSION=dummy
-          -e SECRET_KEY=dummy -e ADMIN_PASSWORD=dummy -e ADMIN_USER=dummy
+          docker run --rm --entrypoint='' -e BUILD_VERSION=dummy -e X_JARVIS_REGISTRY_IMPORT_CHECKS="true"
           "ghcr.io/${{ github.repository_owner }}/jarvis/registry:${{ github.sha }}"
           python -c "from registry.main import app; print(type(app))"
 
@@ -241,6 +240,6 @@ jobs:
 
       - name: Guard the Docker image against import exceptions
         run: >
-          docker run --rm --entrypoint=''
+          docker run --rm --entrypoint='' -e X_JARVIS_REGISTRY_IMPORT_CHECKS="true"
           "ghcr.io/${{ github.repository_owner }}/jarvis/auth-server:${{ github.sha }}"
           python -c "from auth_server.server import app; print(type(app))"

--- a/auth-server/tests/unit/test_config.py
+++ b/auth-server/tests/unit/test_config.py
@@ -1,0 +1,17 @@
+import logging
+import os
+from unittest.mock import patch
+
+import pytest
+
+from auth_server.core.config import AuthSettings
+
+
+@pytest.mark.unit
+@patch.dict(os.environ, {"X_JARVIS_REGISTRY_IMPORT_CHECKS": "disabled"})
+def test_validation_disablement(caplog) -> None:
+    caplog.set_level(logging.WARNING)
+
+    AuthSettings()
+
+    assert "JWT_PRIVATE_KEY and JWT_PUBLIC_KEY validation is disabled." in caplog.text

--- a/docker/registry-entrypoint.sh
+++ b/docker/registry-entrypoint.sh
@@ -103,26 +103,7 @@ backend)
         echo "BUILD_VERSION not set, will use default version"
     fi
 
-    # Validate required environment variables
-    if [ -z "${SECRET_KEY:-}" ]; then
-        echo "ERROR: SECRET_KEY environment variable is not set."
-        echo "Please set SECRET_KEY to a secure value before running the container."
-        exit 1
-    fi
-
-    if [ -z "${ADMIN_PASSWORD:-}" ]; then
-        echo "ERROR: ADMIN_PASSWORD environment variable is not set."
-        echo "Please set ADMIN_PASSWORD to a secure value before running the container."
-        exit 1
-    fi
-
-    if [ -z "${ADMIN_USER:-}" ]; then
-        echo "ERROR: ADMIN_USER environment variable is not set."
-        echo "Please set ADMIN_USER before running the container."
-        exit 1
-    fi
-
-    echo "Running in external tool discovery mode"
+    echo "Running in ${TOOL_DISCOVERY_MODE:-unknown} tool discovery mode"
 
     # Start the registry
     echo "Starting MCP Registry on port 7860..."

--- a/registry-pkgs/src/registry_pkgs/core/config.py
+++ b/registry-pkgs/src/registry_pkgs/core/config.py
@@ -118,11 +118,16 @@ class JarvisBaseSettings(BaseSettings):
     scopes_config_path: str = ""
 
     # ==================== Model Validation ====================
-    x_jarvis_registry_import_checks: bool = False  # Skip validations if True. Intended only for import checks in CI.
+    # Skip model validation if set to "disabled". Disabling should only happen for import checks in CI.
+    x_jarvis_registry_import_checks: str = "enabled"
 
     @model_validator(mode="after")
     def _validate_jwt_key_pair(self) -> Self:
-        if self.x_jarvis_registry_import_checks:
+        if self.x_jarvis_registry_import_checks == "disabled":
+            logging.warning(
+                "JWT_PRIVATE_KEY and JWT_PUBLIC_KEY validation is disabled. This should only happen in CI import checks."
+            )
+
             return self
 
         private_raw = self.jwt_private_key.strip()

--- a/registry-pkgs/src/registry_pkgs/core/config.py
+++ b/registry-pkgs/src/registry_pkgs/core/config.py
@@ -118,9 +118,13 @@ class JarvisBaseSettings(BaseSettings):
     scopes_config_path: str = ""
 
     # ==================== Model Validation ====================
+    x_jarvis_registry_import_checks: bool = False  # Skip validations if True. Intended only for import checks in CI.
 
     @model_validator(mode="after")
     def _validate_jwt_key_pair(self) -> Self:
+        if self.x_jarvis_registry_import_checks:
+            return self
+
         private_raw = self.jwt_private_key.strip()
         public_raw = self.jwt_public_key.strip()
 

--- a/registry-pkgs/tests/unit/test_config.py
+++ b/registry-pkgs/tests/unit/test_config.py
@@ -1,0 +1,17 @@
+import logging
+import os
+from unittest.mock import patch
+
+import pytest
+
+from registry_pkgs.core.config import JarvisBaseSettings
+
+
+@pytest.mark.unit
+@patch.dict(os.environ, {"X_JARVIS_REGISTRY_IMPORT_CHECKS": "disabled"})
+def test_validation_disablement(caplog) -> None:
+    caplog.set_level(logging.WARNING)
+
+    JarvisBaseSettings()
+
+    assert "JWT_PRIVATE_KEY and JWT_PUBLIC_KEY validation is disabled." in caplog.text

--- a/registry/src/registry/core/config.py
+++ b/registry/src/registry/core/config.py
@@ -166,6 +166,9 @@ class Settings(JarvisBaseSettings):
 
     @model_validator(mode="after")
     def _validate_tool_discovery_mode(self) -> Self:
+        if self.x_jarvis_registry_import_checks:
+            return self
+
         if self.tool_discovery_mode not in ("embedded", "external"):
             raise ValueError(
                 f"Invalid tool_discovery_mode: '{self.tool_discovery_mode}'. Must be 'embedded' or 'external'."
@@ -175,6 +178,9 @@ class Settings(JarvisBaseSettings):
 
     @model_validator(mode="after")
     def _validate_creds_key(self) -> Self:
+        if self.x_jarvis_registry_import_checks:
+            return self
+
         if self.creds_key == "":
             raise ValueError("CREDS_KEY must be set for encryption/decryption.")
 

--- a/registry/src/registry/core/config.py
+++ b/registry/src/registry/core/config.py
@@ -1,3 +1,4 @@
+import logging
 from functools import cached_property
 from pathlib import Path
 from typing import Self
@@ -166,7 +167,9 @@ class Settings(JarvisBaseSettings):
 
     @model_validator(mode="after")
     def _validate_tool_discovery_mode(self) -> Self:
-        if self.x_jarvis_registry_import_checks:
+        if self.x_jarvis_registry_import_checks == "disabled":
+            logging.warning("TOOL_DISCOVERY_MODE validation is disabled. This should only happen in CI import checks.")
+
             return self
 
         if self.tool_discovery_mode not in ("embedded", "external"):
@@ -178,7 +181,9 @@ class Settings(JarvisBaseSettings):
 
     @model_validator(mode="after")
     def _validate_creds_key(self) -> Self:
-        if self.x_jarvis_registry_import_checks:
+        if self.x_jarvis_registry_import_checks == "disabled":
+            logging.warning("CREDS_KEY validation is disabled. This should only happen in CI import checks.")
+
             return self
 
         if self.creds_key == "":

--- a/registry/tests/unit/core/test_config.py
+++ b/registry/tests/unit/core/test_config.py
@@ -2,6 +2,7 @@
 Unit tests for the configuration module.
 """
 
+import logging
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -144,3 +145,13 @@ class TestSettings:
 
         assert settings.container_registry_dir == custom_registry_dir
         assert settings.servers_dir == custom_registry_dir / "servers"
+
+    @pytest.mark.unit
+    @patch.dict(os.environ, {**_SETTINGS_ENV, "X_JARVIS_REGISTRY_IMPORT_CHECKS": "disabled"})
+    def test_validation_disablement(self, caplog) -> None:
+        caplog.set_level(logging.WARNING)
+
+        Settings()
+
+        for key in ("JWT_PRIVATE_KEY and JWT_PUBLIC_KEY", "CREDS_KEY", "TOOL_DISCOVERY_MODE"):
+            assert f"{key} validation is disabled." in caplog.text


### PR DESCRIPTION
Our workflow `build-images-reusable.yml` has a step that checks all Python dependencies (as long as they are imported at module top level) are in place **right after `docker build` and before deployment**.

After we added Pydantic `model_validator` for certain environment variables, these checks break for the wrong reason - the environment variable are not in place during the import check, but they are in place in deployed environment. Since two of the env vars are multi-line PEM-encoded RSA keys, it's hard to generated them and use them in the import checks only.

Therefore, we decided to use the environment variable `X_JARVIS_REGISTRY_IMPORT_CHECKS` to signal that model validations should be skipped when this env var is set to `true`.