### PR TITLE
Feature/as 1506

### DIFF
--- a/registry-pkgs/src/registry_pkgs/models/enums.py
+++ b/registry-pkgs/src/registry_pkgs/models/enums.py
@@ -11,7 +11,6 @@ class ToolDiscoveryMode(StrEnum):
 class ServerEntityType(StrEnum):
     """Entity type enumeration for vector documents"""
 
-    SERVER = "server"
     TOOL = "tool"
     RESOURCE = "resource"
     PROMPT = "prompt"

--- a/registry-pkgs/src/registry_pkgs/models/extended_mcp_server.py
+++ b/registry-pkgs/src/registry_pkgs/models/extended_mcp_server.py
@@ -172,36 +172,33 @@ class ExtendedMCPServer(MCPServer):
 
     def to_documents(self, chunking_config: ChunkingConfig | None = None) -> list[LangChainDocument]:
         """
-        Convert ExtendedMCPServer to multiple searchable documents.
+        Convert ExtendedMCPServer to searchable vector documents.
 
-        Strategy:
-        1. Split by semantic units (server, tools, resources, prompts)
-        2. Apply RecursiveCharacterTextSplitter to oversized content
-        3. Maintain parent-child relationship via server_id
+        Each tool/resource/prompt document embeds the server context (name, path, title,
+        description) as a prefix in its content, making every document self-contained for
+        vector search. This eliminates the need for a separate server-level document and
+        allows all discovery paths — including server-level queries — to be served directly
+        from tool/resource/prompt docs without a MongoDB lookup.
 
         Returns:
-            List of LangChain Documents with entity_type metadata
+            List of LangChain Documents with entity_type metadata (tool, resource, prompt)
         """
         docs = []
         chunking_config = chunking_config or ChunkingConfig()
 
-        # 1. Server Overview
-        server_docs = self._create_server_docs(chunking_config)
-        docs.extend(server_docs)
-
-        # 2. Tools
+        # Tools
         tool_functions = self.config.get("toolFunctions", {})
         for tool_name, tool_data in tool_functions.items():
             tool_docs = self._create_tool_docs(tool_name, tool_data, chunking_config)
             docs.extend(tool_docs)
 
-        # 3. Resources
+        # Resources
         resources = self.config.get("resources", [])
         for resource in resources:
             resource_docs = self._create_resource_docs(resource, chunking_config)
             docs.extend(resource_docs)
 
-        # 4. Prompts
+        # Prompts
         prompts = self.config.get("prompts", [])
         for prompt in prompts:
             prompt_docs = self._create_prompt_docs(prompt, chunking_config)
@@ -209,18 +206,10 @@ class ExtendedMCPServer(MCPServer):
 
         logger.info(
             f"Generated {len(docs)} documents for server {self.serverName} "
-            f"(server:{len(server_docs)}, tools:{len(tool_functions)}, "
-            f"resources:{len(resources)}, prompts:{len(prompts)})"
+            f"(tools:{len(tool_functions)}, resources:{len(resources)}, prompts:{len(prompts)})"
         )
 
         return docs
-
-    def _create_server_docs(self, chunking_config: ChunkingConfig) -> list[LangChainDocument]:
-        """Create Server Overview document(s) with text splitting if needed."""
-        content = self.generate_server_content()
-
-        base_metadata = self._get_base_metadata(ServerEntityType.SERVER)
-        return self._split_if_needed(content, base_metadata, chunking_config)
 
     def _create_tool_docs(
         self, tool_name: str, tool_data: dict, chunking_config: ChunkingConfig
@@ -322,34 +311,38 @@ class ExtendedMCPServer(MCPServer):
         logger.info(f"Split into {len(chunks)} chunks")
         return docs
 
-    def generate_server_content(self) -> str:
+    def _server_prefix(self) -> str:
         """
-        Generate content for Server Overview document.
+        Build the shared server context prefix embedded in every tool/resource/prompt document.
 
-        Format: serverName | path | title | description |
-                Contains X tools, Y resources, Z prompts | Tags: tags
+        Embedding this prefix makes each document self-contained so that vector search
+        on tool/resource/prompt docs can match server-level terms (e.g. "github") without
+        requiring a separate MongoDB lookup.
+
+        Format: serverName | path | title | description
         """
-        parts = [self.serverName, self.path, self.config.get("title", ""), self.config.get("description", "")]
-
-        # Statistics
-        num_tools = len(self.config.get("toolFunctions", {}))
-        num_resources = len(self.config.get("resources", []))
-        num_prompts = len(self.config.get("prompts", []))
-
-        parts.append(f"Contains {num_tools} tools, {num_resources} resources, {num_prompts} prompts")
-
-        # Tags
-        if self.tags:
-            parts.append(f"Tags: {', '.join(self.tags)}")
-
-        return " | ".join(filter(None, parts))
+        return " | ".join(
+            filter(
+                None,
+                [
+                    self.serverName,
+                    self.path,
+                    self.config.get("title", ""),
+                    self.config.get("description", ""),
+                ],
+            )
+        )
 
     def generate_tool_content(self, tool_name: str, tool_data: dict) -> str:
         """
         Generate content for Tool document.
 
-        Format: tool_name | description |
+        Format: serverName | path | title | description |
+                tool_name | description |
                 Parameters: param1 (type, required/optional, description), ...
+
+        The server prefix makes tool docs self-contained for vector search,
+        eliminating the need for a MongoDB lookup during server discovery.
         """
         parts = [tool_name]
 
@@ -386,14 +379,17 @@ class ExtendedMCPServer(MCPServer):
                 if param_strs:
                     parts.append(f"Parameters: {', '.join(param_strs)}")
 
-        return " | ".join(filter(None, parts))
+        tool_body = " | ".join(filter(None, parts))
+        return f"{self._server_prefix()} | {tool_body}"
 
     def generate_resource_content(self, resource: dict) -> str:
         """
         Generate content for Resource document.
 
-        Format: name | description | URI: uri_template |
-                Example: example_uri | Use case: inferred_use_case
+        Format: serverName | path | title | description |
+                name | description | URI: uri_template | MIME type: mime_type
+
+        The server prefix makes resource docs self-contained for vector search.
         """
         name = resource.get("name", "")
         description = resource.get("description", "")
@@ -408,14 +404,17 @@ class ExtendedMCPServer(MCPServer):
         if mime_type:
             parts.append(f"MIME type: {mime_type}")
 
-        return " | ".join(filter(None, parts))
+        resource_body = " | ".join(filter(None, parts))
+        return f"{self._server_prefix()} | {resource_body}"
 
     def generate_prompt_content(self, prompt: dict) -> str:
         """
         Generate content for Prompt document.
 
-        Format: name | description |
-                Required: required_args | Optional: optional_args
+        Format: serverName | path | title | description |
+                name | description | Required: required_args | Optional: optional_args
+
+        The server prefix makes prompt docs self-contained for vector search.
         """
         name = prompt.get("name", "")
         description = prompt.get("description", "")
@@ -442,7 +441,8 @@ class ExtendedMCPServer(MCPServer):
         if optional_args:
             parts.append(f"Optional: {', '.join(optional_args)}")
 
-        return " | ".join(filter(None, parts))
+        prompt_body = " | ".join(filter(None, parts))
+        return f"{self._server_prefix()} | {prompt_body}"
 
     @classmethod
     def from_document(cls, document: LangChainDocument) -> dict:

--- a/registry-pkgs/src/registry_pkgs/models/extended_mcp_server.py
+++ b/registry-pkgs/src/registry_pkgs/models/extended_mcp_server.py
@@ -449,21 +449,19 @@ class ExtendedMCPServer(MCPServer):
         """
         Extract metadata from any document type.
 
-        Note: This returns minimal metadata.
-        Full server data should be fetched from MongoDB using server_id.
-
-        Returns:
-            Dict with document metadata including entity_type
+        Returns execution-ready fields for LLM consumption.
+        relevance_score is populated by the reranker (FlashRank sets it in metadata);
+        None for filter-only results where no semantic score is available.
         """
         metadata = document.metadata
 
+        raw_score = metadata.get("relevance_score")
         result = {
             "server_id": metadata.get("server_id"),
             "server_name": metadata.get("server_name"),
             "entity_type": metadata.get("entity_type"),
-            "scope": metadata.get("scope"),
-            "enabled": metadata.get("enabled"),
-            "content": document.page_content,
+            "relevance_score": round(float(raw_score), 3) if raw_score is not None else None,
+            "description": document.page_content,
         }
 
         entity_type = metadata.get("entity_type")
@@ -474,11 +472,6 @@ class ExtendedMCPServer(MCPServer):
             result["resource_uri"] = metadata.get("resource_uri")
         elif entity_type == ServerEntityType.PROMPT:
             result["prompt_name"] = metadata.get("prompt_name")
-
-        # Handle chunked documents
-        if metadata.get("is_chunked"):
-            result["chunk_index"] = metadata.get("chunk_index")
-            result["total_chunks"] = metadata.get("total_chunks")
 
         return result
 

--- a/registry-pkgs/src/registry_pkgs/vector/repositories/mcp_server_repository.py
+++ b/registry-pkgs/src/registry_pkgs/vector/repositories/mcp_server_repository.py
@@ -245,16 +245,16 @@ class MCPServerRepository(Repository[ExtendedMCPServer]):
 
     async def get_all_docs_by_server_id(self, server_id: str) -> dict[str, list[Any]]:
         """
-        Get all vector documents (server, tools, resources, prompts) by server_id.
+        Get all vector documents (tools, resources, prompts) by server_id.
 
         Query by entity type separately for better traceability.
 
         Returns:
-            Dict with keys: 'server', 'tools', 'resources', 'prompts'
+            Dict with keys: 'tools', 'resources', 'prompts'
             Each value is a list of LangChain Documents from weaviate
         """
         try:
-            result = {"server": [], "tools": [], "resources": [], "prompts": []}
+            result: dict[str, list[Any]] = {"tools": [], "resources": [], "prompts": []}
 
             # Query each entity type separately for better logging and debugging
             for entity_type in ServerEntityType:
@@ -268,22 +268,20 @@ class MCPServerRepository(Repository[ExtendedMCPServer]):
                     collection_name=self.collection,
                 )
 
-                # Map entity_type to result key (handle plural forms)
-                result_key = entity_type_value if entity_type_value == "server" else f"{entity_type_value}s"
-                result[result_key] = docs
+                result[f"{entity_type_value}s"] = docs
 
                 logger.debug(f"Found {len(docs)} {entity_type_value} docs for server_id {server_id}")
 
             logger.info(
                 f"Retrieved docs for server_id {server_id}: "
-                f"server={len(result['server'])}, tools={len(result['tools'])}, "
+                f"tools={len(result['tools'])}, "
                 f"resources={len(result['resources'])}, prompts={len(result['prompts'])}"
             )
             return result
 
         except Exception as e:
             logger.error(f"Get all docs by server_id failed: {e}", exc_info=True)
-            return {"server": [], "tools": [], "resources": [], "prompts": []}
+            return {"tools": [], "resources": [], "prompts": []}
 
     async def smart_sync(
         self,
@@ -294,7 +292,7 @@ class MCPServerRepository(Repository[ExtendedMCPServer]):
 
         Strategy:
         1. Generate new documents from server (grouped by entity type)
-        2. For each entity type (SERVER, TOOL, RESOURCE, PROMPT):
+        2. For each entity type (TOOL, RESOURCE, PROMPT):
            - Query existing docs in Weaviate
            - Compare with new docs
            - Determine if content changed or only metadata changed
@@ -385,7 +383,7 @@ class MCPServerRepository(Repository[ExtendedMCPServer]):
         Returns:
             Dict mapping entity_type to list of documents
         """
-        grouped = {"server": [], "tool": [], "resource": [], "prompt": []}
+        grouped: dict[str, list[Any]] = {"tool": [], "resource": [], "prompt": []}
 
         for doc in docs:
             entity_type = doc.metadata.get("entity_type")
@@ -406,7 +404,7 @@ class MCPServerRepository(Repository[ExtendedMCPServer]):
         Sync a specific entity type by comparing existing and new docs.
 
         Args:
-            entity_type: Entity type (server, tool, resource, prompt)
+            entity_type: Entity type (tool, resource, prompt)
             existing_docs: Existing documents from Weaviate
             new_docs: New documents to sync
 
@@ -493,9 +491,7 @@ class MCPServerRepository(Repository[ExtendedMCPServer]):
             entity_type = doc.metadata.get("entity_type")
 
             # Determine unique key based on entity type
-            if entity_type == "server":
-                key = ("server", doc.metadata.get("server_name"))
-            elif entity_type == "tool":
+            if entity_type == "tool":
                 key = ("tool", doc.metadata.get("tool_name"))
             elif entity_type == "resource":
                 key = ("resource", doc.metadata.get("resource_name"))

--- a/registry-pkgs/src/registry_pkgs/vector/repository.py
+++ b/registry-pkgs/src/registry_pkgs/vector/repository.py
@@ -301,7 +301,6 @@ class Repository[T: VectorStorable]:
         Build lookup map for documents by unique key.
 
         Key format:
-        - server: "server:{server_name}"
         - tool: "tool:{server_name}:{tool_name}"
         - resource: "resource:{server_name}:{resource_name}"
         - prompt: "prompt:{server_name}:{prompt_name}"
@@ -322,9 +321,7 @@ class Repository[T: VectorStorable]:
             entity_type = metadata.get("entity_type")
             server_name = metadata.get("server_name")
 
-            if entity_type == "server":
-                key = f"server:{server_name}"
-            elif entity_type == "tool":
+            if entity_type == "tool":
                 tool_name = metadata.get("tool_name")
                 key = f"tool:{server_name}:{tool_name}"
             elif entity_type == "resource":

--- a/registry-pkgs/tests/unit/test_models.py
+++ b/registry-pkgs/tests/unit/test_models.py
@@ -246,7 +246,17 @@ class TestExtendedMCPServerStructure:
                 "description": "desc",
                 "type": "streamable-http",
                 "url": "https://example.com/mcp",
-                "toolFunctions": {},
+                "toolFunctions": {
+                    "ping_mcp_versioned_server": {
+                        "type": "function",
+                        "mcpToolName": "ping",
+                        "function": {
+                            "name": "ping_mcp_versioned_server",
+                            "description": "Ping the server",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                },
                 "resources": [],
                 "prompts": [],
             },
@@ -292,12 +302,118 @@ class TestExtendedMCPServerStructure:
         docs = server.to_documents()
         tool_doc = next(doc for doc in docs if doc.metadata.get("entity_type") == "tool")
 
+        # metadata: tool_name is the downstream MCP name
         assert tool_doc.metadata["tool_name"] == "downstream_tool"
         assert "original_mcp_name" not in tool_doc.metadata
+
+        # content: server prefix is embedded so tool docs are self-contained for vector search
+        assert tool_doc.page_content.startswith("tool-server | /mcp/tool-server |")
 
         result = ExtendedMCPServer.from_document(tool_doc)
         assert result["tool_name"] == "downstream_tool"
         assert "original_mcp_name" not in result
+
+    def test_tool_doc_content_includes_server_prefix(self):
+        """Tool doc content must start with server context so vector search is self-contained."""
+        server = ExtendedMCPServer.model_construct(
+            id=PydanticObjectId(),
+            serverName="github",
+            config={
+                "title": "GitHub MCP Server",
+                "description": "GitHub integration",
+                "type": "streamable-http",
+                "url": "https://example.com/mcp",
+                "toolFunctions": {
+                    "search_code_mcp_github": {
+                        "type": "function",
+                        "mcpToolName": "search_code",
+                        "function": {
+                            "name": "search_code_mcp_github",
+                            "description": "Search code in repositories",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                },
+                "resources": [],
+                "prompts": [],
+            },
+            author=PydanticObjectId(),
+            path="/mcp/github",
+            status="active",
+        )
+
+        docs = server.to_documents()
+        tool_doc = next(doc for doc in docs if doc.metadata.get("entity_type") == "tool")
+
+        assert "github" in tool_doc.page_content
+        assert "/mcp/github" in tool_doc.page_content
+        assert "GitHub MCP Server" in tool_doc.page_content
+        assert "search_code" in tool_doc.page_content
+
+    def test_resource_doc_content_includes_server_prefix(self):
+        """Resource doc content must include server context prefix."""
+        server = ExtendedMCPServer.model_construct(
+            id=PydanticObjectId(),
+            serverName="github",
+            config={
+                "title": "GitHub MCP Server",
+                "description": "GitHub integration",
+                "type": "streamable-http",
+                "url": "https://example.com/mcp",
+                "toolFunctions": {},
+                "resources": [
+                    {
+                        "uri": "github://repo/{owner}/{repo}",
+                        "name": "repository",
+                        "description": "GitHub repository",
+                        "mimeType": "application/json",
+                    }
+                ],
+                "prompts": [],
+            },
+            author=PydanticObjectId(),
+            path="/mcp/github",
+            status="active",
+        )
+
+        docs = server.to_documents()
+        resource_doc = next(doc for doc in docs if doc.metadata.get("entity_type") == "resource")
+
+        assert "github" in resource_doc.page_content
+        assert "/mcp/github" in resource_doc.page_content
+        assert "repository" in resource_doc.page_content
+
+    def test_prompt_doc_content_includes_server_prefix(self):
+        """Prompt doc content must include server context prefix."""
+        server = ExtendedMCPServer.model_construct(
+            id=PydanticObjectId(),
+            serverName="github",
+            config={
+                "title": "GitHub MCP Server",
+                "description": "GitHub integration",
+                "type": "streamable-http",
+                "url": "https://example.com/mcp",
+                "toolFunctions": {},
+                "resources": [],
+                "prompts": [
+                    {
+                        "name": "code_review",
+                        "description": "Review code changes",
+                        "arguments": [],
+                    }
+                ],
+            },
+            author=PydanticObjectId(),
+            path="/mcp/github",
+            status="active",
+        )
+
+        docs = server.to_documents()
+        prompt_doc = next(doc for doc in docs if doc.metadata.get("entity_type") == "prompt")
+
+        assert "github" in prompt_doc.page_content
+        assert "/mcp/github" in prompt_doc.page_content
+        assert "code_review" in prompt_doc.page_content
 
     def test_a2a_to_documents_includes_runtime_version_metadata(self):
         from registry_pkgs.models.a2a_agent import AgentConfig

--- a/registry/src/registry/api/v1/search_routes.py
+++ b/registry/src/registry/api/v1/search_routes.py
@@ -248,7 +248,7 @@ class SearchRequest(BaseModel):
 def _build_search_filters(search: SearchRequest) -> dict[str, object]:
     """Build vector-store filters from the request."""
     return {
-        "enabled": not search.idnclude_disabled,
+        "enabled": not search.include_disabled,
         "entity_type": list(search.type_list or list(ServerEntityType)),
     }
 

--- a/registry/src/registry/api/v1/search_routes.py
+++ b/registry/src/registry/api/v1/search_routes.py
@@ -253,6 +253,45 @@ def _build_search_filters(search: SearchRequest) -> dict[str, object]:
     }
 
 
+def _compute_confidence(results: list) -> str:
+    """
+    Compute a relative confidence signal from the result set.
+
+    Uses the score gap between the top result and the second result rather than
+    an absolute threshold, so the signal stays valid regardless of embedding model,
+    reranker, or data distribution changes.
+
+    Returns:
+        "high"      — top result clearly dominates; safe to execute directly
+        "low"       — top result has a modest lead; LLM should review before executing
+        "ambiguous" — results cluster together; better to retry with a refined query
+        "none"      — no results returned
+    """
+    if not results:
+        return "none"
+
+    scores = [r.get("relevance_score") for r in results if isinstance(r, dict) and r.get("relevance_score") is not None]
+
+    # filter-only results (empty query path) carry no semantic score — treat as high
+    if not scores:
+        return "high" if results else "none"
+
+    top = scores[0]
+
+    if len(scores) == 1:
+        return "high" if top >= 0.5 else "low"
+
+    gap = top - scores[1]
+
+    # We need to adjust according to the actual situation.
+    if gap >= 0.2:
+        return "high"
+    elif gap >= 0.08:
+        return "low"
+    else:
+        return "ambiguous"
+
+
 async def _search_documents(
     search: SearchRequest,
     query: str,
@@ -312,7 +351,13 @@ async def search_entities_impl(
         success = True
         results_count = len(search_results)
 
-        return {"query": query, "type_list": search.type_list, "total": len(search_results), "results": search_results}
+        return {
+            "query": query,
+            "type_list": search.type_list,
+            "total": len(search_results),
+            "confidence": _compute_confidence(search_results),
+            "results": search_results,
+        }
     finally:
         duration = time.perf_counter() - start_time
         try:

--- a/registry/src/registry/api/v1/search_routes.py
+++ b/registry/src/registry/api/v1/search_routes.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import time
 from typing import Literal
@@ -12,10 +11,9 @@ from registry_pkgs.vector.repositories.mcp_server_repository import MCPServerRep
 
 from ...auth.dependencies import CurrentUser
 from ...core.telemetry_decorators import track_registry_operation
-from ...deps import get_mcp_server_repo, get_server_service, get_vector_service
+from ...deps import get_mcp_server_repo, get_vector_service
 from ...schemas.case_conversion import APIBaseModel
 from ...services.search.base import VectorSearchService
-from ...services.server_service import ServerServiceV1
 from ...utils.otel_metrics import record_tool_discovery
 
 logger = logging.getLogger(__name__)
@@ -247,78 +245,25 @@ class SearchRequest(BaseModel):
     include_disabled: bool = Field(default=False, description="Include disabled results")
 
 
-def _is_server_only_search(type_list: list[ServerEntityType] | None) -> bool:
-    """Return True only for the dedicated full-server discovery path."""
-    return bool(type_list) and len(type_list) == 1 and type_list[0] == ServerEntityType.SERVER
-
-
 def _build_search_filters(search: SearchRequest) -> dict[str, object]:
-    """Build shared vector-store filters from the request."""
+    """Build vector-store filters from the request."""
     return {
         "enabled": not search.include_disabled,
-        "entity_type": list(search.type_list),
+        "entity_type": list(search.type_list or list(ServerEntityType)),
     }
 
 
-def _serialize_search_results(results: list) -> list:
-    """Normalize model instances into JSON-compatible dicts for API/tool output."""
-    return [result.model_dump(mode="json") if hasattr(result, "model_dump") else result for result in results]
-
-
-async def _fetch_servers_by_ids(server_ids: list[str], server_service: ServerServiceV1) -> list:
-    """Load full server documents from Mongo for the matched server ids."""
-    async with asyncio.TaskGroup() as tg:
-        tasks = [tg.create_task(server_service.get_server_by_id(server_id)) for server_id in server_ids]
-    return [server for task in tasks if (server := task.result()) is not None]
-
-
-def _extract_unique_server_ids(results: list[dict[str, object]]) -> list[str]:
-    """Preserve result order while removing duplicate/empty server ids."""
-    seen_server_ids: set[str] = set()
-    server_ids: list[str] = []
-    for result in results:
-        server_id = str(result.get("server_id"))
-        if not server_id or server_id in seen_server_ids:
-            continue
-        seen_server_ids.add(server_id)
-        server_ids.append(server_id)
-    return server_ids
-
-
-async def _search_server_documents(
-    search: SearchRequest,
-    query: str,
-    server_service: ServerServiceV1,
-    mcp_server_repo: MCPServerRepository,
-) -> list:
-    """Run the full-server discovery path using Mongo fallback for empty queries."""
-    if not query:
-        status = None if search.include_disabled else "active"
-        raw_servers, _ = await server_service.list_servers(
-            query=None,
-            status=status,
-            page=1,
-            per_page=search.top_n,
-        )
-        return raw_servers
-
-    filters = _build_search_filters(search)
-    results = await mcp_server_repo.asearch_with_rerank(
-        query=query,
-        search_type=search.search_type,
-        filters=filters,
-        k=search.top_n,
-    )
-    server_ids = _extract_unique_server_ids(results)
-    return await _fetch_servers_by_ids(server_ids, server_service)
-
-
-async def _search_non_server_documents(
+async def _search_documents(
     search: SearchRequest,
     query: str,
     mcp_server_repo: MCPServerRepository,
 ) -> list:
-    """Run tool/resource/prompt discovery, using metadata filtering for empty queries."""
+    """
+    Run vector discovery for all entity types (tool, resource, prompt).
+
+    Empty query uses metadata filtering; non-empty query uses semantic search with reranking.
+    All results carry tool_name directly from the vector store — no MongoDB lookup required.
+    """
     filters = _build_search_filters(search)
     if not query:
         return await mcp_server_repo.afilter(filters=filters, limit=search.top_n)
@@ -336,10 +281,15 @@ async def search_servers_impl(
     search: SearchRequest,
     user_context: CurrentUser,
     *,
-    server_service: ServerServiceV1,
     mcp_server_repo: MCPServerRepository,
 ) -> dict[str, object]:
-    """Shared server discovery implementation for both FastAPI routes and MCP tools."""
+    """
+    Shared discovery implementation for both FastAPI routes and MCP tools.
+
+    All entity types (tool, resource, prompt) go through the same vector path.
+    Every tool/resource/prompt doc embeds its server context (name, path, title, description)
+    in the document content, so vector search is fully self-contained — no MongoDB lookup needed.
+    """
     query = search.query.strip()
     top_n = search.top_n
     start_time = time.perf_counter()
@@ -353,13 +303,8 @@ async def search_servers_impl(
     )
 
     try:
-        if _is_server_only_search(search.type_list):
-            raw_servers = await _search_server_documents(search, query, server_service, mcp_server_repo)
-            search_results = _serialize_search_results(raw_servers)
-            logger.info(f"Found {len(search_results)} servers with full details")
-        else:
-            search_results = await _search_non_server_documents(search, query, mcp_server_repo)
-            logger.info(f"✅ Found {len(search_results)} servers")
+        search_results = await _search_documents(search, query, mcp_server_repo)
+        logger.info(f"✅ Found {len(search_results)} results")
 
         success = True
         results_count = len(search_results)
@@ -383,7 +328,7 @@ def _record_discovery_metrics(
     """Record discovery metrics once per discovered server name."""
     discovered_names: set[str] = set()
     for result in search_results:
-        name = getattr(result, "serverName", None) or (result.get("server_name") if isinstance(result, dict) else None)
+        name = result.get("server_name") if isinstance(result, dict) else None
         if name:
             discovered_names.add(name)
 
@@ -412,27 +357,25 @@ def _record_discovery_metrics(
 async def search_servers(
     search: SearchRequest,
     user_context: CurrentUser,
-    server_service: ServerServiceV1 = Depends(get_server_service),
     mcp_server_repo: MCPServerRepository = Depends(get_mcp_server_repo),
 ):
     """
-    Search for MCP servers with their tools, resources, and prompts.
-    POC endpoint returning raw JSON with dual-format tool definitions.
+    Search for MCP tools, resources, and prompts via vector search.
+
+    All entity types go through the unified vector path.
+    Results always contain tool_name and server_id directly, ready for execute_tool.
 
     Request body:
     {
         "query": "search",
         "top_n": 5,
-        "search_type": "hybrid",  # Optional: "near_text", near_vector,"bm25", or "hybrid" (default: "hybrid")
-        "type_list": ["server"], # Optional: ["server", "tool", "resource", "prompt"] (default: ["server"])
-        "include_disabled": false  # Optional: include disabled servers (default: false)
+        "search_type": "hybrid",  # Optional: "near_text", "bm25", or "hybrid" (default)
+        "type_list": ["tool"],    # Optional: ["tool", "resource", "prompt"] (default: all)
+        "include_disabled": false
     }
-
-    Returns raw JSON that can be converted to ExtendedMCPServer format.
     """
     return await search_servers_impl(
         search,
         user_context,
-        server_service=server_service,
         mcp_server_repo=mcp_server_repo,
     )

--- a/registry/src/registry/api/v1/search_routes.py
+++ b/registry/src/registry/api/v1/search_routes.py
@@ -277,7 +277,7 @@ async def _search_documents(
     )
 
 
-async def search_servers_impl(
+async def search_entities_impl(
     search: SearchRequest,
     user_context: CurrentUser,
     *,
@@ -309,7 +309,7 @@ async def search_servers_impl(
         success = True
         results_count = len(search_results)
 
-        return {"query": query, "type_list": search.type_list, "total": len(search_results), "servers": search_results}
+        return {"query": query, "type_list": search.type_list, "total": len(search_results), "results": search_results}
     finally:
         duration = time.perf_counter() - start_time
         try:
@@ -374,7 +374,7 @@ async def search_servers(
         "include_disabled": false
     }
     """
-    return await search_servers_impl(
+    return await search_entities_impl(
         search,
         user_context,
         mcp_server_repo=mcp_server_repo,

--- a/registry/src/registry/api/v1/search_routes.py
+++ b/registry/src/registry/api/v1/search_routes.py
@@ -255,45 +255,6 @@ def _build_search_filters(search: SearchRequest) -> dict[str, object]:
     return filters
 
 
-def _compute_confidence(results: list) -> str:
-    """
-    Compute a relative confidence signal from the result set.
-
-    Uses the score gap between the top result and the second result rather than
-    an absolute threshold, so the signal stays valid regardless of embedding model,
-    reranker, or data distribution changes.
-
-    Returns:
-        "high"      — top result clearly dominates; safe to execute directly
-        "low"       — top result has a modest lead; LLM should review before executing
-        "ambiguous" — results cluster together; better to retry with a refined query
-        "none"      — no results returned
-    """
-    if not results:
-        return "none"
-
-    scores = [r.get("relevance_score") for r in results if isinstance(r, dict) and r.get("relevance_score") is not None]
-
-    # filter-only results (empty query path) carry no semantic score — treat as high
-    if not scores:
-        return "high" if results else "none"
-
-    top = scores[0]
-
-    if len(scores) == 1:
-        return "high" if top >= 0.5 else "low"
-
-    gap = top - scores[1]
-
-    # We need to adjust according to the actual situation.
-    if gap >= 0.2:
-        return "high"
-    elif gap >= 0.08:
-        return "low"
-    else:
-        return "ambiguous"
-
-
 async def _search_documents(
     search: SearchRequest,
     query: str,
@@ -357,7 +318,6 @@ async def search_entities_impl(
             "query": query,
             "type_list": search.type_list,
             "total": len(search_results),
-            "confidence": _compute_confidence(search_results),
             "results": search_results,
         }
     finally:

--- a/registry/src/registry/api/v1/search_routes.py
+++ b/registry/src/registry/api/v1/search_routes.py
@@ -247,10 +247,12 @@ class SearchRequest(BaseModel):
 
 def _build_search_filters(search: SearchRequest) -> dict[str, object]:
     """Build vector-store filters from the request."""
-    return {
-        "enabled": not search.include_disabled,
+    filters: dict[str, object] = {
         "entity_type": list(search.type_list or list(ServerEntityType)),
     }
+    if not search.include_disabled:
+        filters["enabled"] = True
+    return filters
 
 
 def _compute_confidence(results: list) -> str:

--- a/registry/src/registry/api/v1/search_routes.py
+++ b/registry/src/registry/api/v1/search_routes.py
@@ -248,7 +248,7 @@ class SearchRequest(BaseModel):
 def _build_search_filters(search: SearchRequest) -> dict[str, object]:
     """Build vector-store filters from the request."""
     return {
-        "enabled": not search.include_disabled,
+        "enabled": not search.idnclude_disabled,
         "entity_type": list(search.type_list or list(ServerEntityType)),
     }
 
@@ -262,7 +262,10 @@ async def _search_documents(
     Run vector discovery for all entity types (tool, resource, prompt).
 
     Empty query uses metadata filtering; non-empty query uses semantic search with reranking.
-    All results carry tool_name directly from the vector store — no MongoDB lookup required.
+
+    Results include entity-specific identifiers directly from the vector store
+    (for example: tools use `tool_name`, resources use `resource_uri`, and prompts use `prompt_name`)
+    with no MongoDB lookup required.
     """
     filters = _build_search_filters(search)
     if not query:
@@ -363,7 +366,12 @@ async def search_servers(
     Search for MCP tools, resources, and prompts via vector search.
 
     All entity types go through the unified vector path.
-    Results always contain tool_name and server_id directly, ready for execute_tool.
+    Results always contain the execution-ready identifier for their entity type:
+    - tool -> tool_name
+    - resource -> resource_uri
+    - prompt -> prompt_name
+
+    Each result also includes server_id.
 
     Request body:
     {

--- a/registry/src/registry/mcpgw/server.py
+++ b/registry/src/registry/mcpgw/server.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 _SYSTEM_INSTRUCTIONS = """This MCP Gateway provides unified access to registered MCP servers through centralized discovery and execution.
 
 KEY CAPABILITIES:
-- Discover tools, resources, prompts, or full server documents across registered MCP servers
+- Discover tools, resources, and prompts across registered MCP servers
 - Execute downstream MCP tools through a unified proxy
 - Access downstream resources and prompts through the same registry
 - Route requests with the server's configured authentication and connection settings
@@ -28,7 +28,7 @@ GLOBAL WORKFLOW RULES:
 1. If you do not already have a suitable tool for the user's request, call `discover_servers` first.
 2. Do not respond that you lack capability until you have attempted discovery.
 3. If a native fetch or direct access attempt fails with authentication, permission, or access errors, fall back to `discover_servers`.
-4. Prefer `type_list=["tool"]` first. Use `type_list=["server"]` only when you need a full server document to inspect all capabilities on that server.
+4. Prefer `type_list=["tool"]` first.
 
 WHEN TO FALL BACK TO DISCOVERY:
 - Private repository or API access fails
@@ -36,40 +36,41 @@ WHEN TO FALL BACK TO DISCOVERY:
 - A specialized external service is likely needed
 - The user asks what capabilities exist for a domain or service
 
-TOKEN-EFFICIENT DISCOVERY:
-- `type_list=["tool"]`: default and preferred for executable tools
-- `type_list=["resource"]`: for data sources or URIs
+DISCOVERY TYPES:
+- `type_list=["tool"]`: default and preferred — returns executable tools
+- `type_list=["resource"]`: for data sources, cached results, or URI-addressable content
 - `type_list=["prompt"]`: for reusable prompt workflows
-- `type_list=["server"]`: only when you need the full Mongo-style server document
 
-CRITICAL RESULT INTERPRETATION RULE:
-- Treat discovery results as full server documents only when `type_list` is exactly `["server"]`.
-- In every other case, including `type_list=["tool"]`, treat each returned item as a directly usable result for execution purposes.
+CORE RULE — NO SECONDARY LOOKUP NEEDED:
+Every discovery result already contains all fields required for execution.
+Do not inspect nested config, do not look up additional documents, do not transform any field.
 
-EXECUTION RULES:
-- `execute_tool` always runs exactly one downstream MCP tool.
-- The `tool_name` parameter of the `execute_tool` call must always be the final downstream MCP tool name.
-- If the previous discovery call used exactly `type_list=["server"]`, first inspect the `$.config.toolFunctions` field of the server document, choose one tool entry, and pass that chosen entry's `mcpToolName` as `tool_name`. Only if `mcpToolName` is missing may you fall back to that tool entry's key or name.
-- In every other discovery case, pass the returned `tool_name` unchanged into the `tool_name` parameter of the `execute_tool` call.
-- Pair the chosen `tool_name` with the matching `server_id` from the same discovery result or chosen server document.
+EXECUTION PATTERN (by type):
+- Tool    → `execute_tool(tool_name=<result.tool_name>, server_id=<result.server_id>, arguments={...})`
+- Resource → `read_resource(server_id=<result.server_id>, resource_uri=<result.resource_uri>)`
+- Prompt  → `execute_prompt(server_id=<result.server_id>, prompt_name=<result.prompt_name>, arguments={...})`
 
-EXAMPLES:
+EXECUTION CONSTRAINTS:
+- `execute_tool` runs exactly one downstream MCP tool per call.
+- Pass `tool_name` exactly as returned — do not invent, rename, or rewrite it.
+- Always pair `tool_name` with the `server_id` from the same discovery result.
+
+COMPLETE WORKFLOW EXAMPLE:
+  Step 1 — Discover:
+    discover_servers(query="web search news", type_list=["tool"])
+    → [{"tool_name": "tavily_search", "server_id": "abc123", "server_name": "tavily", ...}]
+
+  Step 2 — Execute immediately using the returned fields:
+    execute_tool(tool_name="tavily_search", server_id="abc123", arguments={"query": "AI news"})
+
+DISCOVERY EXAMPLES:
 - Weather or current events → `discover_servers(query="weather forecast", type_list=["tool"])`
-- Web search → `discover_servers(query="web search news", type_list=["tool"])`
-- Stock prices → `discover_servers(query="financial data stock market", type_list=["tool"])`
-- Explore full capabilities of a server domain → `discover_servers(query="github", type_list=["server"])`
-- Access failure on a protected service → `discover_servers(query="<service> authenticated", type_list=["tool"])`
-
-SERVER-DOCUMENT EXAMPLE:
-- If `discover_servers(..., type_list=["server"])` returns a server whose `$.config.toolFunctions` contains:
-  - `add_numbers_mcp_minimal_mcp_iam -> mcpToolName="add_numbers"`
-  - `greet_mcp_minimal_mcp_iam -> mcpToolName="greet"`
-- Then first choose the single tool entry that matches the task.
-- To execute the add tool, call `execute_tool(tool_name="add_numbers", server_id="<server id>", arguments={...})`.
-- To execute the greet tool, call `execute_tool(tool_name="greet", server_id="<server id>", arguments={...})`.
-
-TOOL-RESULT EXAMPLE:
-- If discovery returns `{"tool_name": "tavily_search", "server_id": "abc123", ...}`, call `execute_tool(tool_name="tavily_search", server_id="abc123", arguments={...})`.
+- Web search              → `discover_servers(query="web search news", type_list=["tool"])`
+- Stock prices            → `discover_servers(query="financial data stock market", type_list=["tool"])`
+- GitHub operations       → `discover_servers(query="github repositories", type_list=["tool"])`
+- Cached / URI data       → `discover_servers(query="cached results", type_list=["resource"])`
+- Prompt templates        → `discover_servers(query="code review template", type_list=["prompt"])`
+- Auth failure fallback   → `discover_servers(query="<service> authenticated", type_list=["tool"])`
 """
 
 

--- a/registry/src/registry/mcpgw/server.py
+++ b/registry/src/registry/mcpgw/server.py
@@ -23,34 +23,58 @@ DISCOVERY CHAIN:
    filler words, pronouns, and tense. Do NOT pass the user's raw sentence.
 2. Call discover_entities(query). Default type_list=["tool","resource","prompt"] covers all intent
    shapes in a single round trip. Only narrow type_list when you are certain of the entity type.
-3. Inspect results[].relevance_score and results[].description:
+3. Inspect results[].relevance_score, results[].description, and results[].server_name:
    - Relevance is RELATIVE, not absolute. Compare scores across the returned set — a clear leader
      is trustworthy; clustered scores mean the match is uncertain.
    - Always verify the top result's `description` actually matches the user's intent.
+   - When scores cluster, check server_name across results: same server → ambiguity is about which
+     operation; different servers → ambiguity is about which provider.
 4. Execute the chosen entity immediately using identifiers from the result, verbatim.
 
-EXAMPLES (query formulation + score interpretation):
+EXAMPLES (query formulation + score interpretation + server-aware fallback):
 
 Example 1 — clear leader, execute directly:
   User: "Can you help me find bugs in my GitHub repo?"
   Call: discover_entities(query="github issues")
-  Returns: [{relevance_score:0.82, tool_name:"github_list_issues", description:"List issues in a repo"},
-           {relevance_score:0.31, tool_name:"jira_search",        description:"Search JIRA tickets"}]
-  -> Clear leader (0.82 vs 0.31). Call execute_tool(tool_name="github_list_issues", server_id=..., arguments={...}).
+  Returns: [{relevance_score:0.82, server_name:"github-mcp", tool_name:"github_list_issues", description:"List issues in a repo"},
+           {relevance_score:0.31, server_name:"jira-mcp",   tool_name:"jira_search",        description:"Search JIRA tickets"}]
+  -> Clear leader. Call execute_tool(tool_name="github_list_issues", server_id=..., arguments={...}).
 
-Example 2 — clustered scores, ask user to disambiguate:
+Example 2 — clustered within ONE server, ask which operation:
+  User: "do something with my slack"
+  Call: discover_entities(query="slack")
+  Returns: [{relevance_score:0.51, server_name:"slack-mcp", tool_name:"slack_post"},
+           {relevance_score:0.48, server_name:"slack-mcp", tool_name:"slack_list_channels"},
+           {relevance_score:0.46, server_name:"slack-mcp", tool_name:"slack_read_messages"}]
+  -> All from slack-mcp; ambiguity is about the action. Ask the user which operation.
+
+Example 3 — clustered across DIFFERENT servers, retry with server name in query:
   User: "send a notification about the incident"
-  Call: discover_entities(query="send notification")
-  Returns: [{relevance_score:0.44, tool_name:"slack_post"},
-           {relevance_score:0.41, tool_name:"email_send"},
-           {relevance_score:0.38, tool_name:"sms_send"}]
-  -> Scores clustered. Ask the user which channel before executing.
+  Call 1: discover_entities(query="send notification")
+  Returns: [{relevance_score:0.44, server_name:"slack-mcp",  tool_name:"slack_post"},
+           {relevance_score:0.41, server_name:"email-mcp",  tool_name:"email_send"},
+           {relevance_score:0.38, server_name:"twilio-mcp", tool_name:"sms_send"}]
+  -> Different servers, no clear winner. Ask the user which channel. If the user answers "slack":
+  Call 2: discover_entities(query="slack post message")
+  -> Clear leader from slack-mcp; execute.
 
-Example 3 — non-tool intent, mixed type_list finds it in one call:
+Example 4 — non-tool intent, mixed type_list finds it in one call:
   User: "please summarize yesterday's meeting notes"
   Call: discover_entities(query="summarize meeting notes")
   Returns top result with entity_type="prompt", relevance_score 0.71, clearly leading.
   -> Call execute_prompt(prompt_name=..., server_id=..., arguments={...}).
+
+Example 5 — survey fallback when keywords fail:
+  User: "make a quick memo about this"
+  Call 1: discover_entities(query="create memo") -> empty or all < 0.2.
+  Call 2: discover_entities(query="note")        -> empty.
+  Call 3 (SURVEY): discover_entities(query="", top_n=20)
+  -> Returns a capability catalog. Group mentally by server_name:
+       • notes-mcp: create_note, list_notes, delete_note
+       • github-mcp: github_list_issues, github_create_issue, ...
+       • slack-mcp: slack_post, slack_list_channels, ...
+  -> Spot notes-mcp. Call 4: discover_entities(query="notes-mcp create note") or execute directly
+     using the identifiers already returned by the survey.
 
 EXECUTION (use identifiers verbatim; never transform, shorten, or invent them):
 - Tool     -> execute_tool(tool_name=<result.tool_name>, server_id=<result.server_id>, arguments={...})
@@ -58,18 +82,23 @@ EXECUTION (use identifiers verbatim; never transform, shorten, or invent them):
 - Prompt   -> execute_prompt(server_id=<result.server_id>, prompt_name=<result.prompt_name>, arguments={...})
 
 WHEN NO SUITABLE ENTITY IS FOUND (empty results, low scores, or no description matches intent):
-1. Retry with REFINED keywords — synonyms or the domain term the user actually used
+1. Refine keywords — synonyms, the domain term the user actually used
    (e.g. "github issues" instead of "bug tracker").
-2. Retry with BROADER keywords — drop qualifiers, use the core noun/verb alone.
-3. SURVEY fallback: call discover_entities(query="", top_n=20) to list registered capabilities when
-   user phrasing may not match any registered name.
-4. If nothing matches after the survey, tell the user plainly: the gateway has no registered
+2. Broaden keywords — drop qualifiers, use the core noun/verb alone.
+3. SURVEY: call discover_entities(query="", top_n=20). The results are a capability catalog — group
+   them mentally by server_name to see which servers exist and what each provides.
+4. If a relevant server appears in the survey, retry with its name in the query
+   (e.g. discover_entities(query="<server_name> <capability>")). The server_name is embedded in
+   document content, so hybrid search will narrow effectively.
+5. If nothing matches after the survey, tell the user plainly: the gateway has no registered
    capability for this request. Do NOT fabricate tool_name / resource_uri / prompt_name / server_id.
 
 RULES:
 - Never claim lack of capability before running discover_entities at least once.
 - Never call execute_tool / read_resource / execute_prompt with identifiers not returned by discover_entities.
 - Prefer one discovery call with good keywords over many narrow calls.
+- When clustered, distinguish same-server ambiguity (ask which operation) from cross-server ambiguity
+  (ask which provider, then retry with the provider name in the query).
 """
 
 

--- a/registry/src/registry/mcpgw/server.py
+++ b/registry/src/registry/mcpgw/server.py
@@ -16,61 +16,57 @@ from .tools import proxied, search
 if TYPE_CHECKING:
     from ..container import RegistryContainer
 
-_SYSTEM_INSTRUCTIONS = """This MCP Gateway provides unified access to registered MCP servers through centralized discovery and execution.
+_SYSTEM_INSTRUCTIONS = """This MCP Gateway provides unified discovery and execution for registered MCP entities.
 
 KEY CAPABILITIES:
-- Discover tools, resources, and prompts across registered MCP servers
+- Discover tools, resources, and prompts through a unified vector index
 - Execute downstream MCP tools through a unified proxy
-- Access downstream resources and prompts through the same registry
-- Route requests with the server's configured authentication and connection settings
+- Read downstream MCP resources
+- Execute downstream MCP prompts
+
+IMPORTANT MENTAL MODEL:
+- Discovery is ENTITY-based, not SERVER-based.
+- The discovery tool returns matched entity documents from the vector index.
+- Results are already execution-ready.
+- Do not perform secondary lookups or name translation after discovery.
 
 GLOBAL WORKFLOW RULES:
-1. If you do not already have a suitable tool for the user's request, call `discover_servers` first.
-2. Do not respond that you lack capability until you have attempted discovery.
-3. If a native fetch or direct access attempt fails with authentication, permission, or access errors, fall back to `discover_servers`.
-4. Prefer `type_list=["tool"]` first.
+1. If you do not already have a suitable tool, call `discover_entities` first.
+2. Prefer `type_list=["tool"]` first for action-oriented tasks.
+3. Do not claim lack of capability until discovery has been attempted.
+4. If a direct/native attempt fails with authentication or permission errors, fall back to discovery.
 
-WHEN TO FALL BACK TO DISCOVERY:
-- Private repository or API access fails
-- Authentication or authorization fails (401, 403, permission denied)
-- A specialized external service is likely needed
-- The user asks what capabilities exist for a domain or service
+DISCOVERY RESULT TYPES:
+- `type_list=["tool"]`
+  returns tool entity documents with `tool_name` + `server_id`
+- `type_list=["resource"]`
+  returns resource entity documents with `resource_uri` + `server_id`
+- `type_list=["prompt"]`
+  returns prompt entity documents with `prompt_name` + `server_id`
 
-DISCOVERY TYPES:
-- `type_list=["tool"]`: default and preferred — returns executable tools
-- `type_list=["resource"]`: for data sources, cached results, or URI-addressable content
-- `type_list=["prompt"]`: for reusable prompt workflows
+CORE RULE — RESULTS ARE EXECUTION-READY:
+Every discovery result already contains the field needed for execution.
+Do not inspect nested config.
+Do not perform a second lookup.
+Do not transform returned names.
 
-CORE RULE — NO SECONDARY LOOKUP NEEDED:
-Every discovery result already contains all fields required for execution.
-Do not inspect nested config, do not look up additional documents, do not transform any field.
+EXECUTION PATTERN:
+- Tool     -> `execute_tool(tool_name=<result.tool_name>, server_id=<result.server_id>, arguments={...})`
+- Resource -> `read_resource(server_id=<result.server_id>, resource_uri=<result.resource_uri>)`
+- Prompt   -> `execute_prompt(server_id=<result.server_id>, prompt_name=<result.prompt_name>, arguments={...})`
 
-EXECUTION PATTERN (by type):
-- Tool    → `execute_tool(tool_name=<result.tool_name>, server_id=<result.server_id>, arguments={...})`
-- Resource → `read_resource(server_id=<result.server_id>, resource_uri=<result.resource_uri>)`
-- Prompt  → `execute_prompt(server_id=<result.server_id>, prompt_name=<result.prompt_name>, arguments={...})`
+NAME HANDLING RULES:
+- `tool_name` is the canonical downstream MCP tool name from the vector database.
+- Never derive it from wrapper names, display labels, `mcpToolName`, `mcp_tool_name`, or casing variants.
+- Use the returned `tool_name` verbatim.
 
-EXECUTION CONSTRAINTS:
-- `execute_tool` runs exactly one downstream MCP tool per call.
-- Pass `tool_name` exactly as returned — do not invent, rename, or rewrite it.
-- Always pair `tool_name` with the `server_id` from the same discovery result.
+EXAMPLE:
+Step 1 — Discover:
+  discover_entities(query="web search news", type_list=["tool"])
+  -> [{"entity_type": "tool", "tool_name": "tavily_search", "server_id": "abc123", ...}]
 
-COMPLETE WORKFLOW EXAMPLE:
-  Step 1 — Discover:
-    discover_servers(query="web search news", type_list=["tool"])
-    → [{"tool_name": "tavily_search", "server_id": "abc123", "server_name": "tavily", ...}]
-
-  Step 2 — Execute immediately using the returned fields:
-    execute_tool(tool_name="tavily_search", server_id="abc123", arguments={"query": "AI news"})
-
-DISCOVERY EXAMPLES:
-- Weather or current events → `discover_servers(query="weather forecast", type_list=["tool"])`
-- Web search              → `discover_servers(query="web search news", type_list=["tool"])`
-- Stock prices            → `discover_servers(query="financial data stock market", type_list=["tool"])`
-- GitHub operations       → `discover_servers(query="github repositories", type_list=["tool"])`
-- Cached / URI data       → `discover_servers(query="cached results", type_list=["resource"])`
-- Prompt templates        → `discover_servers(query="code review template", type_list=["prompt"])`
-- Auth failure fallback   → `discover_servers(query="<service> authenticated", type_list=["tool"])`
+Step 2 — Execute:
+  execute_tool(tool_name="tavily_search", server_id="abc123", arguments={"query": "AI news"})
 """
 
 
@@ -165,7 +161,7 @@ def register_tools(mcp: FastMCP) -> None:
     Args:
         mcp: FastMCP application instance
     """
-    # Register search tools (discover_tools, discover_servers)
+    # Register entity discovery tools
     for tool_name, tool_func in search.get_tools():
         mcp.tool(name=tool_name)(tool_func)
 

--- a/registry/src/registry/mcpgw/server.py
+++ b/registry/src/registry/mcpgw/server.py
@@ -18,22 +18,58 @@ if TYPE_CHECKING:
 
 _SYSTEM_INSTRUCTIONS = """MCP Gateway: discover and execute tools, resources, and prompts from registered MCP servers.
 
-WORKFLOW:
-1. Call discover_entities(query) to find the right entity.
-2. Execute immediately using the returned tool_name/resource_uri/prompt_name + server_id.
-3. Do not claim lack of capability until discovery has been attempted.
+DISCOVERY CHAIN:
+1. Formulate a CONCISE keyword query from the user's intent — core nouns/verbs + domain terms, drop
+   filler words, pronouns, and tense. Do NOT pass the user's raw sentence.
+2. Call discover_entities(query). Default type_list=["tool","resource","prompt"] covers all intent
+   shapes in a single round trip. Only narrow type_list when you are certain of the entity type.
+3. Inspect results[].relevance_score and results[].description:
+   - Relevance is RELATIVE, not absolute. Compare scores across the returned set — a clear leader
+     is trustworthy; clustered scores mean the match is uncertain.
+   - Always verify the top result's `description` actually matches the user's intent.
+4. Execute the chosen entity immediately using identifiers from the result, verbatim.
 
-EXECUTION:
+EXAMPLES (query formulation + score interpretation):
+
+Example 1 — clear leader, execute directly:
+  User: "Can you help me find bugs in my GitHub repo?"
+  Call: discover_entities(query="github issues")
+  Returns: [{relevance_score:0.82, tool_name:"github_list_issues", description:"List issues in a repo"},
+           {relevance_score:0.31, tool_name:"jira_search",        description:"Search JIRA tickets"}]
+  -> Clear leader (0.82 vs 0.31). Call execute_tool(tool_name="github_list_issues", server_id=..., arguments={...}).
+
+Example 2 — clustered scores, ask user to disambiguate:
+  User: "send a notification about the incident"
+  Call: discover_entities(query="send notification")
+  Returns: [{relevance_score:0.44, tool_name:"slack_post"},
+           {relevance_score:0.41, tool_name:"email_send"},
+           {relevance_score:0.38, tool_name:"sms_send"}]
+  -> Scores clustered. Ask the user which channel before executing.
+
+Example 3 — non-tool intent, mixed type_list finds it in one call:
+  User: "please summarize yesterday's meeting notes"
+  Call: discover_entities(query="summarize meeting notes")
+  Returns top result with entity_type="prompt", relevance_score 0.71, clearly leading.
+  -> Call execute_prompt(prompt_name=..., server_id=..., arguments={...}).
+
+EXECUTION (use identifiers verbatim; never transform, shorten, or invent them):
 - Tool     -> execute_tool(tool_name=<result.tool_name>, server_id=<result.server_id>, arguments={...})
 - Resource -> read_resource(server_id=<result.server_id>, resource_uri=<result.resource_uri>)
 - Prompt   -> execute_prompt(server_id=<result.server_id>, prompt_name=<result.prompt_name>, arguments={...})
 
-CONFIDENCE (from discover_entities result):
-- confidence=high:      execute the first result directly.
-- confidence=low:       review description before executing; consider refining the query first.
-- confidence=ambiguous: retry discover_entities with a more specific query.
-- confidence=none:      no results found; try different or broader keywords.
-- Use tool_name verbatim — never transform or derive it from other fields.
+WHEN NO SUITABLE ENTITY IS FOUND (empty results, low scores, or no description matches intent):
+1. Retry with REFINED keywords — synonyms or the domain term the user actually used
+   (e.g. "github issues" instead of "bug tracker").
+2. Retry with BROADER keywords — drop qualifiers, use the core noun/verb alone.
+3. SURVEY fallback: call discover_entities(query="", top_n=20) to list registered capabilities when
+   user phrasing may not match any registered name.
+4. If nothing matches after the survey, tell the user plainly: the gateway has no registered
+   capability for this request. Do NOT fabricate tool_name / resource_uri / prompt_name / server_id.
+
+RULES:
+- Never claim lack of capability before running discover_entities at least once.
+- Never call execute_tool / read_resource / execute_prompt with identifiers not returned by discover_entities.
+- Prefer one discovery call with good keywords over many narrow calls.
 """
 
 

--- a/registry/src/registry/mcpgw/server.py
+++ b/registry/src/registry/mcpgw/server.py
@@ -16,57 +16,22 @@ from .tools import proxied, search
 if TYPE_CHECKING:
     from ..container import RegistryContainer
 
-_SYSTEM_INSTRUCTIONS = """This MCP Gateway provides unified discovery and execution for registered MCP entities.
+_SYSTEM_INSTRUCTIONS = """MCP Gateway: discover and execute tools, resources, and prompts from registered MCP servers.
 
-KEY CAPABILITIES:
-- Discover tools, resources, and prompts through a unified vector index
-- Execute downstream MCP tools through a unified proxy
-- Read downstream MCP resources
-- Execute downstream MCP prompts
-
-IMPORTANT MENTAL MODEL:
-- Discovery is ENTITY-based, not SERVER-based.
-- The discovery tool returns matched entity documents from the vector index.
-- Results are already execution-ready.
-- Do not perform secondary lookups or name translation after discovery.
-
-GLOBAL WORKFLOW RULES:
-1. If you do not already have a suitable tool, call `discover_entities` first.
-2. Prefer `type_list=["tool"]` first for action-oriented tasks.
+WORKFLOW:
+1. Call discover_entities(query) to find the right entity.
+2. Execute immediately using the returned tool_name/resource_uri/prompt_name + server_id.
 3. Do not claim lack of capability until discovery has been attempted.
-4. If a direct/native attempt fails with authentication or permission errors, fall back to discovery.
 
-DISCOVERY RESULT TYPES:
-- `type_list=["tool"]`
-  returns tool entity documents with `tool_name` + `server_id`
-- `type_list=["resource"]`
-  returns resource entity documents with `resource_uri` + `server_id`
-- `type_list=["prompt"]`
-  returns prompt entity documents with `prompt_name` + `server_id`
+EXECUTION:
+- Tool     -> execute_tool(tool_name=<result.tool_name>, server_id=<result.server_id>, arguments={...})
+- Resource -> read_resource(server_id=<result.server_id>, resource_uri=<result.resource_uri>)
+- Prompt   -> execute_prompt(server_id=<result.server_id>, prompt_name=<result.prompt_name>, arguments={...})
 
-CORE RULE — RESULTS ARE EXECUTION-READY:
-Every discovery result already contains the field needed for execution.
-Do not inspect nested config.
-Do not perform a second lookup.
-Do not transform returned names.
-
-EXECUTION PATTERN:
-- Tool     -> `execute_tool(tool_name=<result.tool_name>, server_id=<result.server_id>, arguments={...})`
-- Resource -> `read_resource(server_id=<result.server_id>, resource_uri=<result.resource_uri>)`
-- Prompt   -> `execute_prompt(server_id=<result.server_id>, prompt_name=<result.prompt_name>, arguments={...})`
-
-NAME HANDLING RULES:
-- `tool_name` is the canonical downstream MCP tool name from the vector database.
-- Never derive it from wrapper names, display labels, `mcpToolName`, `mcp_tool_name`, or casing variants.
-- Use the returned `tool_name` verbatim.
-
-EXAMPLE:
-Step 1 — Discover:
-  discover_entities(query="web search news", type_list=["tool"])
-  -> [{"entity_type": "tool", "tool_name": "tavily_search", "server_id": "abc123", ...}]
-
-Step 2 — Execute:
-  execute_tool(tool_name="tavily_search", server_id="abc123", arguments={"query": "AI news"})
+RELEVANCE SCORE:
+- score >= 0.6: execute directly.
+- score < 0.6 or empty results: retry with a more specific query before executing.
+- Use tool_name verbatim — never transform or derive it from other fields.
 """
 
 

--- a/registry/src/registry/mcpgw/server.py
+++ b/registry/src/registry/mcpgw/server.py
@@ -28,9 +28,11 @@ EXECUTION:
 - Resource -> read_resource(server_id=<result.server_id>, resource_uri=<result.resource_uri>)
 - Prompt   -> execute_prompt(server_id=<result.server_id>, prompt_name=<result.prompt_name>, arguments={...})
 
-RELEVANCE SCORE:
-- score >= 0.6: execute directly.
-- score < 0.6 or empty results: retry with a more specific query before executing.
+CONFIDENCE (from discover_entities result):
+- confidence=high:      execute the first result directly.
+- confidence=low:       review description before executing; consider refining the query first.
+- confidence=ambiguous: retry discover_entities with a more specific query.
+- confidence=none:      no results found; try different or broader keywords.
 - Use tool_name verbatim — never transform or derive it from other fields.
 """
 

--- a/registry/src/registry/mcpgw/tools/proxied.py
+++ b/registry/src/registry/mcpgw/tools/proxied.py
@@ -633,8 +633,9 @@ def get_tools() -> list[tuple[str, Callable]]:
             str,
             Field(
                 description=(
-                    "The `tool_name` field from the discover_servers result — use verbatim, no transformation. "
-                    "This exact string is forwarded as `$.params.name` in the JSON-RPC `tools/call` request to the downstream MCP server."
+                    "The canonical downstream MCP tool name from a discover_entities result. "
+                    "Use the exact `tool_name` value returned by discovery. "
+                    "Do not transform casing, do not derive from wrapper names, and do not use aliases."
                 )
             ),
         ],
@@ -653,71 +654,37 @@ def get_tools() -> list[tuple[str, Callable]]:
             str,
             Field(
                 description=(
-                    "The `server_id` field from the same discover_servers result as `tool_name`. "
-                    "Always pair tool_name and server_id from the same result — never mix across results."
+                    "The `server_id` from the SAME discover_entities result as `tool_name`. "
+                    "Always pair the exact `tool_name` and `server_id` from the same entity result."
                 )
             ),
         ],
     ) -> CallToolResult:
         """
-        🚀 AUTO-USE: Execute one downstream MCP tool discovered via discover_servers.
+        🚀 AUTO-USE: Execute one downstream MCP tool returned by discover_entities.
+        Use this only with a discovery result whose `entity_type` is `tool`.
 
-        **When to call:**
-        Call immediately after discover_servers returns a result with entity_type == "tool".
-        Never guess or invent a tool_name — always use the exact value returned by discover_servers.
+        IMPORTANT:
+        - Discovery already resolved the canonical downstream tool name.
+        - `tool_name` is the exact value to send in downstream MCP `tools/call.params.name`.
+        - Do not translate from wrapper names, display names, `mcpToolName`, `mcp_tool_name`,
+          or any camelCase/snake_case variant.
+        - Do not perform a second lookup to resolve the tool name.
 
-        **Parameter mapping — from discovery result to execute_tool:**
-
-          Discovery result:
+        Mapping:
+          discovery result:
             {
-              "tool_name":  "tavily_search",       ← tool_name parameter
-              "server_id":  "abc123",              ← server_id parameter
-              "server_name": "tavily",
-              "content":    "... Parameters: query (string, required, search query), max_results (integer, optional) ..."
-            }                                         ↑ read this to build arguments
+              "entity_type": "tool",
+              "tool_name": "tavily_search",
+              "server_id": "abc123"
+            }
 
-          Execute call:
+          execution:
             execute_tool(
-                tool_name="tavily_search",           ← verbatim from result["tool_name"]
-                server_id="abc123",                  ← verbatim from result["server_id"]
-                arguments={"query": "AI news"},      ← constructed from content
+                tool_name="tavily_search",
+                server_id="abc123",
+                arguments={...},
             )
-
-        **How to construct arguments:**
-        The `content` field of the discovery result contains parameter info in text form:
-          "Parameters: query (string, required, the search query), max_results (integer, optional, number of results)"
-        Parse it to identify parameter names and pass at minimum all required ones.
-
-        **Examples:**
-
-        Example 1 — web search:
-          # discover_servers(query="web search", type_list=["tool"])
-          # → {"tool_name": "tavily_search", "server_id": "abc123",
-          #    "content": "...Parameters: query (string, required), max_results (integer, optional)..."}
-          execute_tool(
-              tool_name="tavily_search",
-              server_id="abc123",
-              arguments={"query": "latest AI news", "max_results": 5},
-          )
-
-        Example 2 — GitHub:
-          # discover_servers(query="github pull requests", type_list=["tool"])
-          # → {"tool_name": "search_pull_requests", "server_id": "def456",
-          #    "content": "...Parameters: owner (string, required), repo (string, required), state (string, optional)..."}
-          execute_tool(
-              tool_name="search_pull_requests",
-              server_id="def456",
-              arguments={"owner": "myorg", "repo": "myproject", "state": "open"},
-          )
-
-        **Hard constraints:**
-        - tool_name must be the exact `tool_name` field from the discovery result.
-          Do not invent, rename, scope, or rewrite it. Do not pass a display label or alias.
-        - server_id must come from the SAME discovery result as tool_name — never mix across results.
-        - Runs exactly one downstream MCP tool per call.
-
-        **Return value:**
-        Tool-specific result (JSON, text, or binary — format varies by tool).
         """
         return await execute_tool_impl(
             ctx,

--- a/registry/src/registry/mcpgw/tools/proxied.py
+++ b/registry/src/registry/mcpgw/tools/proxied.py
@@ -798,7 +798,7 @@ def get_tools() -> list[tuple[str, Callable]]:
             Field(
                 description=(
                     "Prompt arguments as key-value pairs. "
-                    "Read the `content` field of the discovery result for argument names and required/optional status "
+                    "Read the `description` field of the discovery result for argument names and required/optional status "
                     "(format: 'Required: arg1 (description), ... | Optional: arg2 (description), ...'). "
                     "Pass None or omit if the prompt takes no arguments."
                 )
@@ -834,16 +834,16 @@ def get_tools() -> list[tuple[str, Callable]]:
             )
 
         **How to construct arguments:**
-        The `content` field of the discovery result lists required and optional arguments:
+        The `description` field of the discovery result lists required and optional arguments:
           "Required: topic (research topic) | Optional: depth (detail level, default: overview)"
         Pass all required arguments; include optional ones when the user specifies them.
 
         **Examples:**
 
         Example 1 — code review:
-          # discover_servers(query="code review template", type_list=["prompt"])
+          # discover_entities(query="code review template", type_list=["prompt"])
           # → {"prompt_name": "code_reviewer", "server_id": "abc123",
-          #    "content": "... Required: language (programming language) | Optional: focus (review area) ..."}
+          #    "description": "... Required: language (programming language) | Optional: focus (review area) ..."}
           execute_prompt(
               server_id="abc123",
               prompt_name="code_reviewer",
@@ -851,9 +851,9 @@ def get_tools() -> list[tuple[str, Callable]]:
           )
 
         Example 2 — research assistant:
-          # discover_servers(query="research assistant", type_list=["prompt"])
+          # discover_entities(query="research assistant", type_list=["prompt"])
           # → {"prompt_name": "research_assistant", "server_id": "def456",
-          #    "content": "... Required: topic (research topic) | Optional: depth (detail level) ..."}
+          #    "description": "... Required: topic (research topic) | Optional: depth (detail level) ..."}
           execute_prompt(
               server_id="def456",
               prompt_name="research_assistant",

--- a/registry/src/registry/mcpgw/tools/proxied.py
+++ b/registry/src/registry/mcpgw/tools/proxied.py
@@ -632,71 +632,92 @@ def get_tools() -> list[tuple[str, Callable]]:
         tool_name: Annotated[
             str,
             Field(
-                description="Final downstream MCP tool name to execute. If the previous discovery call used `type_list=[\"server\"]` and only `server`, first choose one tool entry from `$.config.toolFunctions`, then pass that chosen entry's `mcpToolName` as `tool_name` (or fall back to that chosen entry's key/name only if `mcpToolName` is missing). In every other discovery case, pass the returned `tool_name` unchanged. This exact string is forwarded as the value of the `$.params.name` field in the JSON-RPC payload of the `tools/call` request to downstream MCP."
+                description=(
+                    "The `tool_name` field from the discover_servers result — use verbatim, no transformation. "
+                    "This exact string is forwarded as `$.params.name` in the JSON-RPC `tools/call` request to the downstream MCP server."
+                )
             ),
         ],
-        arguments: Annotated[dict[str, Any], Field(description="Tool parameters from input_schema")],
-        server_id: Annotated[str, Field(description="Server ID from discovery")],
+        arguments: Annotated[
+            dict[str, Any],
+            Field(
+                description=(
+                    "Tool input parameters as a key-value dict. "
+                    "Read the `content` field of the discovery result for parameter names, types, "
+                    "and required/optional status (format: 'Parameters: name (type, required/optional, description), ...'). "
+                    "Pass all required parameters; include optional ones when they improve the result."
+                )
+            ),
+        ],
+        server_id: Annotated[
+            str,
+            Field(
+                description=(
+                    "The `server_id` field from the same discover_servers result as `tool_name`. "
+                    "Always pair tool_name and server_id from the same result — never mix across results."
+                )
+            ),
+        ],
     ) -> CallToolResult:
         """
-        🚀 AUTO-USE: Execute any discovered tool to get real-time data.
+        🚀 AUTO-USE: Execute one downstream MCP tool discovered via discover_servers.
 
-        **Common Examples:**
-        ```
-        # Web search
-        execute_tool(
-            tool_name="tavily_search",
-            arguments={"query": "latest AI news", "max_results": 5},
-            server_id="6972e222755441652c23090f"
-        )
+        **When to call:**
+        Call immediately after discover_servers returns a result with entity_type == "tool".
+        Never guess or invent a tool_name — always use the exact value returned by discover_servers.
 
-        # GitHub operations
-        execute_tool(
-            tool_name="search_pull_requests",
-            arguments={"owner": "org", "repo": "project", "state": "open"},
-            server_id="abc123..."
-        )
-        ```
+        **Parameter mapping — from discovery result to execute_tool:**
 
-        **Parameters:**
-        - tool_name: Final downstream MCP tool name. This is the exact value that becomes the `$.params.name` field in the JSON-RPC payload of the `tools/call` request to downstream MCP.
-        - arguments: Tool-specific parameters from input_schema
-        - server_id: Server ID from discovery
+          Discovery result:
+            {
+              "tool_name":  "tavily_search",       ← tool_name parameter
+              "server_id":  "abc123",              ← server_id parameter
+              "server_name": "tavily",
+              "content":    "... Parameters: query (string, required, search query), max_results (integer, optional) ..."
+            }                                         ↑ read this to build arguments
 
-        **How to set `tool_name`:**
-        - Case 1: the previous discovery call used `type_list=["server"]` and only `server`.
-          - The discovery response contains full server documents in `servers`.
-          - Pick one server document.
-          - Inspect the `$.config.toolFunctions` field of that server document.
-          - Choose the single tool entry that best matches the user's task.
-          - Set `server_id` to that server document's `id`.
-          - Set `tool_name` to that chosen tool entry's `mcpToolName`.
-          - Only if `mcpToolName` is missing, fall back to that chosen tool entry's key/name.
-        - Case 2: every other discovery case, including `type_list=["tool"]`.
-          - The discovery response already contains executable tool results.
-          - Set `server_id` to the returned `server_id`.
-          - Set `tool_name` to the returned `tool_name` unchanged.
+          Execute call:
+            execute_tool(
+                tool_name="tavily_search",           ← verbatim from result["tool_name"]
+                server_id="abc123",                  ← verbatim from result["server_id"]
+                arguments={"query": "AI news"},      ← constructed from content
+            )
 
-        **Important constraints:**
-        - `execute_tool` always runs exactly one tool.
-        - `tool_name` must always be the final downstream MCP tool name.
-        - Do not invent, rename, scope, or rewrite the tool name.
-        - Do not pass a display label or registry-only alias.
-        - Do not pass the full server document into `execute_tool`.
-        - Pair the final `tool_name` with the matching `server_id` from the same discovery result.
+        **How to construct arguments:**
+        The `content` field of the discovery result contains parameter info in text form:
+          "Parameters: query (string, required, the search query), max_results (integer, optional, number of results)"
+        Parse it to identify parameter names and pass at minimum all required ones.
 
-        **Example:**
-        - If discover_servers returns `{"tool_name": "tavily_search", "server_id": "abc123"}`,
-          then call `execute_tool(tool_name="tavily_search", server_id="abc123", arguments={...})`.
-        - If a server result contains:
-          - `$.config.toolFunctions["add_numbers_mcp_minimal_mcp_iam"].mcpToolName = "add_numbers"`
-          - `$.config.toolFunctions["greet_mcp_minimal_mcp_iam"].mcpToolName = "greet"`
-          then first choose the correct tool entry for the task.
-          - To execute the add tool, call `execute_tool(tool_name="add_numbers", server_id="<server id>", arguments={...})`.
-          - To execute the greet tool, call `execute_tool(tool_name="greet", server_id="<server id>", arguments={...})`.
+        **Examples:**
 
-        ⚠️ Use after discover_servers to execute tools.
-        Returns: Tool-specific results (format varies by tool)
+        Example 1 — web search:
+          # discover_servers(query="web search", type_list=["tool"])
+          # → {"tool_name": "tavily_search", "server_id": "abc123",
+          #    "content": "...Parameters: query (string, required), max_results (integer, optional)..."}
+          execute_tool(
+              tool_name="tavily_search",
+              server_id="abc123",
+              arguments={"query": "latest AI news", "max_results": 5},
+          )
+
+        Example 2 — GitHub:
+          # discover_servers(query="github pull requests", type_list=["tool"])
+          # → {"tool_name": "search_pull_requests", "server_id": "def456",
+          #    "content": "...Parameters: owner (string, required), repo (string, required), state (string, optional)..."}
+          execute_tool(
+              tool_name="search_pull_requests",
+              server_id="def456",
+              arguments={"owner": "myorg", "repo": "myproject", "state": "open"},
+          )
+
+        **Hard constraints:**
+        - tool_name must be the exact `tool_name` field from the discovery result.
+          Do not invent, rename, scope, or rewrite it. Do not pass a display label or alias.
+        - server_id must come from the SAME discovery result as tool_name — never mix across results.
+        - Runs exactly one downstream MCP tool per call.
+
+        **Return value:**
+        Tool-specific result (JSON, text, or binary — format varies by tool).
         """
         return await execute_tool_impl(
             ctx,
@@ -708,45 +729,75 @@ def get_tools() -> list[tuple[str, Callable]]:
     async def read_resource(
         ctx: Context[ServerSession, McpAppContext],
         server_id: Annotated[
-            str, Field(description="Server ID from discover_servers (e.g., '6972e222755441652c23090f')")
+            str,
+            Field(
+                description=(
+                    "The `server_id` field from the discover_servers result (e.g., '6972e222755441652c23090f'). "
+                    "Must be from the same result as resource_uri."
+                )
+            ),
         ],
         resource_uri: Annotated[
-            str, Field(description="Resource URI to read (e.g., 'tavily://search-results/AI', 'file:///path/to/data')")
+            str,
+            Field(
+                description=(
+                    "The `resource_uri` field from the discover_servers result. "
+                    "If the URI is a template (e.g., 'github://repo/{owner}/{repo}'), fill in the variables before calling."
+                )
+            ),
         ],
     ) -> CallToolResult:
         """
-        📄 Read/access resources from any MCP server.
+        📄 Read URI-addressable data or cached content from a registered MCP server.
 
         **What are resources?**
-        Resources are data sources, caches, URIs, or file-like objects exposed by MCP servers.
-        Examples: cached search results, configuration files, data streams, API responses.
+        Resources are URI-addressable data sources exposed by MCP servers:
+        cached results, file-like content, API snapshots, configuration data, etc.
+        Use resources when you need to READ data rather than EXECUTE an action.
 
-        **Common use cases:**
-        - Access cached data: read_resource(server_id="...", resource_uri="tavily://search-results/AI")
-        - Read configuration: read_resource(server_id="...", resource_uri="config://settings")
-        - Access files: read_resource(server_id="...", resource_uri="file:///data/export.json")
+        **When to call:**
+        Call after discover_servers returns a result with entity_type == "resource".
+        Use result["resource_uri"] and result["server_id"] directly — no transformation needed.
 
-        **Workflow:**
-        1. Use discover_servers to find servers with resources
-        2. Review the resources array in server config
-        3. Use read_resource with the resource URI
+        **Parameter mapping — from discovery result to read_resource:**
 
-        **Example:**
-        ```
-        # Discover servers with resources
-        servers = discover_servers(query="search")
+          Discovery result:
+            {
+              "resource_uri": "tavily://search-results/{query}",  ← resource_uri parameter (fill template vars)
+              "server_id":    "abc123",                           ← server_id parameter
+              "resource_name": "search-results",
+            }
 
-        # Find a resource URI from server config
-        resource = servers[0]["config"]["resources"][0]["uri"]
+          Read call (after filling template variables):
+            read_resource(
+                server_id="abc123",
+                resource_uri="tavily://search-results/AI+news",
+            )
 
-        # Read the resource
-        data = read_resource(
-            server_id=servers[0]["_id"],
-            resource_uri=resource
-        )
-        ```
+        **Examples:**
 
-        Returns: Resource contents (format varies: text, JSON, binary, etc.)
+        Example 1 — cached search results:
+          # discover_servers(query="cached web results", type_list=["resource"])
+          # → {"resource_uri": "tavily://search-results/{query}", "server_id": "abc123", ...}
+          read_resource(
+              server_id="abc123",
+              resource_uri="tavily://search-results/AI+trends",
+          )
+
+        Example 2 — GitHub repository data:
+          # discover_servers(query="github repository", type_list=["resource"])
+          # → {"resource_uri": "github://repo/{owner}/{repo}", "server_id": "def456", ...}
+          read_resource(
+              server_id="def456",
+              resource_uri="github://repo/myorg/myproject",
+          )
+
+        **Hard constraints:**
+        - server_id must come from the SAME discovery result as resource_uri.
+        - If resource_uri is a URI template, substitute all `{variable}` placeholders before calling.
+
+        **Return value:**
+        Resource contents — text, JSON, binary, or structured data depending on the resource type.
         """
         return await read_resource_impl(
             ctx.request_context.request.state.user,  # type: ignore[union-attr]
@@ -757,49 +808,98 @@ def get_tools() -> list[tuple[str, Callable]]:
 
     async def execute_prompt(
         ctx: Context[ServerSession, McpAppContext],
-        server_id: Annotated[str, Field(description="Server ID from discover_servers")],
-        prompt_name: Annotated[
-            str, Field(description="Name of the prompt to execute (e.g., 'research_assistant', 'fact_checker')")
+        server_id: Annotated[
+            str,
+            Field(
+                description=(
+                    "The `server_id` field from the discover_servers result. "
+                    "Must be from the same result as prompt_name."
+                )
+            ),
         ],
-        arguments: Annotated[dict[str, Any] | None, Field(description="Prompt arguments as key-value pairs")] = None,
+        prompt_name: Annotated[
+            str,
+            Field(
+                description=(
+                    "The `prompt_name` field from the discover_servers result — use verbatim. "
+                    "Examples: 'research_assistant', 'code_reviewer', 'fact_checker'."
+                )
+            ),
+        ],
+        arguments: Annotated[
+            dict[str, Any] | None,
+            Field(
+                description=(
+                    "Prompt arguments as key-value pairs. "
+                    "Read the `content` field of the discovery result for argument names and required/optional status "
+                    "(format: 'Required: arg1 (description), ... | Optional: arg2 (description), ...'). "
+                    "Pass None or omit if the prompt takes no arguments."
+                )
+            ),
+        ] = None,
     ) -> CallToolResult:
         """
-        💬 Execute prompts from any MCP server.
+        💬 Execute a reusable prompt template from a registered MCP server.
 
         **What are prompts?**
-        Prompts are pre-configured, reusable prompt templates provided by MCP servers.
-        They help standardize complex workflows and provide expert guidance.
+        Prompts are pre-configured, parameterized templates that standardize complex workflows.
+        They return structured messages (role + content pairs) ready to be forwarded to an LLM.
+        Use prompts when you need expert guidance, a standardized workflow, or a multi-turn template.
 
-        **Common use cases:**
-        - Research workflows: execute_prompt(server_id="...", prompt_name="research_assistant", arguments={"topic": "AI"})
-        - Fact checking: execute_prompt(server_id="...", prompt_name="fact_checker", arguments={"claim": "..."})
-        - Code review: execute_prompt(server_id="...", prompt_name="code_reviewer", arguments={"language": "python"})
+        **When to call:**
+        Call after discover_servers returns a result with entity_type == "prompt".
+        Use result["prompt_name"] and result["server_id"] directly — no transformation needed.
 
-        **Workflow:**
-        1. Use discover_servers to find servers with prompts
-        2. Review the prompts array in server config
-        3. Use execute_prompt with required arguments
+        **Parameter mapping — from discovery result to execute_prompt:**
 
-        **Example:**
-        ```
-        # Discover servers with prompts
-        servers = discover_servers(query="research")
+          Discovery result:
+            {
+              "prompt_name": "code_reviewer",      ← prompt_name parameter
+              "server_id":   "abc123",             ← server_id parameter
+              "content":     "... Required: language (programming language) | Optional: focus (review focus area) ..."
+            }                                         ↑ read this to build arguments
 
-        # Find available prompts
-        prompts = servers[0]["config"]["prompts"]
+          Execute call:
+            execute_prompt(
+                server_id="abc123",
+                prompt_name="code_reviewer",         ← verbatim from result["prompt_name"]
+                arguments={"language": "python"},    ← constructed from content
+            )
 
-        # Execute a prompt
-        result = execute_prompt(
-            server_id=servers[0]["_id"],
-            prompt_name="research_assistant",
-            arguments={"topic": "Quantum Computing", "depth": "advanced"}
-        )
+        **How to construct arguments:**
+        The `content` field of the discovery result lists required and optional arguments:
+          "Required: topic (research topic) | Optional: depth (detail level, default: overview)"
+        Pass all required arguments; include optional ones when the user specifies them.
 
-        # Result contains messages ready for LLM
-        messages = result["messages"]
-        ```
+        **Examples:**
 
-        Returns: Prompt messages ready for LLM consumption (role, content pairs)
+        Example 1 — code review:
+          # discover_servers(query="code review template", type_list=["prompt"])
+          # → {"prompt_name": "code_reviewer", "server_id": "abc123",
+          #    "content": "... Required: language (programming language) | Optional: focus (review area) ..."}
+          execute_prompt(
+              server_id="abc123",
+              prompt_name="code_reviewer",
+              arguments={"language": "python", "focus": "security"},
+          )
+
+        Example 2 — research assistant:
+          # discover_servers(query="research assistant", type_list=["prompt"])
+          # → {"prompt_name": "research_assistant", "server_id": "def456",
+          #    "content": "... Required: topic (research topic) | Optional: depth (detail level) ..."}
+          execute_prompt(
+              server_id="def456",
+              prompt_name="research_assistant",
+              arguments={"topic": "Quantum Computing", "depth": "advanced"},
+          )
+
+        **Hard constraints:**
+        - prompt_name must be the exact `prompt_name` field from the discovery result — do not invent or rename it.
+        - server_id must come from the SAME discovery result as prompt_name.
+
+        **Return value:**
+        A list of messages (role + content pairs) ready for LLM consumption.
+        Forward the messages into your context or present them to the user.
         """
         return await execute_prompt_impl(
             ctx.request_context.request.state.user,  # type: ignore[union-attr]

--- a/registry/src/registry/mcpgw/tools/proxied.py
+++ b/registry/src/registry/mcpgw/tools/proxied.py
@@ -644,7 +644,7 @@ def get_tools() -> list[tuple[str, Callable]]:
             Field(
                 description=(
                     "Tool input parameters as a key-value dict. "
-                    "Read the `content` field of the discovery result for parameter names, types, "
+                    "Read the `description` field of the discovery result for parameter names, types, "
                     "and required/optional status (format: 'Parameters: name (type, required/optional, description), ...'). "
                     "Pass all required parameters; include optional ones when they improve the result."
                 )

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -128,7 +128,8 @@ def get_tools() -> list[tuple[str, Callable]]:
             default_factory=lambda: ["tool"],
         ),
     ) -> list[dict[str, Any]]:
-        """Find tools, resources, or prompts matching the query. Returns results with relevance_score.
+        """Find tools, resources, or prompts matching the query.
+        Returns {confidence, results[]} where confidence is high/low/ambiguous/none.
         Execute: tool→execute_tool(tool_name, server_id, arguments), resource→read_resource(server_id, resource_uri), prompt→execute_prompt(server_id, prompt_name, arguments)."""
         return await discover_entities_impl(ctx, query, top_n, "hybrid", type_list)
 

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -132,9 +132,10 @@ def get_tools() -> list[tuple[str, Callable]]:
     ) -> list[dict[str, Any]]:
         """Find tools, resources, or prompts matching the query.
         Pass CONCISE keywords (nouns/verbs/domain terms), not the user's raw sentence.
-        Returns {query, type_list, total, results[]}. Each result has relevance_score (compare RELATIVELY across results, not against a fixed threshold), description, server_id, and one of tool_name/resource_uri/prompt_name.
+        Returns {query, type_list, total, results[]}. Each result has relevance_score (compare RELATIVELY, not against a fixed threshold), description, server_id, server_name, and one of tool_name/resource_uri/prompt_name.
         Execute: tool→execute_tool(tool_name, server_id, arguments), resource→read_resource(server_id, resource_uri), prompt→execute_prompt(server_id, prompt_name, arguments).
-        If no suitable match: retry with refined keywords → broader keywords → query='' with top_n=20 to survey all registered capabilities before giving up."""
+        On clustered scores: same server_name → ask user which operation; different server_names → ask user which provider, then retry with that provider's name in the query.
+        If nothing matches: refined keywords → broader keywords → query='' with top_n=20 to survey all capabilities (group mentally by server_name) → retry with a spotted server_name in the query."""
         return await discover_entities_impl(ctx, query, top_n, "hybrid", type_list)
 
     return [

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -6,7 +6,7 @@ from mcp.server.fastmcp import Context
 from mcp.server.session import ServerSession
 from pydantic import Field
 
-from ...api.v1.search_routes import SearchRequest, search_servers_impl
+from ...api.v1.search_routes import SearchRequest, search_entities_impl
 from ...auth.dependencies import UserContextDict
 from ...core.exceptions import InternalServerException
 from ..core.types import McpAppContext
@@ -14,7 +14,7 @@ from ..core.types import McpAppContext
 logger = logging.getLogger(__name__)
 
 
-async def discover_servers_impl(
+async def discover_entities_impl(
     ctx: Context[ServerSession, McpAppContext],
     query: str,
     top_n: int | None = None,
@@ -68,7 +68,7 @@ async def discover_servers_impl(
         user_context: UserContextDict = ctx.request_context.request.state.user  # type: ignore[union-attr]
 
         lifespan_context = ctx.request_context.lifespan_context
-        result = await search_servers_impl(
+        result = await search_entities_impl(
             search_request,
             user_context,
             mcp_server_repo=lifespan_context.mcp_server_repo,
@@ -100,7 +100,7 @@ def get_tools() -> list[tuple[str, Callable]]:
         List of (tool_name, tool_function) tuples ready for registration
     """
 
-    async def discover_servers(
+    async def discover_entities(
         ctx: Context[ServerSession, McpAppContext],
         query: Annotated[
             str,
@@ -157,9 +157,9 @@ def get_tools() -> list[tuple[str, Callable]]:
         Pass them unchanged to `execute_tool` — no further lookup or name translation needed.
 
         **Examples:**
-        - News or web search: `discover_servers(query="web search news", type_list=["tool"])`
-        - GitHub operations: `discover_servers(query="github repositories", type_list=["tool"])`
-        - Cached data: `discover_servers(query="cached data", type_list=["resource"])`
+        - News or web search: `discover_entities(query="web search news", type_list=["tool"])`
+        - GitHub operations: `discover_entities(query="github repositories", type_list=["tool"])`
+        - Cached data: `discover_entities(query="cached data", type_list=["resource"])`
 
         **Execution:**
         If discovery returns `{"tool_name": "tavily_search", "server_id": "abc123", ...}`,
@@ -168,8 +168,8 @@ def get_tools() -> list[tuple[str, Callable]]:
         Use `read_resource(server_id, resource_uri)` for resources.
         Use `execute_prompt(server_id, prompt_name, arguments)` for prompts.
         """
-        return await discover_servers_impl(ctx, query, top_n, search_type, type_list)
+        return await discover_entities_impl(ctx, query, top_n, search_type, type_list)
 
     return [
-        ("discover_servers", discover_servers),
+        ("discover_entities", discover_entities),
     ]

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -24,8 +24,14 @@ async def discover_entities_impl(
     """
     🔍 Discover available MCP tools, resources, or prompts via vector search.
 
-    All entity types go through the same vector path. Every result contains
-    tool_name and server_id directly, ready for execute_tool.
+    All entity types go through the same vector path.
+
+    Results include entity-specific identifiers directly from the vector store:
+    - tools use `tool_name`
+    - resources use `resource_uri`
+    - prompts use `prompt_name`
+
+    Each result also includes `server_id`, so no MongoDB lookup is required during discovery.
 
     Args:
         query: Natural language description or keywords to search
@@ -44,7 +50,8 @@ async def discover_entities_impl(
         ctx: FastMCP context with user auth
 
     Returns:
-        List of matching entities, each with tool_name and server_id ready for execute_tool.
+        List of matching entity results, each containing the execution-ready identifier
+        for its entity type plus server_id.
 
     Raises:
         InternalServerException: On any runtime exception
@@ -74,7 +81,7 @@ async def discover_entities_impl(
             mcp_server_repo=lifespan_context.mcp_server_repo,
         )
 
-        servers = result.get("servers", [])
+        servers = result.get("results", [])
         total = result.get("total", 0)
 
         logger.info(f"✅ Discovered {total} result(s) for query: '{query}'")
@@ -82,9 +89,9 @@ async def discover_entities_impl(
         return servers
 
     except Exception:
-        logger.exception("Server discovery failed")
+        logger.exception("Entity discovery failed")
 
-        raise InternalServerException("server discovery failed")
+        raise InternalServerException("entity discovery failed")
 
 
 # ============================================================================
@@ -153,8 +160,9 @@ def get_tools() -> list[tuple[str, Callable]]:
         - `similarity_store`: alternative retrieval path
 
         **How to use results:**
-        Every result in the returned array contains `tool_name` and `server_id` directly.
-        Pass them unchanged to `execute_tool` — no further lookup or name translation needed.
+        - tool result     -> execute_tool(tool_name=<result.tool_name>, server_id=<result.server_id>, arguments={...})
+        - resource result -> read_resource(server_id=<result.server_id>, resource_uri=<result.resource_uri>)
+        - prompt result   -> execute_prompt(server_id=<result.server_id>, prompt_name=<result.prompt_name>, arguments={...})
 
         **Examples:**
         - News or web search: `discover_entities(query="web search news", type_list=["tool"])`

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -22,31 +22,29 @@ async def discover_servers_impl(
     type_list: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     """
-    🔍 Discover available MCP servers, tools, resources, or prompts.
+    🔍 Discover available MCP tools, resources, or prompts via vector search.
 
-    This flexible search tool can find specific entity types (tools, resources, prompts)
-    or full servers with all their capabilities. Use type_list to control what's returned.
+    All entity types go through the same vector path. Every result contains
+    tool_name and server_id directly, ready for execute_tool.
 
     Args:
         query: Natural language description or keywords to search
                (e.g., "github", "search engines", "database tools")
-        top_n: Maximum number of results to return.
-              If None, auto-sets to 3 for tools/resources/prompts, 1 for servers
+        top_n: Maximum number of results to return. Defaults to 3 if not specified.
         search_type: Search strategy:
                     - "hybrid" (default): Combines semantic + keyword for best accuracy
                     - "near_text": Pure semantic/vector search (best for concept matching)
                     - "bm25": Pure keyword search (best for exact term matching)
                     - "similarity_store": Alternative similarity algorithm
         type_list: Entity types to search for (default: ["tool"]):
-                  - ["tool"]: Returns only tools (most token-efficient)
-                  - ["resource"]: Returns only resources
-                  - ["prompt"]: Returns only prompts
-                  - ["server"]: Returns full servers with all capabilities (most tokens)
+                  - ["tool"]: Returns individual tools (each doc embeds full server context)
+                  - ["resource"]: Returns resources (each doc embeds full server context)
+                  - ["prompt"]: Returns prompts (each doc embeds full server context)
                   - Mix types: ["tool", "resource"] for multiple entity types
         ctx: FastMCP context with user auth
 
     Returns:
-        List of matching entities based on type_list parameter
+        List of matching entities, each with tool_name and server_id ready for execute_tool.
 
     Raises:
         InternalServerException: On any runtime exception
@@ -54,14 +52,8 @@ async def discover_servers_impl(
     if type_list is None:
         type_list = ["tool"]
 
-    # Smart defaults for top_n based on entity type
     if top_n is None:
-        # For specific entity types (tool/resource/prompt), return more results (3)
-        # For full servers, return fewer (1) due to token cost
-        if "server" in type_list and len(type_list) == 1:
-            top_n = 1  # Servers are token-heavy, return only 1
-        else:
-            top_n = 3  # Tools/resources/prompts are lightweight, return 3
+        top_n = 3
 
     logger.info(f"🔍 Discovering {type_list} for query: '{query}' (search_type={search_type})")
 
@@ -79,7 +71,6 @@ async def discover_servers_impl(
         result = await search_servers_impl(
             search_request,
             user_context,
-            server_service=lifespan_context.server_service,
             mcp_server_repo=lifespan_context.mcp_server_repo,
         )
 
@@ -116,13 +107,13 @@ def get_tools() -> list[tuple[str, Callable]]:
             Field(
                 min_length=0,
                 max_length=512,
-                description="Natural language query or keywords (e.g., 'web search', 'github', 'email automation'). May be omitted or empty. For `type_list=[\"server\"]`, an empty query means list available servers.",
+                description="Natural language query or keywords (e.g., 'web search', 'github', 'email automation'). May be omitted or empty for listing.",
             ),
         ] = "",
         top_n: Annotated[
             int | None,
             Field(
-                description="Max results to return. Auto-sets to 3 for tools/resources/prompts, 1 for servers if not specified",
+                description="Max results to return. Defaults to 3 if not specified.",
             ),
         ] = None,
         search_type: Annotated[
@@ -134,25 +125,26 @@ def get_tools() -> list[tuple[str, Callable]]:
         type_list: Annotated[
             list[str],
             Field(
-                description="Entity types to search: ['tool'] (most efficient, default), ['resource'], ['prompt'], ['server'] (full details, most tokens), or mix multiple types",
+                description="Entity types to search: ['tool'] (default), ['resource'], ['prompt'], or mix multiple types e.g. ['tool', 'resource']",
             ),
         ] = Field(
             default_factory=lambda: ["tool"],
         ),
     ) -> list[dict[str, Any]]:
         """
-        🔍 AUTO-USE: Discover tools, resources, prompts, or full server documents.
+        🔍 AUTO-USE: Discover tools, resources, or prompts from MCP servers.
 
         **Use this search order by default:**
-        1. `type_list=["tool"]` first for executable tools
+        1. `type_list=["tool"]` for action-oriented tasks (default, most efficient)
         2. `type_list=["resource"]` or `type_list=["prompt"]` when the user needs those specifically
-        3. `type_list=["server"]` only when you need a full Mongo-style server document
 
         **What each type means:**
-        - `["tool"]`: best default for action-oriented tasks such as search, API calls, automation, or data operations
+        - `["tool"]`: best default for search, API calls, automation, or data operations
         - `["resource"]`: for reading URIs, cached data, or file-like resources
         - `["prompt"]`: for reusable prompt workflows
-        - `["server"]`: for full server configs, including `config.toolFunctions`, resources, and prompts
+
+        Each result doc embeds full server context (server name, path, title, description)
+        in its content — no separate server lookup is needed.
 
         **Search strategies:**
         - `hybrid`: best default, combines semantic and keyword search
@@ -160,37 +152,18 @@ def get_tools() -> list[tuple[str, Callable]]:
         - `bm25`: exact keyword matching
         - `similarity_store`: alternative retrieval path
 
-        **How to interpret the returned `servers` array:**
-        - Treat results as full server documents only when `type_list` is exactly `["server"]`.
-        - In every other case, including `type_list=["tool"]`, treat each result as a directly usable discovery result for execution.
-
-        **If `type_list` is exactly `["server"]`:**
-        - Each item in `servers` is a full server document in MongoDB format.
-        - To execute a tool from that server:
-          1. Inspect the `$.config.toolFunctions` field of the server document.
-          2. Choose one tool entry whose description and parameters match the user's task
-          3. Set the `server_id` parameter of the `execute_tool` call to that server document's `id`
-          4. Set the `tool_name` parameter of the `execute_tool` call to that chosen tool entry's `mcpToolName`
-          5. Only if `mcpToolName` is missing, fall back to that chosen tool entry's key/name
-
-        **In every other case, including `type_list=["tool"]`:**
-        - Each result is already an executable match.
-        - Use the returned `tool_name` unchanged as `execute_tool.tool_name`.
-        - Use the returned `server_id` unchanged as `execute_tool.server_id`.
+        **How to use results:**
+        Every result in the returned array contains `tool_name` and `server_id` directly.
+        Pass them unchanged to `execute_tool` — no further lookup or name translation needed.
 
         **Examples:**
         - News or web search: `discover_servers(query="web search news", type_list=["tool"])`
         - GitHub operations: `discover_servers(query="github repositories", type_list=["tool"])`
         - Cached data: `discover_servers(query="cached data", type_list=["resource"])`
-        - Full capability inspection: `discover_servers(query="github", type_list=["server"])`
 
-        **Execution examples:**
-        - Tool result:
-          - If discovery returns `{"tool_name": "tavily_search", "server_id": "abc123", ...}`,
-            call `execute_tool(tool_name="tavily_search", server_id="abc123", arguments={...})`.
-        - Server result:
-          - If `$.config.toolFunctions["add_numbers_mcp_minimal_mcp_iam"].mcpToolName = "add_numbers"`,
-            call `execute_tool(tool_name="add_numbers", server_id="<server id>", arguments={...})`.
+        **Execution:**
+        If discovery returns `{"tool_name": "tavily_search", "server_id": "abc123", ...}`,
+        call `execute_tool(tool_name="tavily_search", server_id="abc123", arguments={...})`.
 
         Use `read_resource(server_id, resource_uri)` for resources.
         Use `execute_prompt(server_id, prompt_name, arguments)` for prompts.

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -42,11 +42,11 @@ async def discover_entities_impl(
                     - "near_text": Pure semantic/vector search (best for concept matching)
                     - "bm25": Pure keyword search (best for exact term matching)
                     - "similarity_store": Alternative similarity algorithm
-        type_list: Entity types to search for (default: ["tool"]):
+        type_list: Entity types to search for (default: ["tool", "resource", "prompt"]):
                   - ["tool"]: Returns individual tools (each doc embeds full server context)
                   - ["resource"]: Returns resources (each doc embeds full server context)
                   - ["prompt"]: Returns prompts (each doc embeds full server context)
-                  - Mix types: ["tool", "resource"] for multiple entity types
+                  - Default covers all types in one call — narrow only when entity type is certain
         ctx: FastMCP context with user auth
 
     Returns:
@@ -57,7 +57,7 @@ async def discover_entities_impl(
         InternalServerException: On any runtime exception
     """
     if type_list is None:
-        type_list = ["tool"]
+        type_list = ["tool", "resource", "prompt"]
 
     if top_n is None:
         top_n = 3
@@ -123,14 +123,18 @@ def get_tools() -> list[tuple[str, Callable]]:
         ] = None,
         type_list: Annotated[
             list[str],
-            Field(description="Entity types: 'tool' (default), 'resource', or 'prompt'."),
+            Field(
+                description="Entity types. Default ['tool','resource','prompt'] covers all in one call. Narrow only when entity type is certain."
+            ),
         ] = Field(
-            default_factory=lambda: ["tool"],
+            default_factory=lambda: ["tool", "resource", "prompt"],
         ),
     ) -> list[dict[str, Any]]:
         """Find tools, resources, or prompts matching the query.
-        Returns {confidence, results[]} where confidence is high/low/ambiguous/none.
-        Execute: tool→execute_tool(tool_name, server_id, arguments), resource→read_resource(server_id, resource_uri), prompt→execute_prompt(server_id, prompt_name, arguments)."""
+        Pass CONCISE keywords (nouns/verbs/domain terms), not the user's raw sentence.
+        Returns {query, type_list, total, results[]}. Each result has relevance_score (compare RELATIVELY across results, not against a fixed threshold), description, server_id, and one of tool_name/resource_uri/prompt_name.
+        Execute: tool→execute_tool(tool_name, server_id, arguments), resource→read_resource(server_id, resource_uri), prompt→execute_prompt(server_id, prompt_name, arguments).
+        If no suitable match: retry with refined keywords → broader keywords → query='' with top_n=20 to survey all registered capabilities before giving up."""
         return await discover_entities_impl(ctx, query, top_n, "hybrid", type_list)
 
     return [

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -114,69 +114,23 @@ def get_tools() -> list[tuple[str, Callable]]:
             Field(
                 min_length=0,
                 max_length=512,
-                description="Natural language query or keywords (e.g., 'web search', 'github', 'email automation'). May be omitted or empty for listing.",
+                description="Keywords or natural language describing what you need (e.g., 'web search', 'github', 'send email').",
             ),
         ] = "",
         top_n: Annotated[
             int | None,
-            Field(
-                description="Max results to return. Defaults to 3 if not specified.",
-            ),
+            Field(description="Max results to return. Defaults to 3."),
         ] = None,
-        search_type: Annotated[
-            str,
-            Field(
-                description="Search strategy: 'hybrid' (best), 'near_text' (semantic), 'bm25' (keyword), 'similarity_store' (alternative)",
-            ),
-        ] = "hybrid",
         type_list: Annotated[
             list[str],
-            Field(
-                description="Entity types to search: ['tool'] (default), ['resource'], ['prompt'], or mix multiple types e.g. ['tool', 'resource']",
-            ),
+            Field(description="Entity types: 'tool' (default), 'resource', or 'prompt'."),
         ] = Field(
             default_factory=lambda: ["tool"],
         ),
     ) -> list[dict[str, Any]]:
-        """
-        🔍 AUTO-USE: Discover tools, resources, or prompts from MCP servers.
-
-        **Use this search order by default:**
-        1. `type_list=["tool"]` for action-oriented tasks (default, most efficient)
-        2. `type_list=["resource"]` or `type_list=["prompt"]` when the user needs those specifically
-
-        **What each type means:**
-        - `["tool"]`: best default for search, API calls, automation, or data operations
-        - `["resource"]`: for reading URIs, cached data, or file-like resources
-        - `["prompt"]`: for reusable prompt workflows
-
-        Each result doc embeds full server context (server name, path, title, description)
-        in its content — no separate server lookup is needed.
-
-        **Search strategies:**
-        - `hybrid`: best default, combines semantic and keyword search
-        - `near_text`: semantic/concept matching
-        - `bm25`: exact keyword matching
-        - `similarity_store`: alternative retrieval path
-
-        **How to use results:**
-        - tool result     -> execute_tool(tool_name=<result.tool_name>, server_id=<result.server_id>, arguments={...})
-        - resource result -> read_resource(server_id=<result.server_id>, resource_uri=<result.resource_uri>)
-        - prompt result   -> execute_prompt(server_id=<result.server_id>, prompt_name=<result.prompt_name>, arguments={...})
-
-        **Examples:**
-        - News or web search: `discover_entities(query="web search news", type_list=["tool"])`
-        - GitHub operations: `discover_entities(query="github repositories", type_list=["tool"])`
-        - Cached data: `discover_entities(query="cached data", type_list=["resource"])`
-
-        **Execution:**
-        If discovery returns `{"tool_name": "tavily_search", "server_id": "abc123", ...}`,
-        call `execute_tool(tool_name="tavily_search", server_id="abc123", arguments={...})`.
-
-        Use `read_resource(server_id, resource_uri)` for resources.
-        Use `execute_prompt(server_id, prompt_name, arguments)` for prompts.
-        """
-        return await discover_entities_impl(ctx, query, top_n, search_type, type_list)
+        """Find tools, resources, or prompts matching the query. Returns results with relevance_score.
+        Execute: tool→execute_tool(tool_name, server_id, arguments), resource→read_resource(server_id, resource_uri), prompt→execute_prompt(server_id, prompt_name, arguments)."""
+        return await discover_entities_impl(ctx, query, top_n, "hybrid", type_list)
 
     return [
         ("discover_entities", discover_entities),

--- a/registry/tests/integration/test_search_routes.py
+++ b/registry/tests/integration/test_search_routes.py
@@ -371,6 +371,7 @@ class TestServerSearchRoutes:
             "query": "",
             "type_list": ["tool", "resource", "prompt"],
             "total": 0,
+            "confidence": "none",
             "results": [],
         }
 

--- a/registry/tests/integration/test_search_routes.py
+++ b/registry/tests/integration/test_search_routes.py
@@ -371,7 +371,6 @@ class TestServerSearchRoutes:
             "query": "",
             "type_list": ["tool", "resource", "prompt"],
             "total": 0,
-            "confidence": "none",
             "results": [],
         }
 

--- a/registry/tests/integration/test_search_routes.py
+++ b/registry/tests/integration/test_search_routes.py
@@ -369,7 +369,7 @@ class TestServerSearchRoutes:
         mock_filter.assert_awaited_once()
         assert response.json() == {
             "query": "",
-            "type_list": ["server", "tool", "resource", "prompt"],
+            "type_list": ["tool", "resource", "prompt"],
             "total": 0,
             "servers": [],
         }

--- a/registry/tests/integration/test_search_routes.py
+++ b/registry/tests/integration/test_search_routes.py
@@ -196,7 +196,7 @@ class TestServerSearchRoutes:
         # Verify response structure
         assert "query" in data
         assert "total" in data
-        assert "servers" in data
+        assert "results" in data
         assert data["query"] == "test query"
 
         # Verify search was called with correct parameters
@@ -371,7 +371,7 @@ class TestServerSearchRoutes:
             "query": "",
             "type_list": ["tool", "resource", "prompt"],
             "total": 0,
-            "servers": [],
+            "results": [],
         }
 
     def test_search_servers_returns_results(self, test_client: TestClient):
@@ -394,5 +394,5 @@ class TestServerSearchRoutes:
         data = response.json()
         assert "query" in data
         assert "total" in data
-        assert "servers" in data
+        assert "results" in data
         assert data["query"] == "test"

--- a/registry/tests/unit/api/v1/test_search_routes.py
+++ b/registry/tests/unit/api/v1/test_search_routes.py
@@ -74,7 +74,7 @@ async def test_search_servers_uses_vector_directly():
 
     mcp_server_repo.asearch_with_rerank.assert_awaited_once()
     assert response["total"] == 2
-    assert response["servers"] == tool_results
+    assert response["results"] == tool_results
 
 
 @pytest.mark.asyncio
@@ -101,4 +101,4 @@ async def test_search_servers_filters_metadata_when_tool_query_is_empty():
     mcp_server_repo.afilter.assert_awaited_once_with(filters={"enabled": True, "entity_type": ["tool"]}, limit=5)
     assert response["query"] == ""
     assert response["total"] == 1
-    assert response["servers"] == filter_results
+    assert response["results"] == filter_results

--- a/registry/tests/unit/api/v1/test_search_routes.py
+++ b/registry/tests/unit/api/v1/test_search_routes.py
@@ -1,7 +1,6 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from pydantic import BaseModel
 from tests.conftest import make_container
 
 from registry.api.v1.search_routes import SearchRequest, SemanticSearchRequest, search_servers, semantic_search
@@ -52,90 +51,34 @@ async def test_semantic_search_uses_injected_vector_service():
 
 
 @pytest.mark.asyncio
-async def test_search_servers_uses_injected_server_service():
-    server_service = MagicMock()
-    server_service.get_server_by_id = AsyncMock(side_effect=[{"serverName": "server-1"}, {"serverName": "server-2"}])
+async def test_search_servers_uses_vector_directly():
+    """Tool search must go through vector search and return tool_name directly."""
+    tool_results = [
+        {"server_id": "id-1", "server_name": "github", "entity_type": "tool", "tool_name": "search_code"},
+        {"server_id": "id-1", "server_name": "github", "entity_type": "tool", "tool_name": "create_pr"},
+    ]
     mcp_server_repo = MagicMock()
-    mcp_server_repo.asearch_with_rerank = AsyncMock(return_value=[{"server_id": "id-1"}, {"server_id": "id-2"}])
+    mcp_server_repo.asearch_with_rerank = AsyncMock(return_value=tool_results)
 
     response = await search_servers(
         search=SearchRequest(
-            query="test",
+            query="github",
             top_n=2,
             search_type=SearchType.HYBRID,
-            type_list=[ServerEntityType.SERVER],
+            type_list=[ServerEntityType.TOOL],
             include_disabled=False,
         ),
         user_context={"username": "tester"},
-        server_service=server_service,
         mcp_server_repo=mcp_server_repo,
     )
 
-    assert server_service.get_server_by_id.await_count == 2
     mcp_server_repo.asearch_with_rerank.assert_awaited_once()
     assert response["total"] == 2
-    assert len(response["servers"]) == 2
-
-
-class _FakeServerModel(BaseModel):
-    serverName: str
-    path: str
+    assert response["servers"] == tool_results
 
 
 @pytest.mark.asyncio
-async def test_search_servers_serializes_server_models_to_dicts():
-    fake_server = _FakeServerModel(serverName="server-1", path="/server-1")
-    mcp_server_repo = MagicMock()
-    mcp_server_repo.asearch_with_rerank = AsyncMock(return_value=[{"server_id": "id-1"}])
-
-    with patch.object(server_service := MagicMock(), "get_server_by_id", new=AsyncMock(return_value=fake_server)):
-        response = await search_servers(
-            search=SearchRequest(
-                query="github",
-                top_n=1,
-                search_type=SearchType.HYBRID,
-                type_list=[ServerEntityType.SERVER],
-                include_disabled=False,
-            ),
-            user_context={"username": "tester"},
-            server_service=server_service,
-            mcp_server_repo=mcp_server_repo,
-        )
-
-    assert response["total"] == 1
-    assert response["servers"] == [{"serverName": "server-1", "path": "/server-1"}]
-
-
-@pytest.mark.asyncio
-async def test_search_servers_lists_servers_when_query_is_empty():
-    fake_server = _FakeServerModel(serverName="server-1", path="/server-1")
-    list_servers = AsyncMock(return_value=([fake_server], 1))
-    mcp_server_repo = MagicMock()
-    mcp_server_repo.asearch_with_rerank = AsyncMock(
-        side_effect=AssertionError("vector search should not run for empty server query")
-    )
-
-    response = await search_servers(
-        search=SearchRequest(
-            query="",
-            top_n=5,
-            search_type=SearchType.HYBRID,
-            type_list=[ServerEntityType.SERVER],
-            include_disabled=False,
-        ),
-        user_context={"username": "tester"},
-        server_service=make_container(list_servers=list_servers),
-        mcp_server_repo=mcp_server_repo,
-    )
-
-    list_servers.assert_awaited_once_with(query=None, status="active", page=1, per_page=5)
-    assert response["query"] == ""
-    assert response["total"] == 1
-    assert response["servers"] == [{"serverName": "server-1", "path": "/server-1"}]
-
-
-@pytest.mark.asyncio
-async def test_search_servers_filters_metadata_when_non_server_query_is_empty():
+async def test_search_servers_filters_metadata_when_tool_query_is_empty():
     filter_results = [{"server_id": "id-1", "server_name": "server-1", "entity_type": "tool", "tool_name": "search"}]
     mcp_server_repo = MagicMock()
     mcp_server_repo.afilter = AsyncMock(return_value=filter_results)
@@ -152,7 +95,6 @@ async def test_search_servers_filters_metadata_when_non_server_query_is_empty():
             include_disabled=False,
         ),
         user_context={"username": "tester"},
-        server_service=MagicMock(),
         mcp_server_repo=mcp_server_repo,
     )
 


### PR DESCRIPTION
We consolidate all server content that requires vectorization into tools, resources, and prompts, and use them as a unified representation for retrieval.
Instead of searching by type, we perform a single unified search.



## take tool as an example

before:
    one server doc: "github | /mcp/github | GitHub MCP Server | ..."
    five tool doc:  "search_code | Search code | ..."
                   "create_pr | Create pull request | ..."

now:
   fix  tool doc:  "github | /mcp/github | GitHub MCP Server | search_code | Search code | ..."
                  "github | /mcp/github | GitHub MCP Server | create_pr | Create PR | ..."

The only drawback is that it consumes a bit more tokens, but we don't need to rebuild them every time. In the long run, our tools, resources, and prompts won't change frequently, so this overhead is negligible!


## Discovery Flow (Current)

```
┌──────────────┐
│ User intent  │  e.g. "Can you find bugs in my github repo?"
└──────┬───────┘
       │
       ▼ LLM extracts concise keywords
┌─────────────────────────────────────────────────────────────┐
│ discover_entities(                                          │
│   query="github issues",                                    │
│   type_list=["tool","resource","prompt"],   # default       │
│   top_n=3                                                   │
│ )                                                           │
└──────┬──────────────────────────────────────────────────────┘
       │
       ▼
┌─────────────────────────────────────────────────────────────┐
│ Weaviate hybrid search (BM25 + vector) + FlashRank rerank   │
│ • Filter: entity_type ∈ type_list, enabled=true             │
│ • Single query across all three entity types                │
└──────┬──────────────────────────────────────────────────────┘
       │
       ▼
┌─────────────────────────────────────────────────────────────┐
│ results[]: {                                                │
│   server_id, server_name, entity_type,                      │
│   relevance_score (0–1, from FlashRank),                    │
│   description (page_content),                               │
│   one of: tool_name | resource_uri | prompt_name            │
│ }                                                           │
└──────┬──────────────────────────────────────────────────────┘
       │
       ▼ LLM judges (RELATIVE score comparison + description check)
┌─────────────────────────────────────────────────────────────┐
│ Execute:                                                    │
│   tool     → execute_tool(tool_name, server_id, arguments)  │
│   resource → read_resource(server_id, resource_uri)         │
│   prompt   → execute_prompt(server_id, prompt_name, args)   │
└─────────────────────────────────────────────────────────────┘
```