### PR TITLE
Feature: Add a `/local-frontend-check` skill for AI-driven local frontend testing

### DIFF
--- a/.github/skills/local-frontend-check/SKILL.md
+++ b/.github/skills/local-frontend-check/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: local-frontend-check
+description: Smoke-test or verify UI behaviour on the local Jarvis Registry frontend running at http://localhost/gateway. Use for manual regression checks, bug-fix verification, and end-to-end confirmation of specific flows without running the automated test suite.
+allowed-tools: Bash(playwright-cli:*) Bash(docker:*)
+---
+
+## Local Frontend Check Skill
+
+### Fixed Configuration
+
+| Setting | Value |
+|---|---|
+| Base URL | `http://localhost/gateway` |
+| Browser session | Named `jarvis` — keeps a stable, reusable identity across runs |
+| Launch flags | `--persistent --headed` — profile saved to disk, browser window visible |
+| Backend log container | `jarvis-registry-registry-1` |
+
+---
+
+### Workflow
+
+Follow these phases in order every time this skill is invoked. Do not skip phases.
+
+---
+
+#### Phase 1 — Open the browser
+
+```bash
+playwright-cli -s=jarvis open http://localhost/gateway --persistent --headed
+```
+
+Then take a snapshot to read the page's current state:
+
+```bash
+playwright-cli -s=jarvis snapshot
+```
+
+---
+
+#### Phase 2 — Handle authentication
+
+Inspect the snapshot.
+
+**If the app loads directly** (no login form, no auth redirect visible): the persistent profile is still valid. Skip to Phase 3.
+
+**If a login page or auth redirect is visible**: the session has expired or this is a first run. Do the following:
+
+1. Tell the user: *"The browser window is open and showing a login page. Please log in in the headed browser window, then confirm here when done."*
+2. Use `AskUserQuestion` to wait for the user's confirmation before continuing.
+3. Take a second snapshot and verify the app has loaded (URL is no longer the login page, and the main app UI is visible). If still on the login page, tell the user and repeat.
+
+Because `--persistent` saves the profile to disk, subsequent runs will pick up the stored session automatically and this phase will be skipped.
+
+---
+
+#### Phase 3 — Orient and navigate
+
+Read the user's description of what to check. Navigate to the relevant section of the UI:
+
+- Use `playwright-cli -s=jarvis goto <url>` for direct navigation.
+- Use `playwright-cli -s=jarvis snapshot --depth=3` to get a lightweight view of a complex page.
+- Use `playwright-cli -s=jarvis click <ref>` to follow navigation links or open panels.
+
+Take snapshots as needed to orient yourself before acting.
+
+---
+
+#### Phase 4 — Perform the described operations
+
+Execute the operations step by step. After each significant action (form submit, dialog confirm, delete button, save button), take a snapshot immediately to observe the result.
+
+Note what you see:
+
+- **Success signals**: confirmation toast/banner, resource list updated, no error visible, HTTP response in UI shows 2xx.
+- **Failure signals**: error toast, error dialog, HTTP 4xx/5xx error text, UI stuck in loading state.
+
+Capture a screenshot at any notable point (success or failure):
+
+```bash
+playwright-cli -s=jarvis screenshot
+```
+
+---
+
+#### Phase 5 — Read backend logs
+
+After triggering the key operation(s), read recent logs from the backend container:
+
+```bash
+docker logs jarvis-registry-registry-1 --tail=200 2>&1
+```
+
+Look for:
+- Python tracebacks or `ERROR`-level log lines near the time of the operation.
+- HTTP route log lines showing the request method, path, and status code.
+- Any `RuntimeError`, `ValueError`, or `DuplicateKeyError` messages.
+
+If the log output is noisy, filter for the operation's timeframe by scanning the last N lines around when you performed the action.
+
+---
+
+#### Phase 6 — Report findings
+
+Summarise clearly:
+
+1. **Operations performed** — what you did and in what order.
+2. **UI result** — what the browser showed after each operation (include snapshot filenames or key text).
+3. **Log evidence** — relevant log lines (errors, warnings, or confirmation of a clean request/response).
+4. **Verdict** — `PASS` or `FAIL` with a one-sentence reason.
+
+---
+
+### Notes
+
+- Do **not** close the browser session at the end unless the user asks. Leaving it open avoids re-login overhead on follow-up checks.
+- If the app is unreachable (`ERR_CONNECTION_REFUSED`), tell the user that the services may not be running and suggest `docker compose up -d`.
+- Use `playwright-cli -s=jarvis snapshot <ref>` to inspect a specific element more closely when the full-page snapshot is too large.
+- If an operation opens a confirmation dialog, handle it explicitly with `playwright-cli -s=jarvis click <confirm-button-ref>` rather than assuming it auto-dismisses.

--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,7 @@ image-manifest.json
 # Folders for Claude specs and plans
 /.spec
 /.plan
+
+# Artifacts produced by Playwright for frontend test
+/.playwright-cli
+/.playwright

--- a/docs/frontend-testing.md
+++ b/docs/frontend-testing.md
@@ -1,0 +1,170 @@
+# Frontend Testing via AI Skills
+
+The `local-frontend-check` Claude skill lets you ask AI (in natural language) to navigate
+the Jarvis Registry UI, perform operations, and verify results — while it cross-checks backend
+logs automatically. It is intended for manual regression checks, bug-fix verification, and
+end-to-end confirmation of specific flows without running the full automated test suite.
+
+---
+
+## Prerequisites
+
+### 1. Install `playwright-cli`
+
+`playwright-cli` must be available as a global command. Install it via Homebrew like below.
+
+```bash
+brew install playwright-cli
+```
+
+If Homebrew is not available, use `npm install -g`.
+
+```bash
+npm install -g @playwright/cli@latest
+```
+
+Verify:
+
+```bash
+playwright-cli --version   # should print 0.1.7 or later
+```
+
+Install `playwright-cli` skills into the `.claude/skills/` folder of this project.
+The `.claude/` folder is not Git tracked.
+
+```bash
+playwright-cli install --skills
+```
+
+### 2. Make the skill available to your editor
+
+The skill lives in `.github/skills/local-frontend-check/`.
+After creating a symlink into it from `.claude/skills/`,
+Claude Code CLI picks it up automatically.
+When using VS Code Copilot or Claude Desktop, you need to tell it the explicit path
+to the skill folder.
+
+---
+
+## Symlinking for Claude Code CLI
+
+Claude Code CLI looks for skills relative to the workspace root.
+Create a symlink so Claude Code can find the `.claude/` directory:
+
+```bash
+# From project root
+mkdir -p .claude/skills
+pushd .claude/skills
+ln -s ../../.github/skills/local-frontend-check/
+popd
+```
+
+---
+
+## How to invoke the skill
+
+Before you invoke the skill, you should start the local services via `docker compose`,
+and check that you can access Registry frontend at `http://localhost/gateway`.
+In particular, in your `.env` file the value of `REGISTRY_CLIENT_URL` should have a `/gateway`
+path portion.
+
+```
+REGISTRY_CLIENT_URL=http://localhost:80/gateway
+```
+
+### Claude Code CLI
+
+Prefix your request with `/local-frontend-check`:
+
+```
+/local-frontend-check Navigate to the MCP Servers list and verify that "my-server" appears with status Enabled.
+```
+
+```
+/local-frontend-check Delete the federation named "adhoc-test" and verify success.
+```
+
+Claude will open a headed Chrome window, navigate the UI, perform the requested operations,
+read backend logs from `jarvis-registry-registry-1`, and report a `PASS` / `FAIL` verdict.
+
+### VS Code Copilot (chat panel)
+
+VS Code Copilot has no equivalent of invoking the `/local-frontend-check` skill as in Claude Code CLI. You must tell it the explicit path to the skill folder `.github/skills/local-frontend-check/`,
+the explicit path to the `playwright-cli` skill folder `.claude/skills/playwright-cli/`,
+and then give it natural language prompts.
+
+It's recommended to use a Claude model to do this.
+
+---
+
+## First-run authentication
+
+The first time the skill runs (or after a session expiry), the browser will land on the login
+page. Claude Code will pause and ask you to log in manually in the headed window. Once you confirm,
+it continues from where it left off.
+
+---
+
+## Session persistence
+
+The `jarvis` browser session uses a **persistent profile** stored on disk:
+
+```
+~/Library/Caches/ms-playwright/daemon/<daemon-id>/ud-jarvis-undefined/
+```
+
+Because the profile is saved between runs, your login cookies survive across invocations.
+Subsequent skill runs skip the login step entirely as long as the session has not expired.
+
+### Checking session state
+
+```bash
+playwright-cli list
+```
+
+Possible statuses:
+
+| Status | Meaning |
+|---|---|
+| `open` | Browser window is running |
+| `closed` | Window was closed; profile data still on disk, daemon record retained |
+
+### Closing a session
+
+If you close the browser window manually, the daemon record lingers. Clean it up with:
+
+```bash
+playwright-cli -s=jarvis close
+```
+
+### Deleting profile data
+
+To wipe the saved login cookies and force a fresh login on the next run:
+
+```bash
+playwright-cli -s=jarvis delete-data
+```
+
+---
+
+## Testing artifacts
+
+Every skill run writes artifacts to `.playwright-cli/` at the **repo root**. This directory is
+gitignored (see `.gitignore`).
+
+| File pattern | Contents |
+|---|---|
+| `page-<timestamp>.png` | Screenshots captured with `playwright-cli screenshot` |
+| `page-<timestamp>.yml` | Accessibility-tree snapshots (used internally for element targeting) |
+| `console-<timestamp>.log` | Browser console output (errors, warnings) |
+
+Screenshots are the most useful artifacts for human review — they capture the UI state at key
+moments (after a save, after a delete, on an error). Snapshot YAML files are text-only
+structural dumps used by the skill to locate elements by ref; you rarely need to read them
+directly.
+
+Artifacts accumulate over time. Delete them when no longer needed:
+
+```bash
+rm -rf .playwright-cli/
+```


### PR DESCRIPTION
I used it to verify the changes in [this PR](https://github.com/ascending-llc/jarvis-registry/pull/298) from the frontend in `docker compose`. Worked well.