### PR TITLE
Hotfix: `MCPOAuthService` uses `decrypt_auth_fields` wrong.

### DIFF
--- a/registry/src/registry/services/oauth/oauth_service.py
+++ b/registry/src/registry/services/oauth/oauth_service.py
@@ -247,7 +247,7 @@ class MCPOAuthService:
                     return None, None, f"Dynamic client registration failed: {str(dcr_error)}"
             else:
                 logger.debug(f"[OAuth] Using static credentials for {server.serverName}")
-                # Note that decrypt_auth_fields excepts the `.config` field of an ExtendedMCPServer document object.
+                # Note that decrypt_auth_fields expects the `.config` field of an ExtendedMCPServer document object.
                 oauth_config = decrypt_auth_fields({"oauth": oauth_config})["oauth"]
 
             oauth_config = self._merge_oauth_config(oauth_config, oauth_metadata)
@@ -648,7 +648,7 @@ class MCPOAuthService:
             if not oauth_config:
                 return False, f"Server '{server_id}' OAuth configuration not found"
 
-            # Note that decrypt_auth_fields excepts the `.config` field of an ExtendedMCPServer document object.
+            # Note that decrypt_auth_fields expects the `.config` field of an ExtendedMCPServer document object.
             oauth_config = decrypt_auth_fields({"oauth": oauth_config})["oauth"]
             oauth_metadata = mcp_server.config.get("oauthMetadata")
             oauth_config = self._merge_oauth_config(oauth_config, oauth_metadata)
@@ -780,7 +780,7 @@ class MCPOAuthService:
                     "server_name": server_name,
                 }
 
-            # Note that decrypt_auth_fields excepts the `.config` field of an ExtendedMCPServer document object.
+            # Note that decrypt_auth_fields expects the `.config` field of an ExtendedMCPServer document object.
             oauth_config = decrypt_auth_fields({"oauth": oauth_config})["oauth"]
             oauth_metadata = server.config.get("oauthMetadata")
             oauth_config = self._merge_oauth_config(oauth_config, oauth_metadata)

--- a/registry/src/registry/services/oauth/oauth_service.py
+++ b/registry/src/registry/services/oauth/oauth_service.py
@@ -247,7 +247,8 @@ class MCPOAuthService:
                     return None, None, f"Dynamic client registration failed: {str(dcr_error)}"
             else:
                 logger.debug(f"[OAuth] Using static credentials for {server.serverName}")
-                oauth_config = decrypt_auth_fields(oauth_config)
+                # Note that decrypt_auth_fields excepts the `.config` field of an ExtendedMCPServer document object.
+                oauth_config = decrypt_auth_fields({"oauth": oauth_config})["oauth"]
 
             oauth_config = self._merge_oauth_config(oauth_config, oauth_metadata)
 
@@ -647,7 +648,8 @@ class MCPOAuthService:
             if not oauth_config:
                 return False, f"Server '{server_id}' OAuth configuration not found"
 
-            oauth_config = decrypt_auth_fields(oauth_config)
+            # Note that decrypt_auth_fields excepts the `.config` field of an ExtendedMCPServer document object.
+            oauth_config = decrypt_auth_fields({"oauth": oauth_config})["oauth"]
             oauth_metadata = mcp_server.config.get("oauthMetadata")
             oauth_config = self._merge_oauth_config(oauth_config, oauth_metadata)
 
@@ -778,7 +780,8 @@ class MCPOAuthService:
                     "server_name": server_name,
                 }
 
-            oauth_config = decrypt_auth_fields(oauth_config)
+            # Note that decrypt_auth_fields excepts the `.config` field of an ExtendedMCPServer document object.
+            oauth_config = decrypt_auth_fields({"oauth": oauth_config})["oauth"]
             oauth_metadata = server.config.get("oauthMetadata")
             oauth_config = self._merge_oauth_config(oauth_config, oauth_metadata)
 

--- a/registry/tests/unit/services/test_oauth_service.py
+++ b/registry/tests/unit/services/test_oauth_service.py
@@ -316,9 +316,7 @@ class TestMCPOAuthService:
         )
 
         # Mock crypto utils
-        with patch(
-            "registry.services.oauth.oauth_service.decrypt_auth_fields", return_value=mock_server.config["oauth"]
-        ):
+        with patch("registry.services.oauth.oauth_service.decrypt_auth_fields", return_value=mock_server.config):
             flow_id, auth_url, error = await oauth_service.initiate_oauth_flow(user_id, mock_server)
 
             assert flow_id == "test_flow_id"


### PR DESCRIPTION
 AS-1548 (previously merged) fixes the bug inside `decrypt_auth_fields`, this commit fixes the wrong uses (argument type) of the function. One from inside. The other from the outside.