### PR TITLE
feat(docs): add Explore Agentic content section

### DIFF
--- a/docs/explore-agentic/comparisons/agentforce-vs-copilot-studio.md
+++ b/docs/explore-agentic/comparisons/agentforce-vs-copilot-studio.md
@@ -1,0 +1,123 @@
+# Agentforce vs Copilot Studio: 2026 pricing & MCP
+
+> Salesforce announced Agentforce September 12, 2024, hit GA October 25, 2024, shipped Agentforce 2.0 December 17, 2024, and has cycled through three pricing models ($2/conversation, $0.10/Flex Credit, $125+/user/month). Microsoft Copilot Studio went to MCP GA in May 2025. An Agentforce vs Copilot Studio side-by-side with citations and all three Salesforce pricing models on one page.
+
+*Comparison · Platforms · Salesforce Agentforce vs Microsoft Copilot Studio · 12 minutes · Updated April 16, 2026 · Author Laura Bradley McCoy · Reviewed by Elias Saljuki*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/comparisons/agentforce-vs-copilot-studio/](https://www.exploreagentic.ai/comparisons/agentforce-vs-copilot-studio/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Verdict
+
+If your system of record is Salesforce (CRM, Service Cloud, Marketing Cloud) Agentforce is the shorter path. The reasoning engine is native to Data Cloud, the agent surface inherits your existing permissions model, and the pricing is outcome-aligned. If your employees live inside Microsoft 365 (Teams, Outlook, SharePoint) Copilot Studio is the shorter path. Multi-agent orchestration is native to the Power Platform, and governance flows through Purview and Entra. Neither platform is likely to displace the other in the organizations where the other is already the backbone.
+
+## Scorecard
+
+| Category | Salesforce Agentforce | Microsoft Copilot Studio | Winner |
+| --- | --- | --- | --- |
+| Native system of record | Salesforce (CRM + Data Cloud) | Microsoft 365 + Dataverse | tie |
+| Surface where agents appear | Salesforce UIs (Service Cloud, Sales Cloud, Experience Cloud) | Teams, Outlook, SharePoint, Microsoft 365 Copilot | tie |
+| Reasoning engine | Atlas Reasoning Engine (Salesforce-built) | Model-agnostic routing across GPT-5, Anthropic, Azure OpenAI | tie |
+| Supported LLMs | Multiple models via Einstein Trust Layer; Atlas-routed | GPT-5, Anthropic, Azure OpenAI in the multi-model lineup | tie |
+| Pricing model | ~$2 per conversation; also Agentforce 1 Editions with per-agent licensing | Bundled ($30/user/month in M365 Copilot) + Copilot Credits ($200/pack of 25K credits) + pay-as-you-go | tie |
+| MCP support | Announced, rolling out | Supported alongside 1,400+ external connectors | b |
+| Multi-agent orchestration | Agentforce 2.0 added orchestration across agents | Multi-agent systems native in Copilot Studio | tie |
+| Governance and audit | Einstein Trust Layer (masking, audit trail) | Purview, Entra, Power Platform admin centre, Viva Insights | tie |
+
+## What each platform actually is
+
+Agentforce is Salesforce's agentic-AI platform, the successor to Einstein. Three dates, three releases. Announced September 12, 2024 <a href="#cite-1" class="cite-ref">[1]</a>. GA on October 25, 2024 <a href="#cite-2" class="cite-ref">[2]</a>. Agentforce 2.0 introduced on December 17, 2024 <a href="#cite-3" class="cite-ref">[3]</a>, with multi-agent orchestration and an extended reasoning layer. The architectural bet is that Data Cloud (Salesforce's customer data platform) is the ground truth the agent reasons over, with the Atlas Reasoning Engine handling planning and tool invocation on top.
+
+Copilot Studio is Microsoft's low-code platform for building agents that live inside Microsoft 365, Teams, Outlook, SharePoint, and third-party channels. Microsoft's own description: "an end-to-end conversational AI platform that empowers you to create agents using natural language or a graphical interface." The architectural bet is that the Microsoft Graph, the identity, permission, and content layer across M365, is the ground truth, with Azure OpenAI, GPT-5, and Anthropic available as routed models.
+
+## Pricing, with the caveats
+
+Both vendors run deliberately complex pricing. Salesforce has shipped three Agentforce models since launch: $2 per conversation at October 2024 GA, Flex Credits at $0.10 per action from May 15, 2025, and per-user licences at $125 to $650 per user per month in late 2025. All three run at once <a href="#cite-5" class="cite-ref">[5]</a>. Microsoft's Copilot Studio stack prices as $200 per 25,000-credit pack on top of the Microsoft 365 Copilot add-on. Direct list-to-list comparison is misleading unless the deployment matches the canonical pricing assumptions.
+
+*Published pricing as of April 2026*
+
+| Item | Agentforce | Copilot Studio |
+| --- | --- | --- |
+| Headline unit | ~$2 per conversation (pay-per-use) | $30 per user per month, bundled into Microsoft 365 Copilot |
+| Alternative unit | Agentforce 1 Editions: per-agent licensing (talk to Salesforce for pricing) | Copilot Credits: $200 per pack (25,000 credits) per month, up to 20% savings at pre-purchase |
+| Pay-as-you-go | Included in conversation-based pricing | Usage-based Azure billing; no upfront commitment |
+| Free trial / dev | Agentforce Developer Edition | Copilot Studio trial; Copilot Studio Lite for light use |
+
+Pricing signal, plainly. Agentforce's $2-per-conversation model is unusual in enterprise software: it aligns vendor incentive with outcome volume. The shift to Flex Credits and per-user tiers in 2025 <a href="#cite-5" class="cite-ref">[5]</a> suggests even Salesforce found the conversation model hard to scale on enterprise workflows. Copilot Studio's bundled-with-M365 pricing is the conventional enterprise model, and looks "free at the margin" to organizations already paying for the $30-per-user-per-month Microsoft 365 Copilot add-on <a href="#cite-8" class="cite-ref">[8]</a>.
+
+## Where each one wins
+
+Six categories where one platform has the clearer advantage:
+
+*Directional advantages · evaluated on publicly documented capabilities*
+
+| Situation | Better starting point |
+| --- | --- |
+| Service / Sales agents grounded in CRM data | Agentforce |
+| Agents that live inside Teams, Outlook, SharePoint | Copilot Studio |
+| Outcome-aligned pricing preferred by procurement | Agentforce ($/conversation) |
+| Existing M365 E5 agreement to bundle against | Copilot Studio |
+| MCP-native architectural bet, broad connector reuse | Copilot Studio (1,400+ connectors + MCP) |
+| Marketing Cloud / Customer 360 orchestration depth | Agentforce |
+| Purview + Entra governance alignment already in place | Copilot Studio |
+| Einstein Trust Layer (masking + audit) already in use | Agentforce |
+
+## Things that could reshape the comparison
+
+Three developments we are watching through 2026 that could move the scorecard:
+
+- **MCP coverage parity.** Copilot Studio reached MCP GA in May 2025 <a href="#cite-6" class="cite-ref">[6]</a> alongside 1,400+ Power Platform connectors <a href="#cite-7" class="cite-ref">[7]</a>; Agentforce MCP client entered pilot July 2025 and hosted MCP servers reached beta October 2025 <a href="#cite-4" class="cite-ref">[4]</a>. Copilot Studio has the deeper production rollout for now; Agentforce is closing the gap.
+- **Outcome pricing transparency.** Salesforce's $2-per-conversation number is the reference point; Microsoft has not shipped a directly equivalent metric. If Microsoft publishes outcome pricing, the procurement conversation changes overnight.
+- **Multi-agent interoperability.** Both platforms have multi-agent orchestration, but neither meaningfully inter-operates with the other. Standards like MCP and A2A (agent-to-agent) could reduce the lock-in premium of either single-vendor choice.
+
+> **Disclosure**: Explore Agentic is published by ASCENDING, which builds Jarvis AI. This page compares Agentforce and Copilot Studio without recommending our own product; they are both category leaders in their respective ecosystems, and most buyers choose between them based on which system of record they already run. If you want a cloud-neutral alternative to either, /jarvis is that conversation; it is not the conversation on this page.
+
+## FAQ
+
+**Q: How much does Salesforce Agentforce cost in 2026?**
+
+Three pricing models running in parallel <a href="#cite-5" class="cite-ref">[5]</a>. The first one: $2 per conversation, since October 2024. The second: Flex Credits at $0.10 per action, 100,000-credit minimum ($10,000 floor), starting May 2025. The third: per-user licences at $125 to $650 per user per month, added late 2025. All three still active. Enterprise deals get quoted on whichever fits the workflow shape.
+
+**Q: How much does Microsoft Copilot Studio cost?**
+
+Two shapes. Microsoft 365 Copilot at $30 per user per month, which bundles Copilot Studio access for agent-building. Standalone Copilot Studio uses $200 per 25,000-credit packs per month ($0.01 per credit PAYG) <a href="#cite-8" class="cite-ref">[8]</a>. One or the other. Rarely both at the same seat.
+
+**Q: When did Agentforce launch and when did MCP support ship?**
+
+Four dates matter. Agentforce announced September 12, 2024 <a href="#cite-1" class="cite-ref">[1]</a>. GA October 25, 2024 <a href="#cite-2" class="cite-ref">[2]</a>. Agentforce 2.0 with multi-agent orchestration on December 17, 2024 <a href="#cite-3" class="cite-ref">[3]</a>. MCP client support entered pilot July 2025, hosted servers reached beta October 2025 <a href="#cite-4" class="cite-ref">[4]</a>. Copilot Studio MCP beat that timeline by six months: GA May 2025 <a href="#cite-6" class="cite-ref">[6]</a>.
+
+**Q: Should I pick Agentforce or Copilot Studio if my CRM is Salesforce?**
+
+Agentforce. Three reasons. The Atlas Reasoning Engine is native to Data Cloud. The agent surface inherits Salesforce permissions. The Einstein Trust Layer covers masking and audit. Copilot Studio can reach Salesforce via connectors <a href="#cite-7" class="cite-ref">[7]</a>, but the integration tax and a duplicate governance surface add up over the renewal cycle.
+
+**Q: Should I pick Agentforce or Copilot Studio if my stack is M365?**
+
+Copilot Studio. Three things tip it. Native integration with Teams, Outlook, SharePoint, and Microsoft Graph. Governance via Purview and Entra. E5-renewal bundling. When M365 is already the daily substrate, that stack beats Agentforce on friction every time.
+
+**Q: Which platform has broader MCP and connector support?**
+
+Copilot Studio, in April 2026. MCP reached GA in Copilot Studio in May 2025 <a href="#cite-6" class="cite-ref">[6]</a>. 1,400+ Power Platform connectors alongside <a href="#cite-7" class="cite-ref">[7]</a>. Agentforce is catching up, not ahead: MCP pilot July 2025, hosted-server beta October 2025 <a href="#cite-4" class="cite-ref">[4]</a>. The connector catalog there depends on MuleSoft (40 pre-built connectors announced with Agentforce 2.0).
+
+## Citations
+
+1. **Salesforce** — Salesforce Unveils Agentforce - What AI Was Meant to Be — https://www.salesforce.com/news/press-releases/2024/09/12/agentforce-announcement/ [accessed 2026-04-16] *(September 12, 2024 Agentforce announcement.)* { #cite-1 }
+2. **Salesforce** — Agentforce Is Here: Trusted, Autonomous AI Agents — https://www.salesforce.com/news/press-releases/2024/10/29/agentforce-general-availability-announcement/ [accessed 2026-04-16] *(October 25, 2024 GA; $2 per conversation launch price.)* { #cite-2 }
+3. **Salesforce** — Introducing Agentforce 2.0: The Digital Labor Platform — https://www.salesforce.com/news/press-releases/2024/12/17/agentforce-2-0-announcement/ [accessed 2026-04-16] *(December 17, 2024 Agentforce 2.0; multi-agent orchestration and Atlas Reasoning Engine.)* { #cite-3 }
+4. **Salesforce Developer Blog** — Introducing MCP Support Across Salesforce — https://developer.salesforce.com/blogs/2025/06/introducing-mcp-support-across-salesforce [accessed 2026-04-16] *(June 2025 Agentforce MCP client pilot; October 2025 hosted MCP servers in beta.)* { #cite-4 }
+5. **SaaStr** — Salesforce Now Has 3+ Pricing Models for Agentforce — https://www.saastr.com/salesforce-now-has-3-pricing-models-for-agentforce-and-maybe-right-now-thats-the-way-to-do-it/ [accessed 2026-04-16] *(Analysis of three Agentforce pricing models: $2/conversation, Flex Credits at $0.10/action, $125-$650/user/month.)* { #cite-5 }
+6. **Microsoft Copilot Blog** — MCP GA in Copilot Studio — https://www.microsoft.com/en-us/microsoft-copilot/blog/copilot-studio/model-context-protocol-mcp-is-now-generally-available-in-microsoft-copilot-studio/ [accessed 2026-04-16] *(May 2025 GA; preview March 2025.)* { #cite-6 }
+7. **Microsoft Learn** — Use connectors in Copilot Studio agents — https://learn.microsoft.com/en-us/microsoft-copilot-studio/advanced-connectors [accessed 2026-04-16] *(1,400+ Power Platform connectors.)* { #cite-7 }
+8. **Microsoft** — Microsoft 365 Copilot Plans and Pricing — https://www.microsoft.com/en-us/microsoft-365-copilot/pricing [accessed 2026-04-16] *($30/user/month add-on; Copilot Credits $200 per 25,000-credit pack.)* { #cite-8 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/comparisons/agentforce-vs-copilot-studio/](https://www.exploreagentic.ai/comparisons/agentforce-vs-copilot-studio/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/comparisons/agentspace-vs-copilot.md
+++ b/docs/explore-agentic/comparisons/agentspace-vs-copilot.md
@@ -1,0 +1,122 @@
+# Agentspace vs Microsoft Copilot: 2026 Gemini rebrand
+
+> Google Agentspace, the company's enterprise-AI offering, was folded into Gemini Enterprise in early 2026. The conversational and agent-orchestration technology that was Agentspace now powers Gemini Enterprise's core functionality. A side-by-side of Gemini Enterprise and Microsoft 365 Copilot, the two horizontal productivity-AI platforms most enterprises are comparing.
+
+*Comparison · Platforms · Google Gemini Enterprise (formerly Agentspace) vs Microsoft 365 Copilot · 11 minutes · Updated April 16, 2026 · Author Merve Tengiz · Reviewed by Elias Saljuki*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/comparisons/agentspace-vs-copilot/](https://www.exploreagentic.ai/comparisons/agentspace-vs-copilot/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Verdict
+
+The two platforms now price and position almost identically ($21 to $30 per seat per month) and both pitch the same thing: an enterprise assistant that reads across your corporate data, invokes tools, and deploys into your existing collaboration surface. The choice is mostly determined by which productivity suite you already pay for. Google Gemini Enterprise is the cleaner bet if you are on Workspace or want Gemini 3 as the default model. Microsoft 365 Copilot is the cleaner bet if you are on M365 and want multi-model (GPT-5 and Anthropic now in the lineup). Neither is a cloud-neutral choice; both lock you into the publisher's cloud identity layer.
+
+## Scorecard
+
+| Category | Google Gemini Enterprise (formerly Agentspace) | Microsoft 365 Copilot | Winner |
+| --- | --- | --- | --- |
+| Branding / productisation | Gemini Enterprise (Agentspace now folded in) | Microsoft 365 Copilot (with Copilot Studio for agent authoring) | tie |
+| Headline price | $21 per seat per month (Business); $30 per seat per month (Standard / Plus) | $30 per user per month (Microsoft 365 Copilot) | a |
+| Default LLM family | Gemini 3 and Gemini Enterprise tuning | GPT-5, Anthropic, Azure OpenAI | tie |
+| Multi-LLM routing | Gemini-family focused | Multi-model routing; model choice per agent | b |
+| Native productivity surface | Google Workspace (Docs, Sheets, Drive, Gmail, Meet) | Microsoft 365 (Word, Excel, Outlook, Teams, SharePoint) | tie |
+| Enterprise-data connectors | Workspace + M365 + Salesforce + SAP + BigQuery (per Google's own documentation) | M365 + Dataverse + 1,400+ external connectors | b |
+| MCP / open-protocol support | Google has announced MCP support; rolling out | MCP support plus Copilot extension model | b |
+| Developer / agent-building platform | Agent Development Kit, integrated with Gemini Enterprise | Copilot Studio, integrated with Microsoft 365 Copilot | tie |
+
+## What actually happened with the rebrand
+
+Google launched Agentspace on December 13, 2024 <a href="#cite-3" class="cite-ref">[3]</a>, the company's enterprise-AI answer to Microsoft Copilot. Ten months later it folded. At the October 9, 2025 Gemini Enterprise launch <a href="#cite-2" class="cite-ref">[2]</a>, Google folded Agentspace into Gemini Enterprise, positioning the combined offering as "the" Google enterprise AI platform rather than maintaining two. Google's own framing: "The conversational AI and agent creation and orchestration technology behind Agentspace is now powering the core functionalities of the Gemini Enterprise platform." <a href="#cite-1" class="cite-ref">[1]</a>
+
+Existing Agentspace customers keep their entitlements. New customers land on Gemini Enterprise: $21 per seat per month for Business, $30 per seat per month for Standard and Plus editions <a href="#cite-2" class="cite-ref">[2]</a>. Both are Google Cloud products, priced separately from Google Workspace and Microsoft 365.
+
+## What each platform actually is in April 2026
+
+Gemini Enterprise is Google's enterprise AI offering. Three things in one: conversational assistant, agent orchestration, connectors into corporate data <a href="#cite-1" class="cite-ref">[1]</a>. The assistant runs on Gemini 3 by default. The platform ships with connectors into Workspace, Microsoft 365, Salesforce, SAP, and BigQuery, a deliberately cross-cloud connector story.
+
+Microsoft 365 Copilot is the enterprise assistant. Copilot Studio is the low-code agent-authoring platform that extends it. The $30-per-user-per-month headline <a href="#cite-4" class="cite-ref">[4]</a> is an add-on: it requires a qualifying E3 ($36 rising to $39 on July 1, 2026) or E5 ($57 rising to $60) base licence. Copilot runs across GPT-5, Claude Sonnet 4, Claude Opus 4.1, and Azure OpenAI. Microsoft added Anthropic in September 2025 <a href="#cite-5" class="cite-ref">[5]</a>.
+
+## Pricing, side by side
+
+*Published list pricing, April 2026*
+
+| Tier | Gemini Enterprise | Microsoft 365 Copilot |
+| --- | --- | --- |
+| Entry seat | $21 per seat per month (Business edition) | Not offered below $30 tier |
+| Standard seat | $30 per seat per month (Standard / Plus editions) | $30 per user per month |
+| Agent authoring included? | Yes (Agent Development Kit) | Yes (Copilot Studio) |
+| Usage / metered billing | Enterprise add-ons vary | Copilot Credits: $200 per 25,000 credits per month; also PAYG via Azure |
+
+On list, Gemini Enterprise Business is materially cheaper: $21 vs $30 <a href="#cite-2" class="cite-ref">[2]</a>. In practice, enterprise buyers rarely pay list. Volume discounts. Bundles with Workspace or M365 commitments. Usage metering. All three move the effective number. The more interesting signal is that Google is willing to publish a $21 entry at all, a procurement lever Microsoft has not matched (especially once you factor in the required E3 or E5 base licence <a href="#cite-4" class="cite-ref">[4]</a>).
+
+## Which fits which organization
+
+*Decision framework · based on public product documentation*
+
+| If your situation is… | Better starting point |
+| --- | --- |
+| Already on Google Workspace; Gemini models preferred | Gemini Enterprise |
+| Already on Microsoft 365; users live in Teams and Outlook | Microsoft 365 Copilot |
+| Multi-LLM routing across GPT, Anthropic, and Gemini in one agent | Microsoft 365 Copilot (currently broader LLM lineup) |
+| Heterogeneous SaaS; connector breadth across Salesforce, SAP, M365, Workspace | Either; both connector catalogs are credible, and Microsoft's is broader |
+| Budget pressure at seat level | Gemini Enterprise Business ($21/seat) |
+| Cloud-neutral mandate (neither Azure nor Google Cloud) | Neither; these are both cloud-aligned platforms |
+
+## What to watch through 2026
+
+- **Multi-model coverage on both sides.** Microsoft added Anthropic and GPT-5 to the Copilot lineup in 2025. Google's multi-model story is still Gemini-first. If Google opens multi-model routing inside Gemini Enterprise, the comparison narrows.
+- **Connector-catalog parity.** Microsoft's "1,400+ external connectors" figure is difficult to match; Google's connector story is sharper but narrower. Both are investing heavily; the gap will close.
+- **MCP rollout.** Microsoft Copilot Studio reached MCP GA in May 2025; Google has announced MCP support for Gemini Enterprise and is rolling out through 2026. MCP-native vendors (including Jarvis <a href="#cite-8" class="cite-ref">[8]</a>) are betting the interoperability layer (MCP was released by Anthropic November 25, 2024 <a href="#cite-7" class="cite-ref">[7]</a>) meaningfully reduces lock-in; how much that plays out here is one of the more important 2026 questions.
+- **Procurement line-item simplicity.** Gemini Enterprise's $21 list price is a procurement-friendly anchor. If Microsoft responds with an equivalent entry tier, a category-wide price reset is on the table.
+
+> **Disclosure**: Explore Agentic is published by ASCENDING, which builds Jarvis AI. This page compares Gemini Enterprise and Microsoft 365 Copilot without pushing our product; most enterprises will make this decision based on which productivity suite they already run. If you need a cloud-neutral alternative to either, /jarvis is that conversation; it is not the conversation here.
+
+## FAQ
+
+**Q: How much does Google Gemini Enterprise cost per seat in 2026?**
+
+Two tiers, twenty-one and thirty. Gemini Business runs $21 per seat per month. Gemini Enterprise (Standard and Plus) is $30 per seat per month <a href="#cite-2" class="cite-ref">[2]</a>. Both are Google Cloud products, priced separately from Workspace, and ship with the Agent Development Kit and connectors into Workspace, Microsoft 365, Salesforce, SAP, and BigQuery.
+
+**Q: How much does Microsoft 365 Copilot cost per user in 2026?**
+
+Thirty dollars per user per month for the Microsoft 365 Copilot add-on <a href="#cite-4" class="cite-ref">[4]</a>. That sits on top of a qualifying base licence. The base goes up on July 1, 2026: E3 from $36 to $39, E5 from $57 to $60. All-in: $42.50 to $87 per user per month, depending on which base seat you already own.
+
+**Q: Is Google Agentspace the same product as Gemini Enterprise in 2026?**
+
+Yes, the same product with a new label. Agentspace was folded into Gemini Enterprise at the October 9, 2025 launch <a href="#cite-2" class="cite-ref">[2]</a>. The agent-creation and orchestration technology that was Agentspace now powers Gemini Enterprise. Existing Agentspace customers keep their entitlements. New customers land on Gemini Enterprise. The original Agentspace launch: December 13, 2024 <a href="#cite-3" class="cite-ref">[3]</a>.
+
+**Q: Should I pick Gemini Enterprise or Microsoft 365 Copilot if I am on Google Workspace?**
+
+Gemini Enterprise. The assistant runs on Gemini 3 by default. Native integration with Docs, Sheets, Drive, Gmail, and Meet. And at $21 to $30 per seat, it prices below a full Microsoft 365 Copilot stack if you do not already pay for E5. Copilot reaches Workspace via connectors, but the integration tax and the duplicated governance surfaces are real.
+
+**Q: Should I pick Gemini Enterprise or Microsoft 365 Copilot if I am on M365?**
+
+Microsoft 365 Copilot. Three reasons. Native integration with Word, Excel, PowerPoint, Outlook, Teams, and SharePoint. Governance via Purview and Entra. And the multi-model lineup: GPT-5 as default, with Claude Sonnet 4 and Opus 4.1 added in September 2025 <a href="#cite-5" class="cite-ref">[5]</a>. Copilot also ships with 1,400+ Power Platform connectors <a href="#cite-6" class="cite-ref">[6]</a>.
+
+**Q: Which platform has broader MCP support in 2026?**
+
+Microsoft, today. Copilot Studio reached MCP GA in May 2025, the deeper production rollout. Google has announced MCP support for Gemini Enterprise and is rolling it out through 2026. For MCP-first architecture bets (protocol released by Anthropic November 25, 2024 <a href="#cite-7" class="cite-ref">[7]</a>), a cloud-neutral option like Jarvis <a href="#cite-8" class="cite-ref">[8]</a> is worth evaluating. Gemini Enterprise and Microsoft 365 Copilot both lock you into the publisher cloud.
+
+## Citations
+
+1. **Google Cloud** — Gemini Enterprise: Best of Google AI for Business — https://cloud.google.com/gemini-enterprise [accessed 2026-04-16] *(Canonical product page; folds former Agentspace into Gemini Enterprise.)* { #cite-1 }
+2. **CNBC** — Google launches Gemini Enterprise to boost AI agent use at work — https://www.cnbc.com/2025/10/09/google-launches-gemini-enterprise-to-boost-ai-agent-use-at-work.html [accessed 2026-04-16] *(October 9, 2025 launch coverage. Gemini Business $21/seat; Gemini Enterprise $30/seat.)* { #cite-2 }
+3. **Google Cloud Blog** — Bringing AI Agents to Enterprises with Google Agentspace — https://cloud.google.com/blog/products/ai-machine-learning/bringing-ai-agents-to-enterprises-with-google-agentspace [accessed 2026-04-16] *(December 13, 2024 Agentspace launch announcement.)* { #cite-3 }
+4. **Microsoft** — Microsoft 365 Copilot Plans and Pricing — https://www.microsoft.com/en-us/microsoft-365-copilot/pricing [accessed 2026-04-16] *($30/user/month add-on; E3 $36 rising to $39 on July 1, 2026; E5 $57 rising to $60.)* { #cite-4 }
+5. **Microsoft 365 Blog** — Expanding model choice in Microsoft 365 Copilot — https://www.microsoft.com/en-us/microsoft-365/blog/2025/09/24/expanding-model-choice-in-microsoft-365-copilot/ [accessed 2026-04-16] *(September 2025 Claude Sonnet 4 / Opus 4.1 added; GPT-5 default late 2025.)* { #cite-5 }
+6. **Microsoft Learn** — Use connectors in Copilot Studio agents — https://learn.microsoft.com/en-us/microsoft-copilot-studio/advanced-connectors [accessed 2026-04-16] *(1,400+ Power Platform, Microsoft Graph, and Power Query connectors.)* { #cite-6 }
+7. **Anthropic** — Introducing the Model Context Protocol — https://www.anthropic.com/news/model-context-protocol [accessed 2026-04-16] *(November 25, 2024 MCP launch.)* { #cite-7 }
+8. **AWS Marketplace** — Jarvis - Simplifying AI Adoption — https://aws.amazon.com/marketplace/pp/prodview-ckf77lbx67sx2 [accessed 2026-04-16] *(Public listing; $1,500 / $2,500 / custom monthly tiers.)* { #cite-8 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/comparisons/agentspace-vs-copilot/](https://www.exploreagentic.ai/comparisons/agentspace-vs-copilot/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/comparisons/index.md
+++ b/docs/explore-agentic/comparisons/index.md
@@ -1,0 +1,79 @@
+# Comparisons
+
+> Honest side-by-sides — including where Jarvis loses. Comparisons built from public documentation, AWS Marketplace listings, and analyst commentary. Entries that include Jarvis (our product) open with a disclosure banner and mark categories where Jarvis loses. Every table is dated; every claim is cited.
+
+!!! warning "Disclosure"
+
+    Jarvis is built by ASCENDING Inc., the same company that publishes Explore Agentic. Pages comparing Jarvis to other vendors are flagged below. We mark categories where Jarvis loses; if you think a balance is off, write in and we update rather than defend.
+
+## Including Jarvis
+
+<div class="grid cards" markdown>
+
+-   **[Jarvis vs Moveworks](jarvis-vs-moveworks.md)**
+
+    ---
+
+    Our product against the Moveworks / ServiceNow AI Agents platform. Where we win (MCP-native, multi-LLM, transparent mid-market pricing) and where we lose (logo wall, ITSM-native depth).
+
+    *Includes Jarvis · April 2026 · 11 min*
+
+-   **[Jarvis vs Glean](jarvis-vs-glean.md)**
+
+    ---
+
+    Our product against Glean. Where we win (MCP-native, governance-first, private AWS deployment) and where we lose (connector catalog breadth, search ranking maturity).
+
+    *Includes Jarvis · April 2026 · 10 min*
+
+-   **[Jarvis vs Copilot Studio](jarvis-vs-copilot-studio.md)**
+
+    ---
+
+    Our product against Microsoft's Copilot Studio. Where we win (cloud-neutral, MCP-native, no Azure lock-in) and where we lose (M365 integration, enterprise footprint).
+
+    *Includes Jarvis · April 2026 · 10 min*
+
+</div>
+
+## Other side-by-sides
+
+<div class="grid cards" markdown>
+
+-   **[Moveworks vs Glean](moveworks-vs-glean.md)**
+
+    ---
+
+    After the $2.85B ServiceNow acquisition, the picture changed. A side-by-side rebuilt from both vendors' public documentation, AWS Marketplace listings, and analyst commentary.
+
+    *Enterprise search · April 2026 · 13 min*
+
+-   **[MCP vs RAG](mcp-vs-rag.md)**
+
+    ---
+
+    The two protocols people most often confuse. A side-by-side on what each is for and when to choose one over the other.
+
+    *Architecture · March 2026 · 9 min*
+
+-   **[Agentforce vs Copilot Studio](agentforce-vs-copilot-studio.md)**
+
+    ---
+
+    Two of the largest agent platforms, built on different architectural bets. Salesforce Data Cloud native vs Microsoft 365 native — pricing, LLM choice, MCP support, governance.
+
+    *Platforms · April 2026 · 12 min*
+
+-   **[Agentspace vs Copilot](agentspace-vs-copilot.md)**
+
+    ---
+
+    After the Gemini Enterprise rebrand. $21/$30 per seat vs $30 per user. Multi-model routing, connector breadth, and the procurement lever neither side has fully played.
+
+    *Platforms · April 2026 · 11 min*
+
+</div>
+
+---
+
+The comparisons are mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — the canonical index lives at [www.exploreagentic.ai/comparisons/](https://www.exploreagentic.ai/comparisons/).

--- a/docs/explore-agentic/comparisons/jarvis-vs-copilot-studio.md
+++ b/docs/explore-agentic/comparisons/jarvis-vs-copilot-studio.md
@@ -1,0 +1,113 @@
+# Jarvis vs Microsoft Copilot Studio: the 2026 buyer's guide
+
+> Microsoft 365 Copilot is $30 per user per month on an E3/E5 base; Copilot Studio is $200 per 25,000-credit pack per month. Jarvis is our product. A Jarvis vs Microsoft Copilot Studio side-by-side for buyers weighing the cloud-neutral option, with citations and pricing on each column.
+
+*Comparison · Includes our own product · Jarvis AI vs Microsoft Copilot Studio · 10 minutes · Updated April 16, 2026 · Author Elias Saljuki · Reviewed by Merve Tengiz*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/comparisons/jarvis-vs-copilot-studio/](https://www.exploreagentic.ai/comparisons/jarvis-vs-copilot-studio/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Verdict
+
+If you are deeply embedded in M365 and Azure and have a single-vendor procurement mandate, Copilot Studio is the lower-friction pick: the integration with Office / Teams / Outlook is native, and the enterprise agreement will price it competitively. If you want cloud-neutral deployment, MCP-native connectivity, or multi-LLM routing, Jarvis is the comparison worth running. Both platforms target the same category; they make very different architectural bets.
+
+## Scorecard
+
+| Category | Jarvis AI | Microsoft Copilot Studio | Winner |
+| --- | --- | --- | --- |
+| M365 / Teams / Outlook integration | Via connectors and MCP servers | Native, first-party | b |
+| Cloud-neutral / vendor-neutral | Multi-LLM, multi-cloud | Azure-aligned | a |
+| MCP-native gateway | First-class (Jarvis Registry) | MCP support available; Microsoft-first framing | a |
+| Multi-LLM routing | OpenAI, Anthropic, Bedrock, Gemini, DeepSeek | Primarily OpenAI / Azure OpenAI | a |
+| Governance as a primitive | PII/DLP, RBAC, SSO, audit as shared layer | Purview / Entra integration, strong for M365 | tie |
+| Private AWS deployment | Available | Azure-only | a |
+| Enterprise footprint | Concentrated in regulated + mid-market | Global Microsoft enterprise base | b |
+| Pricing transparency (list) | Published AWS Marketplace tiers | Per-message + license bundling; complex, published | a |
+
+## Disclosure, stated plainly
+
+Jarvis AI is our product. ASCENDING Inc., the company that publishes Explore Agentic, builds Jarvis. This page is our side-by-side; the usual caveat applies. If you think the balance is off, write in and we update rather than defend.
+
+## What each product actually is
+
+Microsoft Copilot Studio is the low-code platform for building agents that live inside Microsoft Copilot, Teams, and Outlook. Native M365 integration. Entra-backed identity. Purview governance. A tightly-coupled experience for organisations already running on Microsoft's stack. The architectural centre is the Microsoft Graph. The model default is Azure OpenAI.
+
+Jarvis is the cloud-neutral alternative. Multi-LLM by default. MCP-native. Available for private AWS deployment. The architectural centre is the MCP protocol. The model default is whichever your procurement team has already approved.
+
+## Where Copilot Studio wins
+
+- **M365 integration.** If your users live in Teams, Outlook, and SharePoint, Copilot Studio agents surface there natively without an additional integration project. Jarvis can surface in the same places via MCP + connector, but it is an integration; Copilot Studio is a first-party experience.
+- **Entra / Purview governance alignment.** If your identity and data-protection stack is already Entra + Purview, Copilot Studio slots in without re-implementing access-control logic. Jarvis integrates with SAML/OAuth and brings its own governance layer, which is great if that is your story and redundant if you are already all-in on Microsoft.
+- **Enterprise agreement pricing.** Bundled inside an E5 or Microsoft 365 Copilot agreement, Copilot Studio is often effectively free at the margin. A standalone procurement of Jarvis will be a new line item on the CFO's desk.
+
+## Where Jarvis wins
+
+- **Cloud-neutral and multi-LLM.** If your procurement team has said “no Azure lock-in,” Copilot Studio is difficult; Jarvis is default. If you want to route the same prompt to OpenAI, Anthropic, and Bedrock in an A/B, Jarvis does that out of the box.
+- **MCP-native gateway.** Jarvis Registry is a first-class MCP gateway with a growing catalog of servers, the community-standard way to connect tools in 2026. Copilot Studio supports MCP but the product's centre of gravity is Microsoft Graph.
+- **Private AWS deployment.** Regulated industries with AWS-only mandates can run Jarvis in a private VPC. Copilot Studio does not offer a non-Azure deployment.
+- **Transparent, line-item pricing.** Published AWS Marketplace tiers. Copilot Studio pricing is a function of E5 / Copilot seat bundling + per-message metering, predictable only if you are already inside the Microsoft world.
+
+## Which fits your situation
+
+*A decision framework, not a ranking*
+
+| If your situation is… | Our honest recommendation |
+| --- | --- |
+| Already deep in M365 + Azure, single-vendor mandate | Copilot Studio |
+| Users live in Teams / Outlook, agent surface is the goal | Copilot Studio |
+| AWS-aligned stack, MCP-native roadmap | Jarvis |
+| Multi-cloud or cloud-neutral procurement mandate | Jarvis |
+| Need multi-LLM routing (OpenAI + Anthropic + Bedrock) | Jarvis |
+| Mid-market without an E5 agreement to bundle into | Jarvis |
+
+> **Pragmatic note**: Many enterprises run both. If you have M365 deeply embedded, Copilot Studio for in-Teams surfaces is often right; if you also have AWS workloads and a multi-cloud governance function, Jarvis complements it. We would rather help you architect that than fight over the whole deal.
+
+## FAQ
+
+**Q: How much does Copilot Studio cost per user in 2026?**
+
+Two numbers. Copilot Credits run $200 per 25,000-credit pack per month, or $0.01 per credit PAYG <a href="#cite-7" class="cite-ref">[7]</a>. Microsoft 365 Copilot adds $30 per user per month on top of an E3 or E5 base <a href="#cite-6" class="cite-ref">[6]</a>. The base goes up July 1, 2026: E3 from $36 to $39, E5 from $57 to $60.
+
+**Q: How does Jarvis vs Copilot Studio pricing compare?**
+
+Jarvis lists flat monthly tiers on AWS and Azure Marketplace: $1,500 Basic, $2,500 Pro, Enterprise custom <a href="#cite-4" class="cite-ref">[4]</a>. All flat-fee regardless of seat count. Without an existing E5 seat, the all-in for Microsoft 365 Copilot lands between $42.50 and $87 per user per month <a href="#cite-6" class="cite-ref">[6]</a>. With 100 seats that is a $50K-$100K/year floor before agent-building credits.
+
+**Q: Does Copilot Studio support MCP in 2026?**
+
+Yes. Preview March 2025. GA May 2025 <a href="#cite-2" class="cite-ref">[2]</a>. The architectural centre remains Microsoft Graph, plus the 1,400+ Power Platform connector catalog <a href="#cite-1" class="cite-ref">[1]</a>. MCP sits alongside, not underneath.
+
+**Q: Should I pick Jarvis or Copilot Studio if I am deep in M365?**
+
+Copilot Studio. Four reasons in a row. Native M365 integration. Entra identity. Purview governance. E5 bundling. The integration tax on Jarvis from that starting point is harder to justify.
+
+**Q: Which one is better for multi-LLM routing?**
+
+Jarvis. Jarvis routes across OpenAI, Anthropic, AWS Bedrock, Google Gemini, and DeepSeek. Copilot Studio runs GPT-5 by default and added Claude in September 2025 <a href="#cite-3" class="cite-ref">[3]</a>. All Azure-hosted. That is the ceiling.
+
+**Q: Can Copilot Studio be deployed outside Azure?**
+
+No. Copilot Studio is Azure-only. For AWS-only mandates, Jarvis is the architectural match: private AWS deployment is available out of the box.
+
+## Citations
+
+1. **Microsoft Learn** — Use connectors in Copilot Studio agents — https://learn.microsoft.com/en-us/microsoft-copilot-studio/advanced-connectors [accessed 2026-04-16] *(1,400+ Power Platform connectors.)* { #cite-1 }
+2. **Microsoft Copilot Blog** — MCP GA in Copilot Studio — https://www.microsoft.com/en-us/microsoft-copilot/blog/copilot-studio/model-context-protocol-mcp-is-now-generally-available-in-microsoft-copilot-studio/ [accessed 2026-04-16] *(May 2025 GA; preview March 2025.)* { #cite-2 }
+3. **Microsoft 365 Blog** — Expanding model choice in Microsoft 365 Copilot — https://www.microsoft.com/en-us/microsoft-365/blog/2025/09/24/expanding-model-choice-in-microsoft-365-copilot/ [accessed 2026-04-16] *(September 2025 Claude added; GPT-5 default.)* { #cite-3 }
+4. **AWS Marketplace** — Jarvis: Simplifying AI Adoption — https://aws.amazon.com/marketplace/pp/prodview-ckf77lbx67sx2 [accessed 2026-04-16] *($1,500 / $2,500 / custom monthly tiers.)* { #cite-4 }
+5. **Anthropic** — Introducing the Model Context Protocol — https://www.anthropic.com/news/model-context-protocol [accessed 2026-04-16] *(November 25, 2024 MCP launch.)* { #cite-5 }
+6. **Microsoft** — Microsoft 365 Copilot Plans and Pricing — https://www.microsoft.com/en-us/microsoft-365-copilot/pricing [accessed 2026-04-16] *($30/user/month; E3 $36→$39 and E5 $57→$60 effective July 1, 2026.)* { #cite-6 }
+7. **Microsoft Learn** — Billing rates: Copilot Studio — https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-messages-management [accessed 2026-04-16] *($200 per 25,000-credit pack; $0.01 per credit PAYG.)* { #cite-7 }
+8. **Microsoft Copilot Blog** — Anthropic joins Copilot Studio — https://www.microsoft.com/en-us/microsoft-copilot/blog/copilot-studio/anthropic-joins-the-multi-model-lineup-in-microsoft-copilot-studio/ [accessed 2026-04-16] *(Claude Sonnet 4 / Opus 4.1 added.)* { #cite-8 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/comparisons/jarvis-vs-copilot-studio/](https://www.exploreagentic.ai/comparisons/jarvis-vs-copilot-studio/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/comparisons/jarvis-vs-glean.md
+++ b/docs/explore-agentic/comparisons/jarvis-vs-glean.md
@@ -1,0 +1,110 @@
+# Jarvis vs Glean: the 2026 buyer's guide (with disclosure)
+
+> Glean raised a $150M Series F at a $7.2B valuation in June 2025 and lists 100+ connectors on its site. Jarvis is our product. A Jarvis vs Glean side-by-side for buyers weighing both, with citations and pricing on each column.
+
+*Comparison · Includes our own product · Jarvis AI vs Glean · 10 minutes · Updated April 16, 2026 · Author Elias Saljuki · Reviewed by Wenjia (Soraya) Zheng*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/comparisons/jarvis-vs-glean/](https://www.exploreagentic.ai/comparisons/jarvis-vs-glean/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Verdict
+
+Glean wins on raw enterprise-search depth and connector catalog breadth. Jarvis wins on MCP-native connectivity, governance-first architecture, multi-LLM routing, and transparent mid-market pricing. If your primary pain is knowledge-sprawl across heterogeneous SaaS with search-as-the-seam, Glean is the shorter path. If your primary pain is agent orchestration with tool use and you want governance and MCP as platform primitives, Jarvis is.
+
+## Scorecard
+
+| Category | Jarvis AI | Glean | Winner |
+| --- | --- | --- | --- |
+| Enterprise search breadth | Capable across the connectors we support | Category-leading connector count | b |
+| Search ranking quality | Solid for targeted corpora | Category-leading, with years of ranking work | b |
+| MCP-native gateway | First-class (Jarvis Registry) | MCP support in GA; closed-connector bias | a |
+| Governance as platform primitive | PII/DLP, RBAC, SSO, audit as shared layer | Permissions-aware index, less emphasised as primitive | a |
+| Multi-LLM / cloud-neutral | OpenAI, Anthropic, Bedrock, Gemini, DeepSeek | Multi-LLM, cloud-aware | tie |
+| Private AWS deployment | Available | SaaS-first | a |
+| Pricing transparency | Published AWS Marketplace tiers | No public pricing | a |
+| Analyst footprint | Newer in quadrants | Leader in enterprise-search quadrants | b |
+
+## Disclosure, stated plainly
+
+Jarvis AI is our product. ASCENDING Inc., the company that publishes Explore Agentic, builds Jarvis. We have tried to write this page the way we would want competitors to write theirs: honest about where we win, honest about where we lose, with public sources on both columns.
+
+## What each product actually is
+
+Glean is a search engine first. One of the best money can buy. A layered assistant sits on top. The strength is the ranking model, the permissions-aware index, and a connector catalog wider than any competitor we track. Chat and assistance are added layers. Retrieval is the foundation.
+
+Jarvis is an agent platform and MCP gateway. Retrieval is one capability among several. The centre of gravity is governance, tool use, and multi-LLM routing. Jarvis Registry (our MCP gateway) is first-class and in GA, with a growing catalog of MCP servers rather than hand-built connectors.
+
+## Where Glean wins
+
+- **Connector breadth.** Glean's connector catalog is category-leading. If your problem is “we have 40 SaaS tools and can't find anything,” and your main solve is a single search box over everything, Glean ranks first.
+- **Ranking model maturity.** Years of IR research and tuning. On pure “did we find the right document” benchmarks, Glean is the bar to beat. Jarvis will match on targeted corpora; Glean wins on breadth.
+- **Analyst footprint.** Glean is a named Leader in Gartner's enterprise search / generative-AI-search quadrants. If your procurement team requires analyst-quadrant placement, we are newer in those reports.
+
+## Where Jarvis wins
+
+- **MCP-native.** Jarvis Registry is an MCP gateway in GA. Glean has MCP support but its architectural centre remains closed connectors; Jarvis inherits whatever the open MCP community ships. If your bet is MCP-first, Jarvis is the more aligned product.
+- **Governance as a primitive, not a setting.** PII/DLP, RBAC, SSO, audit log export, and egress policy sit at the platform layer in Jarvis, available identically to chat, agents, and MCP tool calls. Glean does governance well for search; Jarvis does it uniformly across the agent stack.
+- **Private AWS deployment and transparent mid-market pricing.** Same story as the Moveworks comparison: $1,500/$2,500/custom monthly tiers on AWS and Azure Marketplace vs Glean's six-figure deals, with private VPC deployment available for regulated workloads.
+
+## Which fits your situation
+
+*A decision framework, not a ranking*
+
+| If your situation is… | Our honest recommendation |
+| --- | --- |
+| Knowledge sprawl across 30+ SaaS tools, search is the primary solve | Glean |
+| Agent orchestration with tool use, MCP on your roadmap | Jarvis |
+| Regulated industry, strict governance at platform layer | Jarvis |
+| Mid-market, $150K+ floor is prohibitive | Jarvis |
+| Procurement team requires Leader-quadrant placement | Glean |
+| Private AWS VPC deployment required | Jarvis |
+
+## FAQ
+
+**Q: How does Jarvis vs Glean pricing compare in 2026?**
+
+Jarvis publishes monthly tiers on AWS and Azure Marketplace: $1,500 Basic (Chat or Registry), $2,500 Pro (Chat + Registry), Enterprise custom <a href="#cite-4" class="cite-ref">[4]</a>. All flat-fee regardless of seat count. Glean is quote-based. Third-party data: roughly $50 per user per month, plus a Work AI add-on near $15 per user per month, 100-seat minimum. That works out to a $60K/year floor <a href="#cite-8" class="cite-ref">[8]</a>. Paid POC with Glean is reported up to $70K before the first production seat.
+
+**Q: Should I pick Jarvis or Glean for enterprise search across 30+ SaaS tools?**
+
+Glean. The product was built for that exact shape. 100+ connectors on the catalog <a href="#cite-1" class="cite-ref">[1]</a>. Permissions-aware index. Both are the bar in the category. Jarvis does search too, but the product's centre is agent orchestration and MCP, not breadth of connectors.
+
+**Q: Should I pick Jarvis or Glean if MCP is on my architecture roadmap?**
+
+Jarvis. Jarvis Registry is a first-class MCP gateway in GA today. Glean added MCP support in March 2025 <a href="#cite-6" class="cite-ref">[6]</a> and has kept expanding server coverage. The architectural centre is still the closed connector catalog.
+
+**Q: Is Glean in the Gartner Magic Quadrant?**
+
+Not quite. Glean was named an Emerging Leader in Gartner's November 17, 2025 eMQ for Generative AI Knowledge Management Apps <a href="#cite-5" class="cite-ref">[5]</a>. eMQ is the Emerging Market Quadrant, not a classic Magic Quadrant (a distinction most RFPs miss). Jarvis is not placed in analyst quadrants as of April 2026.
+
+**Q: Can Jarvis or Glean be deployed in a private AWS VPC?**
+
+Jarvis yes. Glean no. Jarvis offers private AWS deployment for regulated workloads. Glean is SaaS-first; the deployment model is the multi-tenant Glean cloud. If the security model requires data residency inside a customer-controlled VPC, Jarvis is the architectural match.
+
+**Q: Is Glean funded well enough to stay independent?**
+
+As of April 2026, yes. $150M Series F in June 2025 at a $7.2B valuation <a href="#cite-3" class="cite-ref">[3]</a>. Less than a year after the Series E at $4.6B. That sequence put the company on the independent-platform path. After ServiceNow absorbed Moveworks in December 2025, Glean became the largest independent enterprise-AI-search pure-play in the category.
+
+## Citations
+
+1. **Glean** — App Integrations for Glean: 100+ Apps — https://www.glean.com/connectors [accessed 2026-04-16] *(Canonical Glean connector catalog page.)* { #cite-1 }
+2. **Business Wire** — Glean's Latest AI Assistant Moves Every Employee from Insight to Execution — https://www.businesswire.com/news/home/20260217973304/en/Gleans-Latest-AI-Assistant-Moves-Every-Employee-from-Insight-to-Execution [accessed 2026-04-16] *(February 2026 third-generation Glean Assistant release.)* { #cite-2 }
+3. **TechCrunch** — Enterprise AI startup Glean lands a $7.2B valuation — https://techcrunch.com/2025/06/10/enterprise-ai-startup-glean-lands-a-7-2b-valuation/ [accessed 2026-04-16] *(June 10, 2025 $150M Series F led by Wellington Management.)* { #cite-3 }
+4. **AWS Marketplace** — Jarvis: Simplifying AI Adoption (ASCENDING Inc.) — https://aws.amazon.com/marketplace/pp/prodview-ckf77lbx67sx2 [accessed 2026-04-16] *(Public listing; three tiers at $1,500 / $2,500 / custom per month.)* { #cite-4 }
+5. **Glean Press** — Glean Named as Emerging Leader in Gartner's 2025 eMQ — https://www.glean.com/press/glean-named-as-one-of-the-emerging-leaders-in-the-gartner-r-emerging-market-quadrant-of-the-2025-innovation-guide-for-generative-ai-knowledge-management-apps [accessed 2026-04-16] *(November 17, 2025 Gartner eMQ Emerging Leader placement.)* { #cite-5 }
+6. **Glean** — Glean's MCP servers bring full company context where your AI runs — https://www.glean.com/blog/mcp-servers-septdrop-2025 [accessed 2026-04-16] *(September 2025 MCP server drop; initial support announced March 27, 2025.)* { #cite-6 }
+7. **Anthropic** — Introducing the Model Context Protocol — https://www.anthropic.com/news/model-context-protocol [accessed 2026-04-16] *(November 25, 2024 MCP launch.)* { #cite-7 }
+8. **Workativ** — Glean Pricing: Costs, Hidden Fees & TCO 2026 — https://workativ.com/ai-agent/blog/glean-pricing [accessed 2026-04-16] *(Third-party Glean pricing analysis; ~$50/user/month + $15/user/month Work AI add-on; POC up to $70K.)* { #cite-8 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/comparisons/jarvis-vs-glean/](https://www.exploreagentic.ai/comparisons/jarvis-vs-glean/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/comparisons/jarvis-vs-moveworks.md
+++ b/docs/explore-agentic/comparisons/jarvis-vs-moveworks.md
@@ -1,0 +1,130 @@
+# Jarvis AI vs Moveworks: the 2026 buyer's guide
+
+> ServiceNow closed its $2.85B Moveworks acquisition on December 15, 2025. Moveworks now sells as the AI Agents layer inside the ServiceNow platform. Jarvis is our product. A Jarvis vs Moveworks side-by-side for buyers weighing both, with citations and pricing on both columns.
+
+*Comparison · Includes our own product · Jarvis AI vs Moveworks · 11 minutes · Updated April 16, 2026 · Author Elias Saljuki · Reviewed by Gloria Qian Zhang*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/comparisons/jarvis-vs-moveworks/](https://www.exploreagentic.ai/comparisons/jarvis-vs-moveworks/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Verdict
+
+If you are already a ServiceNow shop with ITSM as your biggest employee-experience pain, Moveworks (now ServiceNow AI Agents) is the shorter path: integration is now native, and the logo wall behind the product is unmatched in the category. If you are not a ServiceNow shop, want MCP-native connectivity, need multi-LLM choice, or are a mid-market organisation priced out of Moveworks' six-figure floor, Jarvis is the comparison we recommend you run. Both products solve adjacent problems with different centres of gravity.
+
+## Scorecard
+
+| Category | Jarvis AI | Moveworks | Winner |
+| --- | --- | --- | --- |
+| Employee assistance / ITSM depth | Capable; strongest in regulated + mid-market | Native; the category definition | b |
+| Enterprise logo wall | Concentrated in regulated industries | Category-leading Fortune 500 presence | b |
+| MCP-native gateway | First-class (Jarvis Registry) | Selective MCP support in preview | a |
+| Multi-LLM / cloud-neutral | OpenAI, Anthropic, Bedrock, Gemini, DeepSeek | ServiceNow-aligned | a |
+| Private AWS deployment | Available | SaaS-only | a |
+| Pricing transparency | Published Marketplace tiers ($1,500 / $2,500 / custom per month) | No public pricing; six-figure floor | a |
+| Consulting + implementation partner on-call | ASCENDING (same team that built it) | ServiceNow partner network | tie |
+
+## Disclosure, stated plainly
+
+Jarvis AI is our product. ASCENDING Inc., the company that publishes Explore Agentic, builds Jarvis. We have tried to write this page the way we would want competitors to write theirs: honest about where we win, honest about where we lose, with public sources on both columns. If you think the balance is off, write in. We update pages rather than defending them.
+
+## What each product actually is in April 2026
+
+Moveworks is now a ServiceNow product. The $2.85B deal closed December 15, 2025 <a href="#cite-1" class="cite-ref">[1]</a>. At its core: an employee-assistance platform with deep ITSM roots. Triage, resolution, ticket creation, all end to end. The post-acquisition pitch is that the Moveworks agent layer is now native inside any ServiceNow workflow. The customer page lists 350+ organisations and 10% of the Fortune 500. Named logos: Hearst, Instacart, Palo Alto Networks, Siemens, Toyota, Unilever. In February 2026, Moveworks GovCloud cleared FedRAMP Moderate on AWS GovCloud (US) <a href="#cite-2" class="cite-ref">[2]</a>.
+
+Jarvis is an agent platform and MCP gateway listed on AWS Marketplace and Azure Marketplace as "Jarvis: Simplifying AI Adoption" by seller ASCENDING Inc. at $1,500 / $2,500 / custom per month across three tiers <a href="#cite-3" class="cite-ref">[3]</a>. The product has three parts: a Governed AI Layer (PII/DLP, RBAC, SSO, audit logs, LLM routing), Jarvis Chat (multi-LLM enterprise chat with RAG and embed-anywhere), and Jarvis Registry (MCP gateway connecting Claude, Copilot, Cursor, Windsurf, ChatGPT and Jarvis Chat to Jira, Confluence, Slack, Google Workspace, PostgreSQL, Snowflake, AWS, GitHub, Atlassian, Databricks, Salesforce). The pitch: governance, multi-LLM, and MCP are primitives, not add-ons.
+
+## Where Moveworks wins
+
+Three categories, plainly:
+
+- **ITSM depth.** Moveworks was built for IT and HR service management. If your single biggest employee-experience pain is ticket volume in ServiceNow, Moveworks is now native to the workflow. Jarvis can cover the same ground via MCP + ServiceNow connectors, but it is a platform-first product, not an ITSM-first product.
+- **Logo wall and analyst coverage.** Moveworks has a decade of Fortune 500 customer logos (Hearst, Instacart, Palo Alto Networks, Siemens, Toyota, Unilever) and 5.5 million covered employees per its customer page. Jarvis is newer, our logo wall is narrower, and we have not chased analyst quadrant placement.
+- **ServiceNow-native integration and federal footprint.** If procurement has said "add to the ServiceNow renewal or don't buy it," Moveworks / ServiceNow AI Agents clears faster than Jarvis. Moveworks' February 25, 2026 FedRAMP Moderate authorisation <a href="#cite-2" class="cite-ref">[2]</a> also puts it ahead for federal workloads. We would rather you get the deployment than stall on our product.
+
+## Where Jarvis wins
+
+Three categories where we have the stronger story:
+
+- **MCP-native gateway.** Jarvis Registry is a first-class MCP gateway in GA. Moveworks has an MCP explainer on its blog <a href="#cite-4" class="cite-ref">[4]</a> and selective support in its agent builder, but the product was built on closed connectors pre-acquisition. If your architecture bet is that MCP (released by Anthropic on November 25, 2024 <a href="#cite-5" class="cite-ref">[5]</a> and donated to the Linux Foundation on December 9, 2025) becomes the interoperability layer for enterprise AI (ours is), Jarvis is already shipped. See our [MCP pillar](../pillars/mcp.md) for the long version.
+- **Multi-LLM and cloud-neutral.** Jarvis routes across OpenAI, Anthropic, AWS Bedrock, Google Gemini, and DeepSeek. Moveworks' alignment with ServiceNow's model strategy narrows that surface. Procurement teams that have rejected Azure-locked Copilot or Gemini-only Agentspace bring the same critique to ServiceNow's stack. Cloud-neutral is the default for Jarvis.
+- **Transparent mid-market pricing.** Our AWS Marketplace and Azure Marketplace listings are public: Basic $1,500/mo, Pro $2,500/mo, Enterprise custom <a href="#cite-3" class="cite-ref">[3]</a>. All flat-fee regardless of seat count. Third-party data on Moveworks reports $100–$200 per user per year with annual contract values from $150K to $1M+ depending on headcount <a href="#cite-6" class="cite-ref">[6]</a>. ServiceNow's separate AI pricing is tiered and quote-based, with Pro Plus and Enterprise Plus commanding 25-40% premiums over standard Pro <a href="#cite-7" class="cite-ref">[7]</a>. For mid-market organisations without a seven-figure platform budget, that price gap is the entire evaluation.
+
+## Jarvis vs Moveworks pricing: the numbers on paper
+
+*Published and third-party-reported pricing · April 2026*
+
+| Item | Jarvis AI | Moveworks (ServiceNow AI Agents) |
+| --- | --- | --- |
+| Entry tier | $1,500/mo (Basic, Chat or Registry) | Not publicly disclosed; ACV floor ~$150K |
+| Mid tier | $2,500/mo (Pro, Chat + Registry) | Not publicly disclosed |
+| Top tier | Custom (Enterprise, adds governance controls) | Not publicly disclosed; ACV typically $500K–$1M+ |
+| Per-user list | Flat annual contract | Typically $100–$200 per employee per year (third-party) |
+| ServiceNow AI tier premium | Not applicable | Pro Plus / Enterprise Plus 25-40% over Pro |
+| Public pricing page | Yes, via AWS Marketplace | No, quote-based |
+
+Sources: Jarvis from ASCENDING's AWS Marketplace listing <a href="#cite-3" class="cite-ref">[3]</a>. Moveworks ACVs from Vendr aggregated procurement data <a href="#cite-6" class="cite-ref">[6]</a>. ServiceNow AI premium from eesel AI's published breakdown <a href="#cite-7" class="cite-ref">[7]</a>. Treat all non-Jarvis numbers as directional procurement anchors, not vendor quotes.
+
+## Which fits your situation
+
+*A decision framework, not a ranking*
+
+| If your situation is… | Our honest recommendation |
+| --- | --- |
+| Already a ServiceNow shop, ITSM is the biggest pain | Moveworks / ServiceNow AI Agents |
+| Heterogeneous SaaS, MCP is on your architecture roadmap | Jarvis |
+| Mid-market organisation, $200K+ floor is out of budget | Jarvis |
+| Regulated industry, need private AWS deployment | Jarvis |
+| Fortune 500 with existing six-figure AI platform budget | Evaluate both; bring us in for the gateway if you pick Moveworks |
+| Government or state/local with contract-vehicle mandate | Jarvis (we hold TX DIR, VASCUPP, Florida DMS, TIPS and others) |
+
+> **Next step**: If Jarvis sounds like the right evaluation, the product page (/jarvis) has the full capability breakdown, pricing, and contact routes. We don't gate it behind a form.
+
+## FAQ
+
+**Q: How does Jarvis vs Moveworks pricing compare in 2026?**
+
+Jarvis publishes monthly tiers on AWS and Azure Marketplace: $1,500 Basic (Chat or Registry), $2,500 Pro (Chat + Registry), Enterprise custom <a href="#cite-3" class="cite-ref">[3]</a>. All flat-fee regardless of seat count. Moveworks does not publish list. Third-party procurement data puts typical ACVs between $150K and $1M+ <a href="#cite-6" class="cite-ref">[6]</a>. If you are mid-market, that gap is the entire evaluation.
+
+**Q: Should I pick Jarvis or Moveworks if I already run ServiceNow?**
+
+Moveworks. After the December 15, 2025 acquisition close <a href="#cite-1" class="cite-ref">[1]</a>, ServiceNow-native integration is the shortest path. ServiceNow is your system of record. ITSM is your primary pain. Path-of-least-resistance wins, no close second.
+
+**Q: Should I pick Jarvis or Moveworks if MCP is on my roadmap?**
+
+Jarvis. Jarvis Registry is a first-class MCP gateway in GA today. Moveworks has an MCP explainer and selective support <a href="#cite-4" class="cite-ref">[4]</a>. The product was built on closed connectors, and the ServiceNow-led roadmap has not changed that.
+
+**Q: Is Jarvis FedRAMP authorized?**
+
+No, as of April 2026. Moveworks GovCloud cleared FedRAMP Moderate on February 25, 2026 <a href="#cite-2" class="cite-ref">[2]</a>. For federal workloads that need FedRAMP Moderate today, Moveworks has the shorter path. That gap closes when we get the authorization; it has not closed yet.
+
+**Q: Can Jarvis be deployed privately in my AWS VPC?**
+
+Yes. Jarvis offers private AWS deployment for regulated workloads. Moveworks is SaaS-only (with GovCloud for public sector). If the security model requires data inside a customer-controlled VPC, Jarvis is the architectural match and Moveworks is not.
+
+**Q: How much does ServiceNow AI Agents cost?**
+
+ServiceNow does not publish AI Agents pricing. The tiered model places AI agent capabilities behind Pro Plus or Enterprise Plus SKUs, at a 25-40% premium over standard Pro <a href="#cite-7" class="cite-ref">[7]</a>. The exact number depends on the ServiceNow paper you already hold.
+
+## Citations
+
+1. **Moveworks** — ServiceNow completes acquisition of Moveworks — https://www.moveworks.com/us/en/company/news/press-releases/servicenow-completes-acquisition-of-moveworks [accessed 2026-04-16] *(December 15, 2025 closing press release; $2.85B deal announced March 10, 2025.)* { #cite-1 }
+2. **ServiceNow Newsroom** — Moveworks from ServiceNow achieves FedRAMP Moderate authorization — https://newsroom.servicenow.com/press-releases/details/2026/Moveworks-from-ServiceNow-achieves-FedRAMP-moderate-authorization-to-provide-secure-conversational-AI-to-public-sector/default.aspx [accessed 2026-04-16] *(February 25, 2026 FedRAMP Moderate on AWS GovCloud (US).)* { #cite-2 }
+3. **AWS Marketplace** — Jarvis: Simplifying AI Adoption (ASCENDING Inc.) — https://aws.amazon.com/marketplace/pp/prodview-ckf77lbx67sx2 [accessed 2026-04-16] *(Public listing; Basic $1,500/mo, Pro $2,500/mo, Enterprise custom.)* { #cite-3 }
+4. **Moveworks** — Understanding the Power of Model Context Protocol (MCP) — https://www.moveworks.com/us/en/resources/blog/model-context-protocol-mcp-explained [accessed 2026-04-16] *(Moveworks' MCP explainer.)* { #cite-4 }
+5. **Anthropic** — Introducing the Model Context Protocol — https://www.anthropic.com/news/model-context-protocol [accessed 2026-04-16] *(November 25, 2024 MCP launch.)* { #cite-5 }
+6. **Vendr Marketplace** — Moveworks Software Pricing & Plans 2026 — https://www.vendr.com/marketplace/moveworks [accessed 2026-04-16] *(Typical Moveworks ACVs $150K–$1M+.)* { #cite-6 }
+7. **eesel AI** — A Complete Guide to ServiceNow AI Pricing in 2025 — https://www.eesel.ai/blog/servicenow-ai-pricing [accessed 2026-04-16] *(Pro Plus / Enterprise Plus 25-40% premium over Pro.)* { #cite-7 }
+8. **TechCrunch** — ServiceNow to buy Moveworks for $2.85B — https://techcrunch.com/2025/03/10/servicenow-buys-moveworks-for-2-85b-to-grow-its-ai-portfolio/ [accessed 2026-04-16] *(March 10, 2025 reporting.)* { #cite-8 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/comparisons/jarvis-vs-moveworks/](https://www.exploreagentic.ai/comparisons/jarvis-vs-moveworks/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/comparisons/mcp-vs-rag.md
+++ b/docs/explore-agentic/comparisons/mcp-vs-rag.md
@@ -1,0 +1,108 @@
+# MCP vs RAG: two protocols for two different problems
+
+> MCP is a wire protocol Anthropic released on November 25, 2024. RAG is an architectural pattern Lewis et al. introduced in May 2020. A clean MCP vs RAG side-by-side on what each is for, where they overlap, and why the production answer is usually both.
+
+*Comparison · Architecture · Model Context Protocol vs Retrieval-Augmented Generation · 10 minutes · Updated April 16, 2026 · Author Wenjia (Soraya) Zheng · Reviewed by Alexander*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/comparisons/mcp-vs-rag/](https://www.exploreagentic.ai/comparisons/mcp-vs-rag/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Verdict
+
+MCP is a transport layer for tool calls; RAG is a retrieval architecture. They do not replace each other. In a realistic enterprise deployment, RAG runs as an MCP server (or several): the agent uses MCP to reach the retrieval layer, and the retrieval layer is implemented as RAG. You need both. Stop treating it as either/or.
+
+## Scorecard
+
+| Category | Model Context Protocol | Retrieval-Augmented Generation | Winner |
+| --- | --- | --- | --- |
+| What kind of thing is it? | Open protocol / specification | Architectural pattern | tie |
+| What problem does it solve? | Standardizing how clients invoke tools and fetch context | Grounding model output in retrieved knowledge | tie |
+| Where does it live? | Between clients and servers (the wire) | Inside a server (usually) | tie |
+| Are they composable? | Yes, RAG can be an MCP server | Yes, a RAG server can speak MCP | tie |
+
+## The MCP vs RAG framing mistake
+
+The most common framing we hear ("should we use MCP or RAG?") embeds a category error. MCP is a protocol. RAG is a pattern. Asking which to pick is like asking whether to use HTTP or a database. Different layers. You almost always want both.
+
+For reference: MCP was released by Anthropic as an open JSON-RPC specification on November 25, 2024 <a href="#cite-1" class="cite-ref">[1]</a>. RAG was introduced by Patrick Lewis and co-authors at Facebook AI Research in a May 22, 2020 arXiv paper titled "Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks" <a href="#cite-2" class="cite-ref">[2]</a>. MCP is four and a half years younger than RAG. It is not a successor. A different primitive entirely.
+
+## What MCP actually does
+
+MCP standardises the wire format for context and tool calls between an AI client and a server. The spec defines three primitives on the server side (Prompts, Resources, Tools) and two on the client side (Roots, Sampling), exchanged as JSON-RPC messages <a href="#cite-3" class="cite-ref">[3]</a>. It does not tell you where the data lives. It does not tell you how to retrieve it. It tells you how to ask.
+
+The value is composability. A client that speaks MCP can use any server that speaks MCP without a custom integration. Anthropic's original November 2024 release shipped reference servers for Google Drive, Slack, GitHub, Git, PostgreSQL, and Puppeteer, plus SDKs in Python, TypeScript, C#, and Java <a href="#cite-1" class="cite-ref">[1]</a>. The protocol was donated to the Agentic AI Foundation at the Linux Foundation on December 9, 2025. See our [MCP pillar](../pillars/mcp.md) for the full governance arc.
+
+## What RAG actually does
+
+RAG is a pattern, not a spec. Three steps. Retrieve candidate documents. Pass them to a model as context. Generate a grounded answer. The Lewis et al. 2020 paper combined a pre-trained seq2seq model for parametric memory with a dense vector index of Wikipedia as non-parametric memory, accessed via a pre-trained neural retriever <a href="#cite-2" class="cite-ref">[2]</a>. The industry took that architecture and generalised it.
+
+In production, the retrieval layer can be vector search (FAISS, Pinecone, Weaviate, pgvector), keyword search (Elasticsearch, OpenSearch), a knowledge graph, or a hybrid of all three with a re-ranker on top. Implementation details (chunk size, embedding model, re-ranker, eval harness) dominate results in practice. Our [Enterprise RAG pillar](../pillars/enterprise-rag.md) covers the tradeoffs chapter by chapter.
+
+## How MCP and RAG fit together in production
+
+In a realistic enterprise deployment, the agent uses MCP to talk to a set of servers. One of those servers is a RAG implementation over your corpus. The agent does not know it is calling RAG. It knows it is calling a tool that returns relevant context. The RAG server does not know the agent's full plan. It knows it received a query and returned passages. Most enterprise references now describe this pattern <a href="#cite-4" class="cite-ref">[4]</a>.
+
+The separation is useful. You can replace the RAG server with a different retrieval implementation (vector DB swap, hybrid retrieval, GraphRAG) without changing the agent, and you can replace the agent without changing the RAG server. That is the whole point of a protocol.
+
+> **Practical rule**: If you are building your first agent in 2026, start with a single MCP-wrapped RAG server and grow the server catalog from there. If you already have RAG in production and are adding an agent layer, retrofit your retrieval endpoint as an MCP server rather than inventing a new calling convention.
+
+## When to pick which (and when you need both)
+
+*Decision matrix for MCP vs RAG in April 2026*
+
+| Scenario | What you actually need |
+| --- | --- |
+| Single assistant that must answer from your private docs | RAG is the substantive architecture; MCP optional until you add more tools |
+| Agent that must call Jira, Slack, and Snowflake in one plan | MCP for tool composability; retrieval only if you also need grounded answers |
+| Chatbot with 10,000 documents, permissions-aware | RAG with a permissions-aware retriever; expose via MCP if multi-client |
+| Regulated deployment needing auditable tool calls | MCP (standardised, loggable wire format) + RAG with citation provenance |
+| Proof-of-concept, one model, one data source | RAG alone; MCP wrapping adds complexity before you need it |
+| Multi-vendor stack (Claude + Copilot + Cursor + custom) | MCP non-negotiable; RAG inside one or more of the servers |
+
+## FAQ
+
+**Q: What is the difference between MCP and RAG?**
+
+Different layers. MCP (Model Context Protocol) is a wire protocol. It standardises how an AI client invokes tools and fetches context from a server <a href="#cite-1" class="cite-ref">[1]</a>. RAG (Retrieval-Augmented Generation) is an architectural pattern. It grounds a model's output in documents retrieved from a corpus <a href="#cite-2" class="cite-ref">[2]</a>. One way to keep them straight: MCP is how the agent talks to tools. RAG is one implementation of a tool.
+
+**Q: Do I need MCP if I already have RAG?**
+
+Not immediately. A single-client RAG deployment works fine without MCP. You need it when two things happen. You add more tools (ticketing, CRM, code, databases). Or you add more clients (Claude, ChatGPT, Copilot, Cursor, your own chat). Either one, and you are now building custom integrations for every pair. At that point, wrapping your RAG endpoint as an MCP server pays back in weeks.
+
+**Q: Can a RAG system be an MCP server?**
+
+Yes. And this is now the canonical enterprise pattern <a href="#cite-4" class="cite-ref">[4]</a>. Your RAG pipeline (retriever + re-ranker + prompt) gets exposed as an MCP server with a single tool, typically named search or query. The agent calls it with a natural-language query and gets back grounded passages. Glean, Pinecone, and most enterprise vector DBs now ship MCP server wrappers by default.
+
+**Q: When should I pick RAG over a pure-MCP approach?**
+
+When the problem is grounding a model in a specific corpus, and the evaluation metric is "did the answer cite the right document." RAG is the substantive architecture for that shape of problem. MCP is incidental. Different problem, different answer: if the job is orchestrating multiple tools and data sources with different access patterns, MCP is the primitive. RAG may or may not be one of the tools.
+
+**Q: Who created MCP and RAG?**
+
+RAG came first. May 2020. Patrick Lewis and co-authors at Facebook AI Research (now Meta AI), in arXiv 2005.11401 <a href="#cite-2" class="cite-ref">[2]</a>. MCP came four and a half years later. Anthropic released it on November 25, 2024 <a href="#cite-1" class="cite-ref">[1]</a>, then donated it to the Agentic AI Foundation at the Linux Foundation on December 9, 2025.
+
+**Q: Is MCP replacing RAG?**
+
+No. MCP is a transport. RAG is a retrieval architecture. Different layers. The direction of travel is RAG implementations being exposed via MCP rather than proprietary APIs. Retrieval layer stays the same. The calling convention gets standardised. That is the whole story.
+
+## Citations
+
+1. **Anthropic** — Introducing the Model Context Protocol — https://www.anthropic.com/news/model-context-protocol [accessed 2026-04-16] *(November 25, 2024 launch announcement; reference servers (Drive, Slack, GitHub, Git, Postgres, Puppeteer) and SDKs in Python, TypeScript, C#, Java.)* { #cite-1 }
+2. **arXiv (Lewis et al.)** — Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks — https://arxiv.org/abs/2005.11401 [accessed 2026-04-16] *(Seminal RAG paper, May 22, 2020. Authors: Lewis, Perez, Piktus, Petroni, Karpukhin, Goyal, Küttler, M. Lewis, Yih, Rocktäschel, Riedel, Kiela.)* { #cite-2 }
+3. **Model Context Protocol** — MCP Specification (2025-11-25) — https://modelcontextprotocol.io/specification/2025-11-25 [accessed 2026-04-16] *(Canonical MCP specification home; JSON-RPC message formats, primitives, and SDK matrix.)* { #cite-3 }
+4. **Thoughtworks** — The Model Context Protocol's impact on 2025 — https://www.thoughtworks.com/en-us/insights/blog/generative-ai/model-context-protocol-mcp-impact-2025 [accessed 2026-04-16] *(Practitioner analysis of MCP-over-RAG composition pattern; covers enterprise production use.)* { #cite-4 }
+5. **NeurIPS** — Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks (camera-ready) — https://proceedings.neurips.cc/paper/2020/file/6b493230205f780e1bc26945df7481e5-Paper.pdf [accessed 2026-04-16] *(NeurIPS 2020 camera-ready version of the Lewis et al. RAG paper.)* { #cite-5 }
+6. **GitHub (modelcontextprotocol)** — Model Context Protocol specification repository — https://github.com/modelcontextprotocol/modelcontextprotocol [accessed 2026-04-16] *(Canonical spec repo and change log; issue tracker for proposed primitives.)* { #cite-6 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/comparisons/mcp-vs-rag/](https://www.exploreagentic.ai/comparisons/mcp-vs-rag/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/comparisons/moveworks-vs-glean.md
+++ b/docs/explore-agentic/comparisons/moveworks-vs-glean.md
@@ -1,0 +1,120 @@
+# Moveworks vs Glean (2026, after the ServiceNow deal)
+
+> ServiceNow closed the $2.85B Moveworks acquisition on December 15, 2025. Glean raised a $150M Series F at a $7.2B valuation six months earlier. A rebuilt Moveworks vs Glean side-by-side drawn from both vendors' homepages, AWS Marketplace, and public analyst coverage.
+
+*Comparison · Enterprise search & AI assistance · Moveworks vs Glean · 13 minutes · Updated April 16, 2026 · Author Gloria Qian Zhang · Reviewed by Michael Clough*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/comparisons/moveworks-vs-glean/](https://www.exploreagentic.ai/comparisons/moveworks-vs-glean/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Verdict
+
+Pick Moveworks (now a ServiceNow product) if your organization already runs on ServiceNow and the primary pain is ticket volume. Pick Glean if you are consolidating knowledge across 30+ SaaS tools and want search as the seam. Most teams who pick Moveworks for a knowledge-sprawl problem regret it within twelve months; most who pick Glean for pure ITSM under-use the license.
+
+## Scorecard
+
+| Category | Moveworks | Glean | Winner |
+| --- | --- | --- | --- |
+| Enterprise search breadth | Strong; narrower connector catalog | Strongest in category; broadest connector catalog per public docs | b |
+| ITSM & employee assistance | Native to the product | Capable but secondary | a |
+| Pricing transparency | No public pricing; six-figure floor | No public pricing; six-figure floor | tie |
+| ServiceNow integration | Now deepest available | Partnership level, not native | a |
+| Open protocol support | Selective MCP support in preview | MCP support in GA | b |
+| Analyst footprint | Leader in conversational AI quadrants | Leader in enterprise search quadrants | tie |
+
+## What changed after the ServiceNow acquisition
+
+The deal was announced March 10, 2025 <a href="#cite-1" class="cite-ref">[1]</a>. It closed December 15, 2025 <a href="#cite-2" class="cite-ref">[2]</a>. $2.85B, the largest in ServiceNow's history. The moveworks.com brand is still there. The center of gravity moved anyway. Procurement conversations that used to sound like "Moveworks vs Glean" now sound like "ServiceNow AI Agents (powered by Moveworks) vs Glean."
+
+If you are already a ServiceNow shop, integration cost drops. The "pick us because we're independent" pitch evaporates. If you are not, the Moveworks ask is now also a ServiceNow ask. February 2026 added another data point. Moveworks GovCloud cleared FedRAMP Moderate <a href="#cite-3" class="cite-ref">[3]</a>. That opens federal agencies and defense contractors sitting on AWS GovCloud (US).
+
+Glean's counterpoint of the same year was different. A $150M Series F at a $7.2B valuation, announced June 10, 2025, with Wellington leading and Kleiner, Sequoia, Lightspeed, and Coatue following on <a href="#cite-4" class="cite-ref">[4]</a>. That round placed Glean as the independent pure-play in a category ServiceNow just folded into its renewal cycle.
+
+## Search-first vs assistance-first
+
+Glean's center of gravity is search. 100+ connectors on the catalog page <a href="#cite-5" class="cite-ref">[5]</a>. February 2026 shipped the third-generation Glean Assistant, which keeps the permissions-aware index as the foundation and sits chat and agents on top <a href="#cite-6" class="cite-ref">[6]</a>. Gartner named Glean an Emerging Leader in its November 2025 eMQ for Generative AI Knowledge Management Apps <a href="#cite-7" class="cite-ref">[7]</a>.
+
+Moveworks is assistance-first. 350+ organizations. 10% of the Fortune 500. Hearst, Instacart, Palo Alto Networks, Siemens, Toyota, Unilever. 5.5 million covered employees per the customer page. The product is judged on end-to-end ticket resolution: triage, answer, resolve, ticket-create. Retrieval is the means, not the end.
+
+Knowledge sprawl? Start with search. Ticket volume? Start with assistance. Both products do both. Each is better at the shape it was built for.
+
+## MCP support: where each one stands in April 2026
+
+Glean got there first. MCP support shipped on a March 27, 2025 X announcement <a href="#cite-8" class="cite-ref">[8]</a>, and server capabilities have kept rolling through 2026. Glean Agents can call tools hosted on remote MCP servers (Notion, Asana, GitHub, ServiceNow, Snowflake); administrators approve which third-party servers are available <a href="#cite-9" class="cite-ref">[9]</a>. It is the more mature MCP story of the two in April 2026.
+
+Moveworks has an MCP explainer on its blog and supports MCP connectors in its agent builder. The posture is selective, not MCP-native. Pre-acquisition the product was built on closed connectors, and the ServiceNow-led roadmap is re-prioritising integration paths. If your architecture bet is that MCP becomes the interoperability layer for enterprise AI ([see our MCP pillar](../pillars/mcp.md)), Glean is the closer match today.
+
+## Moveworks vs Glean pricing in 2026
+
+Neither vendor publishes list pricing on their marketing sites. Third-party numbers are what the procurement team works with. Moveworks marketplace listings report $100 to $200 per user per year, with annual contract values from $150K to $1M+ depending on headcount <a href="#cite-10" class="cite-ref">[10]</a>. Glean typically reports at $50 per user per month, roughly a 100-seat minimum, a $60K/year floor. Work AI add-on is another $15 per user per month <a href="#cite-11" class="cite-ref">[11]</a>.
+
+For a directly quoted mid-market anchor, ASCENDING's Jarvis AI publishes monthly tiers on AWS and Azure Marketplace ($1,500 Basic, $2,500 Pro; Enterprise custom) <a href="#cite-12" class="cite-ref">[12]</a>, a useful floor reference when evaluating whether Moveworks or Glean's enterprise pricing is right-sized for your organisation.
+
+> **Methodology note**: Neither Moveworks nor Glean publishes list prices; the figures above come from third-party marketplaces and aggregated procurement data, not vendor pricing pages. Treat them as starting points for a procurement conversation, not quotes. Jarvis's published $1,500 / $2,500 / custom monthly tiers are the only authoritative vendor-published numbers on this page.
+
+## A decision framework, not a ranking
+
+*Which starting point fits your organization*
+
+| If your situation is… | Starting point |
+| --- | --- |
+| Already a ServiceNow shop, ITSM is the biggest pain | Moveworks / ServiceNow AI Agents |
+| Federal agency or defense contractor needing FedRAMP Moderate | Moveworks (GovCloud authorized Feb 2026) |
+| Heterogeneous SaaS sprawl, knowledge scattered across tools | Glean |
+| Ticket volume dominates your employee-experience spend | Moveworks |
+| MCP-native, multi-agent future-proofing | Glean (GA today; Moveworks selective) |
+| Mid-market without the six-figure floor | Neither; see /comparisons/jarvis-vs-moveworks |
+
+## FAQ
+
+**Q: How does Moveworks vs Glean pricing compare in 2026?**
+
+Both are six-figure deals. Neither publishes list. Glean runs roughly $50 per user per month at a 100-seat minimum, so $60K a year before you add anything <a href="#cite-11" class="cite-ref">[11]</a>. The Work AI add-on is another $15 per user per month. Moveworks is the other shape. $100 to $200 per user per year on a per-seat basis. Annual contract values land in the $150K to $1M+ band depending on headcount <a href="#cite-10" class="cite-ref">[10]</a>. Six-figure floor either way.
+
+**Q: Is Moveworks still an independent product after the ServiceNow acquisition?**
+
+Technically, yes. In procurement, no. Moveworks.com still publishes. The product ships as "Moveworks from ServiceNow." New deals land on ServiceNow paper. Renewals roll into ServiceNow enterprise agreements. December 15, 2025 was the close <a href="#cite-2" class="cite-ref">[2]</a>. Roadmap, paper, renewal line: all under ServiceNow now.
+
+**Q: Should I pick Moveworks or Glean if I run on ServiceNow?**
+
+Moveworks. One stack. One renewal. ITSM workflow, identity, and CMDB already sit on the same platform. Glean connects to ServiceNow, sure. The native path skips the integration tax and a duplicate governance surface you would otherwise have to staff.
+
+**Q: Should I pick Moveworks or Glean for knowledge sprawl across 30+ SaaS tools?**
+
+Glean. The product was built for that shape of problem. 100+ connectors on the canonical catalog <a href="#cite-5" class="cite-ref">[5]</a>. The permissions-aware index is the category bar. Moveworks does search too. It was built for ticket volume, not scattered knowledge. Pick it for the wrong pain and you pay for workflow you never use.
+
+**Q: Which one has better MCP and open-protocol support?**
+
+Glean, today. MCP shipped March 2025 <a href="#cite-8" class="cite-ref">[8]</a>. Server capabilities have kept rolling through 2026. Admin docs cover remote MCP servers and third-party governance <a href="#cite-9" class="cite-ref">[9]</a>. Moveworks has MCP in the agent builder. The posture is selective: a closed-connector heritage and a ServiceNow-led roadmap keep it that way.
+
+**Q: Is Moveworks FedRAMP authorized?**
+
+Yes. February 25, 2026. Moveworks GovCloud, running on AWS GovCloud (US), cleared FedRAMP Moderate <a href="#cite-3" class="cite-ref">[3]</a>. FedRAMP High and Impact Level 5 are the stated next targets. Glean has no equivalent authorization as of April 2026.
+
+## Citations
+
+1. **ServiceNow** — ServiceNow to extend leading agentic AI with acquisition of Moveworks — https://newsroom.servicenow.com/press-releases/details/2025/ServiceNow-to-extend-leading-agentic-AI-to-every-employee-for-every-corner-of-the-business-with-acquisition-of-Moveworks-03-10-2025-traffic/default.aspx [accessed 2026-04-16] *(March 10, 2025 deal announcement; $2.85B in cash and stock.)* { #cite-1 }
+2. **Moveworks** — ServiceNow completes acquisition of Moveworks — https://www.moveworks.com/us/en/company/news/press-releases/servicenow-completes-acquisition-of-moveworks [accessed 2026-04-16] *(December 15, 2025 closing press release; largest deal in ServiceNow history.)* { #cite-2 }
+3. **ServiceNow Newsroom** — Moveworks from ServiceNow achieves FedRAMP Moderate authorization — https://newsroom.servicenow.com/press-releases/details/2026/Moveworks-from-ServiceNow-achieves-FedRAMP-moderate-authorization-to-provide-secure-conversational-AI-to-public-sector/default.aspx [accessed 2026-04-16] *(February 25, 2026 announcement; AWS GovCloud (US) deployment with FedRAMP High and IL5 on roadmap.)* { #cite-3 }
+4. **TechCrunch** — Enterprise AI startup Glean lands a $7.2B valuation — https://techcrunch.com/2025/06/10/enterprise-ai-startup-glean-lands-a-7-2b-valuation/ [accessed 2026-04-16] *(June 10, 2025 reporting on Glean's $150M Series F led by Wellington Management.)* { #cite-4 }
+5. **Glean** — App Integrations for Glean: 100+ Apps — https://www.glean.com/connectors [accessed 2026-04-16] *(Canonical Glean connector catalog page.)* { #cite-5 }
+6. **Business Wire** — Glean's Latest AI Assistant Moves Every Employee from Insight to Execution — https://www.businesswire.com/news/home/20260217973304/en/Gleans-Latest-AI-Assistant-Moves-Every-Employee-from-Insight-to-Execution [accessed 2026-04-16] *(February 2026 third-generation Glean Assistant release; 100+ supported actions.)* { #cite-6 }
+7. **Glean Press** — Glean Named as Emerging Leader in Gartner's 2025 eMQ for GenAI Knowledge Management — https://www.glean.com/press/glean-named-as-one-of-the-emerging-leaders-in-the-gartner-r-emerging-market-quadrant-of-the-2025-innovation-guide-for-generative-ai-knowledge-management-apps [accessed 2026-04-16] *(November 17, 2025 Gartner eMQ Emerging Leader placement.)* { #cite-7 }
+8. **Glean** — Glean's MCP servers bring full company context where your AI runs — https://www.glean.com/blog/mcp-servers-septdrop-2025 [accessed 2026-04-16] *(September 2025 MCP server drop; initial MCP support announced March 27, 2025.)* { #cite-8 }
+9. **Glean** — About the Glean MCP server (admin docs) — https://docs.glean.com/administration/platform/mcp/about [accessed 2026-04-16] *(Admin documentation covering remote MCP servers, agent tool use, and governance.)* { #cite-9 }
+10. **Vendr Marketplace** — Moveworks Software Pricing & Plans 2026 — https://www.vendr.com/marketplace/moveworks [accessed 2026-04-16] *(Third-party procurement marketplace aggregating Moveworks deal data; typical ACV $150K–$1M+.)* { #cite-10 }
+11. **Workativ** — Glean Pricing: Costs, Hidden Fees & TCO 2026 — https://workativ.com/ai-agent/blog/glean-pricing [accessed 2026-04-16] *(Third-party Glean pricing analysis; ~$50/user/month base + $15/user/month Work AI add-on.)* { #cite-11 }
+12. **AWS Marketplace** — Jarvis: Simplifying AI Adoption — https://aws.amazon.com/marketplace/pp/prodview-ckf77lbx67sx2 [accessed 2026-04-16] *(Public Marketplace listing; three tiers at $1,500 / $2,500 / custom per month. Seller: ASCENDING Inc.)* { #cite-12 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/comparisons/moveworks-vs-glean/](https://www.exploreagentic.ai/comparisons/moveworks-vs-glean/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/glossary/agent-observability.md
+++ b/docs/explore-agentic/glossary/agent-observability.md
@@ -1,0 +1,103 @@
+# Agent observability
+
+*Also known as: AI agent tracing, LLM observability · 7 min · Updated April 17, 2026 · Author Kelvin Yu · Reviewed by Elias Saljuki*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/glossary/agent-observability/](https://www.exploreagentic.ai/glossary/agent-observability/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Definition
+
+<strong>Agent observability</strong> makes an agentic AI system legible after the fact. State, decisions, tool calls: all captured, all replayable, all auditable. The vocabulary is borrowed from distributed-systems observability (traces, spans, W3C trace context), then bent around the non-determinism of language-model calls. That bending is the part that breaks every old observability assumption at once. OpenTelemetry's GenAI Semantic Conventions are the emerging open standard, with the AI agent convention based on Google's AI agent white paper <a href="#cite-1" class="cite-ref">[1]</a><a href="#cite-2" class="cite-ref">[2]</a>.
+
+## What counts as observable
+
+The OpenTelemetry GenAI Semantic Conventions define a minimum span shape for any instrumented agent: model name, request and response tokens, tool calls, latency, error state, and correlation IDs from W3C Trace Context <a href="#cite-3" class="cite-ref">[3]</a>. Agent-specific conventions (tasks, actions, memory, agent-to-agent communication) were drafted in 2025 and move through experimental status in 2026 <a href="#cite-2" class="cite-ref">[2]</a>. Framework conventions for CrewAI, AutoGen, LangGraph, and Semantic Kernel are in active development.
+
+- Every input the agent saw, including retrieved context and tool outputs.
+- Every decision the agent made, with the reasoning trace where available.
+- Every tool call: name, parameters, result, latency, error state.
+- The final output, tagged with a conversation ID, a user ID, and a business-outcome reference.
+- A W3C trace context that binds multi-agent spans into a single observable workflow. This is the primitive that multi-agent nesting still breaks for most vendors <a href="#cite-4" class="cite-ref">[4]</a>.
+
+## The vendor landscape in April 2026
+
+Three platforms pulled away from the pack in 2026. LangSmith, the LangChain team's official platform. Arize AI, with the open-source Phoenix next to it. Braintrust, evaluation-first <a href="#cite-5" class="cite-ref">[5]</a>. Datadog added native OpenTelemetry GenAI Semantic Convention support in v1.37 and pulled LLM workloads into its existing APM footprint without asking <a href="#cite-6" class="cite-ref">[6]</a>. AWS Bedrock AgentCore Observability launched in 2025. Telemetry out in OpenTelemetry-compatible format, integrable with CloudWatch, Datadog, LangSmith, and Langfuse <a href="#cite-7" class="cite-ref">[7]</a>.
+
+The honest read in April 2026. LangSmith wins if you live inside LangChain and LangGraph. Arize Phoenix wins if OpenTelemetry neutrality matters or your team has platform engineers to spare. Braintrust wins if evaluations should drive deployment. Nobody has obviously won across every use case. The per-span pricing unit is still unsettled, which means the category keeps moving for another two quarters.
+
+The term is often misused. Vendors selling "AI observability" that only log prompt/response pairs are shipping log search, which is a different product. The sorting test is short. A real agent observability product emits OpenTelemetry-compatible spans with the GenAI conventions applied. It supports multi-agent trace nesting. And it lets you replay a production failure against a different model. Three of three, or call it something else.
+
+## The metrics that matter
+
+- Tool-call success rate, per tool, over time. Anything below 95% for a tool in production is a bug.
+- Latency by phase: retrieval, reasoning, tool, generation. AgentCore Observability breaks these out natively; most vendors follow.
+- Eval-suite pass rate, trended against every model and prompt change. Braintrust's trace-to-test pipeline is the clearest implementation of this pattern in 2026.
+- User-reported failure rate, tied back to trace IDs. Without this linkage, support tickets are floating strings.
+- Token usage per session (the unit that shows up on the cloud bill). AgentCore reports token usage, latency, session duration, and error rates as first-class metrics <a href="#cite-7" class="cite-ref">[7]</a>.
+- Agent quality scores: correctness, helpfulness, safety, goal-success rate. Continuous evaluation against these is what separates observability from log collection.
+
+## Why OpenTelemetry matters
+
+Before OpenTelemetry GenAI conventions existed, every vendor defined its own span shape. Cross-vendor migration was expensive. Multi-vendor deployments were incoherent. The semantic conventions fix both problems at once: a CrewAI agent instrumented with OTel emits spans that Datadog, LangSmith, or Phoenix ingest identically. The AI Agent Application Conventions, experimental as of March 2026, extend this to agent tasks, memory, and agent-to-agent traffic <a href="#cite-2" class="cite-ref">[2]</a>.
+
+For procurement in 2026, the single most useful question is one sentence long: does your vendor emit and ingest OTel GenAI Semantic Conventions natively? Yes is the word you want. Datadog. Phoenix. AgentCore. Langfuse. Safer bets than any vendor that answers "we have our own format and an exporter," which is the sentence that shows up right before a migration bill.
+
+> **Further reading**: Observability does not work without governance. The AI Governance pillar at /ai-governance covers the policy side; the MCP Gateway entry at /glossary/mcp-gateway covers the tool-level observability questions that gateway products answer for the transport layer.
+
+## See Also
+
+- [Model Context Protocol](model-context-protocol.md)
+- [MCP Gateway](mcp-gateway.md)
+- [Agentic RAG](agentic-rag.md)
+- [AI Governance pillar](../pillars/ai-governance.md)
+
+## FAQ
+
+**Q: What is agent observability?**
+
+How you make an agent system legible after the fact. Instrument everything. Capture inputs, decisions, tool calls, outputs. The whole trace has to be inspectable and replayable. The vocabulary comes straight from distributed-systems observability (traces, spans, W3C Trace Context), then gets bent around the fact that language-model calls are not deterministic. That non-determinism breaks a lot of assumptions the old observability stacks baked in. The open standard is OpenTelemetry's GenAI Semantic Conventions. Everything else is a dialect.
+
+**Q: How is agent observability different from LLM monitoring?**
+
+LLM monitoring is a subset. Usually just prompts, responses, and latency for one model call, which is useful as far as it goes. Agent observability goes further. The full multi-step trajectory gets captured. Tool calls. Retrievals. Sub-agents. Reasoning traces. All as nested spans bound together by a shared trace context. The distinction matters because a single-call view cannot explain a multi-agent failure mode. Every team learns this on their first real production incident. Every single one.
+
+**Q: What are OpenTelemetry GenAI Semantic Conventions?**
+
+The open-standard schema for instrumenting generative-AI applications. Span attributes, metrics, event shapes: all defined, all ingestable by any compliant vendor. Agent-specific conventions hit experimental status in March 2026. Framework conventions are in active development for CrewAI, AutoGen, LangGraph, and Semantic Kernel. The short version: emit once, ingest anywhere, and the procurement question about vendor lock-in gets a lot quieter.
+
+**Q: Which agent observability platform should I use?**
+
+Three platforms pulled away from the pack in April 2026. LangSmith. Arize AI (with open-source Phoenix). Braintrust. LangSmith wins for LangChain/LangGraph-centric stacks. Phoenix wins if OpenTelemetry neutrality matters to you. Braintrust wins if evaluations should drive deployment decisions. Datadog and AgentCore Observability are the cloud-native picks for teams already on those platforms, and the answer there is the boring one: use what you already pay for.
+
+**Q: What metrics matter most for agent observability?**
+
+Six metrics do most of the work. Tool-call success rate, per tool. Latency by phase (retrieval, reasoning, tool, generation). Eval-suite pass rate per model and prompt change. User-reported failure rate, tied to trace IDs. Token usage per session, because that is the line-item on the cloud bill. Continuous agent-quality scores on correctness, helpfulness, safety, and goal success. Anything missing from that list and you are running log search, not observability.
+
+**Q: Does AWS Bedrock AgentCore include observability?**
+
+Yes. AgentCore Observability ships as a built-in component of the Bedrock AgentCore service. Telemetry goes out in OpenTelemetry-compatible format. Token usage, latency, session duration, and error rates surface in Amazon CloudWatch dashboards. Integrations are first-class with Datadog, LangSmith, and Langfuse. The one thing AWS does not sell here is an evaluation platform, so Braintrust or Phoenix sits beside it in most serious deployments.
+
+## Citations
+
+1. **OpenTelemetry** — Semantic conventions for generative AI systems — https://opentelemetry.io/docs/specs/semconv/gen-ai/ [accessed 2026-04-17] *(Canonical GenAI semantic conventions.)* { #cite-1 }
+2. **OpenTelemetry** — Semantic Conventions for GenAI agent and framework spans — https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/ [accessed 2026-04-17] *(Agent-specific span conventions; based on Google's AI agent white paper.)* { #cite-2 }
+3. **OpenTelemetry** — AI Agent Observability: Evolving Standards and Best Practices — https://opentelemetry.io/blog/2025/ai-agent-observability/ [accessed 2026-04-17] *(Overview of the GenAI SIG's work on agent observability standards.)* { #cite-3 }
+4. **Uptrace** — OpenTelemetry for AI Systems: LLM and Agent Observability (2026) — https://uptrace.dev/blog/opentelemetry-ai-systems [accessed 2026-04-17] *(Practitioner walkthrough of OTel GenAI conventions and multi-agent tracing.)* { #cite-4 }
+5. **Medium (Anudeep)** — LangSmith vs Arize vs Braintrust: The Definitive 2026 Comparison — https://anudeepsri.medium.com/langsmith-vs-arize-vs-braintrust-e397e4728a76 [accessed 2026-04-17] *(March 2026 side-by-side of the three leading observability platforms.)* { #cite-5 }
+6. **Datadog** — Datadog LLM Observability natively supports OpenTelemetry GenAI Semantic Conventions — https://www.datadoghq.com/blog/llm-otel-semantic-convention/ [accessed 2026-04-17] *(Datadog v1.37 native OTel GenAI support.)* { #cite-6 }
+7. **AWS** — Get started with AgentCore Observability — https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-get-started.html [accessed 2026-04-17] *(AWS Bedrock AgentCore Observability; CloudWatch integration; quality metrics.)* { #cite-7 }
+8. **W3C** — Trace Context: W3C Recommendation — https://www.w3.org/TR/trace-context/ [accessed 2026-04-17] *(W3C standard for propagating trace context across HTTP services.)* { #cite-8 }
+9. **Arize AI** — Phoenix: open-source LLM observability — https://phoenix.arize.com/ [accessed 2026-04-17] *(Open-source observability platform using OpenInference on OTLP.)* { #cite-9 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/glossary/agent-observability/](https://www.exploreagentic.ai/glossary/agent-observability/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/glossary/agent-washing.md
+++ b/docs/explore-agentic/glossary/agent-washing.md
@@ -1,0 +1,98 @@
+# Agent washing
+
+*Also known as: AI agent washing · 7 min · Updated April 17, 2026 · Author Michael Clough · Reviewed by Ryo Hang*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/glossary/agent-washing/](https://www.exploreagentic.ai/glossary/agent-washing/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Definition
+
+<strong>Agent washing</strong> is Gartner's term for products and features marketed as "agentic AI" that do not meet the definitional threshold of an agent, namely systems that observe, reason, and act with meaningful autonomy and the ability to revise their own plan. Chatbots with workflow buttons, RPA with a language-model UI, and fixed-pipeline assistants all get relabeled as agents in response to customer demand. On June 25, 2025, Gartner published a press release forecasting that over 40 percent of agentic AI projects will be cancelled by end of 2027, and estimated that only about 130 of the thousands of vendors claiming to sell agentic AI are building real agents <a href="#cite-1" class="cite-ref">[1]</a>.
+
+## Where the term came from
+
+Gartner coined "agent washing" in 2024, in the same way it earlier coined "cloud washing" and "AI washing": to describe the pattern of vendors rebranding existing products (AI assistants, robotic process automation (RPA), chatbots) to match whichever category currently commands procurement budget. The pattern is predictable; the damage is specific. Buyers evaluate products on the assumption that the category word means something, and when it does not, the procurement conversation is poisoned for everyone.
+
+On June 25, 2025, Gartner published a press release forecasting that over 40% of agentic AI projects will be cancelled by end of 2027, citing escalating costs, unclear business value, and inadequate risk controls <a href="#cite-1" class="cite-ref">[1]</a>. Analyst Anushree Verma is quoted in the release: "Most agentic AI projects right now are early stage experiments or proof of concepts that are mostly driven by hype and are often misapplied." A January 2025 Gartner poll of 3,412 webinar attendees found only 19% of organizations had made significant investments in agentic AI; 42% described themselves as conservative, and 31% were in wait-and-see mode <a href="#cite-1" class="cite-ref">[1]</a>.
+
+The pattern was reinforced by Gartner's April 2026 Hype Cycle for Agentic AI, which placed AI agent development platforms at the Peak of Inflated Expectations with a 2–5 year time to mainstream adoption <a href="#cite-2" class="cite-ref">[2]</a>. GenAI itself entered the Trough of Disillusionment in the same cycle.
+
+> The question isn't whether it's an agent. The question is whether it can change its mind without asking permission.
+
+## How to spot it in a demo
+
+Five tells that consistently separate shipping agent products from rules engines with a language-model wrapper. Four or more firing together, in our experience, is decisive.
+
+1. **The demo runs the same three happy-path queries every time** — Ask for the failure-mode log. Shipped products keep one; prototypes do not. If the seller cannot produce a list of the last twenty things that went wrong and how the agent handled them, it is not a shipping product.
+2. **No public eval suite exists** — Not a blog post. A numbered, versioned suite with a changelog and a nightly run. If the answer is "our customers do that internally," the vendor has no quality signal of their own.
+3. **Replanning requires a human click** — Watch the state machine during the demo. If every branch advances only when the user clicks, it is a workflow with natural-language input, not an agent. Real agents reconsider mid-execution when new information arrives.
+4. **Tool failures become user errors** — Ask what happens when a tool returns a 500, times out, or produces an unparseable response. An agent should retry, substitute, or escalate. A washed product shows the stack trace to the user.
+5. **Pricing is per seat, not per outcome** — Outcome-priced agents exist: you pay per resolved ticket, per completed workflow, per successful transaction. Seat-priced agents are usually chatbots with a project manager. It is not dispositive, but it is a tell.
+
+## Why buyers keep falling for it
+
+The obvious explanation, procurement teams chasing keywords, is only half the story. The other half is that the category genuinely lacks a clear definitional line. Russell and Norvig's taxonomy (simple reflex, model-based, goal-based, utility-based, learning agents), which is more than twenty years old, remains the clearest reference <a href="#cite-3" class="cite-ref">[3]</a>. Most vendors positioning themselves as "agentic" are building goal-based agents with a utility function bolted on, but the marketing uses the word "autonomous" as though it meant something stronger.
+
+The fix, as a buyer, is to stop arguing about whether something is an agent and start asking whether it does the two things that matter: can it change its plan mid-execution without being told to, and does it own the outcome metric rather than the click-through metric. If both answers are yes, the semantic argument is moot. If either is no, you are buying a workflow. IBM's 2025 Cost of a Data Breach report is a useful pressure test: the same governance gaps that enable shadow AI enable agent washing, because neither category gets scrutinised when leadership is chasing the buzzword <a href="#cite-4" class="cite-ref">[4]</a>.
+
+## Further reading on this site
+
+- The Agentic AI pillar (/agentic-ai) expands the five tells into a full argument, including what the honest list of production agentic workloads looks like in April 2026.
+- Our Jarvis-inclusive comparisons flag where any product, including our own, does not meet the agent threshold for a given workflow.
+
+## See Also
+
+- [Agentic AI pillar](../pillars/agentic-ai.md)
+- [Guardian agent](guardian-agent.md)
+- [Agent observability](agent-observability.md)
+- [Shadow AI](shadow-ai.md)
+
+## FAQ
+
+**Q: What is agent washing?**
+
+Gartner's term for products marketed as "agentic AI" that do not meet the threshold of an agent. The threshold is short: a system that observes, reasons, and acts with autonomy, and can revise its own plan. Washed products usually cannot do the last bit. Chatbots with workflow buttons. RPA with a language-model UI. Fixed-pipeline assistants that dress up natural-language input as planning. Gartner coined the term in 2024, in the same way it earlier coined "cloud washing" and "AI washing." Same pattern, different buzzword.
+
+**Q: What percentage of agentic AI projects will fail?**
+
+Over 40%. Gartner's June 25, 2025 forecast has that many agentic AI projects canceled by end of 2027. The reasons are the usual three: escalating costs, unclear business value, inadequate risk controls. Same release added a number that changed how buyers shortlist. Of the thousands of vendors positioning themselves in agentic AI, Gartner estimated only about 130 are real. A 98% noise-to-signal ratio, give or take, which is the reason procurement teams keep getting burned.
+
+**Q: How do I spot agent washing in a vendor demo?**
+
+Five tells. Watch for them in the demo. The demo runs the same three happy-path queries every time and has no failure-mode log. No public eval suite exists, which means the vendor has no quality signal of their own. Replanning requires a human click, which means it's a workflow with language-model input, not an agent. Tool failures surface as stack traces to the user, not as agent retries. Pricing is per seat, not per outcome. Four or more firing together is decisive in our experience.
+
+**Q: Is every 'AI agent' product agent-washed?**
+
+No. Real agents exist and ship. The cleanest screen is two questions. Can the product change its plan mid-execution without being told to? And does the vendor price on outcomes, meaning resolved tickets or completed workflows, rather than seats? Customer support, ticket triage, reconciliation, structured document review: vendors in those categories tend to publish the outcome numbers. Agent-washed products, by and large, cannot. That is the whole sorting test.
+
+**Q: How does agent washing relate to hype-cycle dynamics?**
+
+Tightly. Gartner's April 2026 Hype Cycle for Agentic AI put AI agent development platforms at the Peak of Inflated Expectations. GenAI itself had already slid into the Trough of Disillusionment. Those two positions together make agent washing inevitable. Procurement budgets chase the peak-of-hype category. Vendors relabel existing products to match. It is the same play that produced cloud washing in 2010 and AI washing in 2023, and it will produce the same outcome: a lot of cancelled contracts in 2027.
+
+**Q: What is the Russell and Norvig agent taxonomy?**
+
+The five-tier taxonomy from Russell and Norvig's 'Artificial Intelligence: A Modern Approach', Chapter 2. Five categories. Simple reflex. Model-based reflex. Goal-based. Utility-based. Learning agents. Most products positioned as 'agentic' in 2026 are goal-based agents with a utility function bolted on, which is fine. The problem is the marketing word 'autonomous,' which is stronger than the engineering supports. The taxonomy is more than twenty years old and still the clearest reference.
+
+## Citations
+
+1. **Gartner** — Gartner Predicts Over 40% of Agentic AI Projects Will Be Canceled by End of 2027 — https://www.gartner.com/en/newsroom/press-releases/2025-06-25-gartner-predicts-over-40-percent-of-agentic-ai-projects-will-be-canceled-by-end-of-2027 [accessed 2026-04-17] *(June 25, 2025 press release; identifies agent washing and the ~130 real vendors; January 2025 3,412-respondent poll data.)* { #cite-1 }
+2. **Gartner** — What the 2026 Hype Cycle for Agentic AI Reveals — https://www.gartner.com/en/articles/hype-cycle-for-agentic-ai [accessed 2026-04-17] *(April 2026 Hype Cycle; AI agent development platforms at Peak of Inflated Expectations; GenAI in Trough of Disillusionment.)* { #cite-2 }
+3. **Pearson** — Russell & Norvig: Artificial Intelligence: A Modern Approach — https://aima.cs.berkeley.edu/ [accessed 2026-04-17] *(Canonical textbook; Chapter 2 agent taxonomy.)* { #cite-3 }
+4. **IBM** — Cost of a Data Breach Report 2025 — https://www.ibm.com/reports/data-breach [accessed 2026-04-17] *(97% of shadow-AI-linked breaches lacked AI access controls, the same governance gap that enables agent washing.)* { #cite-4 }
+5. **BigDATAwire** — Gartner Predicts Over 40% of Agentic AI Projects Will Be Canceled by End of 2027 — https://www.hpcwire.com/bigdatawire/this-just-in/gartner-predicts-over-40-of-agentic-ai-projects-will-be-canceled-by-end-of-2027/ [accessed 2026-04-17] *(Industry reporting summary of the Gartner forecast.)* { #cite-5 }
+6. **RCR Wireless** — Gartner: More than 40% of agentic AI projects will fail by 2027 — https://www.rcrwireless.com/20250627/business/agentic-ai-gartner [accessed 2026-04-17] *(Second industry report on the June 2025 Gartner press release.)* { #cite-6 }
+7. **Outreach** — Agent washing exposed: Why 40% of AI projects fail in 2025 — https://www.outreach.io/resources/blog/agent-washing-ai-projects-fail-guide [accessed 2026-04-17] *(Vendor analysis of agent-washing patterns.)* { #cite-7 }
+8. **XMPRO** — Gartner's 40% Agentic AI Failure Prediction Exposes a Core Architecture Problem — https://xmpro.com/gartners-40-agentic-ai-failure-prediction-exposes-a-core-architecture-problem/ [accessed 2026-04-17] *(Architecture-centric analysis of agent-washing failure modes.)* { #cite-8 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/glossary/agent-washing/](https://www.exploreagentic.ai/glossary/agent-washing/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/glossary/agentic-rag.md
+++ b/docs/explore-agentic/glossary/agentic-rag.md
@@ -1,0 +1,97 @@
+# Agentic RAG
+
+*Also known as: Agent-augmented retrieval, Active retrieval, Reasoning RAG · 7 min · Updated April 17, 2026 · Author Ziyi Tao · Reviewed by Michael Clough*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/glossary/agentic-rag/](https://www.exploreagentic.ai/glossary/agentic-rag/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Definition
+
+<strong>Agentic RAG</strong> is retrieval-augmented generation where retrieval is part of the agent's planning loop. The model decides what to retrieve, judges whether the result is good enough, and retrieves again if not, rather than performing a single fixed retrieval at the start of the response. The term entered common use after the January 2025 arXiv survey by Singh et al. (arXiv:2501.09136) <a href="#cite-1" class="cite-ref">[1]</a>, though the underlying techniques trace back to FLARE (Jiang et al., October 2023) <a href="#cite-2" class="cite-ref">[2]</a> and Self-RAG (Asai et al., ICLR 2024) <a href="#cite-3" class="cite-ref">[3]</a>.
+
+## How agentic RAG differs from vanilla RAG
+
+Vanilla RAG is one retrieval, then generation. The parameters are fixed: embedding model, top-k, filters. If the first retrieval is wrong, the generation is wrong, and the system has no obvious way to recover. Published 2026 surveys put naive-RAG retrieval precision at 70–80% for anything harder than simple factual lookup <a href="#cite-4" class="cite-ref">[4]</a>.
+
+Agentic RAG loops. An agent issues a retrieval, assesses relevance (sometimes by sampling a small answer first, sometimes by explicit judgment against reflection tokens as in Self-RAG <a href="#cite-3" class="cite-ref">[3]</a>), and issues a refined retrieval if the first pass was weak. The January 2025 Singh et al. survey formalises a taxonomy of agentic-RAG architectures along four axes: agent cardinality, control structure, autonomy, and knowledge representation <a href="#cite-1" class="cite-ref">[1]</a>.
+
+Production deployments of agentic or self-reflective RAG report a 25–40% reduction in irrelevant retrievals over single-pass baselines <a href="#cite-4" class="cite-ref">[4]</a>. The cost is latency and token spend; the benefit is robustness on questions that vanilla RAG silently fails on.
+
+## The paper trail: where the idea came from
+
+The techniques predate the label. FLARE (Forward-Looking Active REtrieval), published by Jiang et al. in 2023, used the next predicted sentence as a retrieval query and regenerated the sentence when confidence was low <a href="#cite-2" class="cite-ref">[2]</a>. Self-RAG, published by Akari Asai and collaborators at ICLR 2024, trained a single LM to adaptively retrieve passages on-demand and to reflect on retrieved passages using special reflection tokens <a href="#cite-3" class="cite-ref">[3]</a>. Auto-RAG (Yu et al., arXiv:2411.19443, November 2024) extended the pattern with fully autonomous multi-turn retrieval dialogues <a href="#cite-5" class="cite-ref">[5]</a>.
+
+The phrase "agentic RAG" became standard with the January 2025 survey by Singh et al. <a href="#cite-1" class="cite-ref">[1]</a>, which framed these techniques as instances of agentic planning applied to retrieval. A follow-up survey in July 2025, "Towards Agentic RAG with Deep Reasoning" (arXiv:2507.09477), argued the state of the art had moved toward reasoning-driven retrieval where the agent actively decides when, what, and how to retrieve <a href="#cite-6" class="cite-ref">[6]</a>.
+
+## When it earns its seat
+
+- Multi-hop questions, where the answer requires joining facts from two or more documents. Self-RAG and FLARE both show consistent gains on HotpotQA-style benchmarks.
+- Follow-up conversations, where the user's second message depends on the first retrieval's context. Hybrid RAG without agentic control tends to ignore conversation state.
+- Ambiguous intent, where the query could mean two things, and asking a clarifying retrieval is cheaper than guessing wrong.
+- High-stakes domains (medical, legal, compliance) where a second look is worth the latency tax. The 2025 PMC evaluation of an agentic LLM RAG framework for patient education published measurable accuracy gains over static RAG <a href="#cite-7" class="cite-ref">[7]</a>.
+- Tool-orchestrated workflows, where retrieval must be interleaved with calculation, API calls, or structured-output validation. Naive RAG has no mechanism for this.
+
+## When it is a tax
+
+For simple lookup queries ("what is our 401(k) match?") the retrieval loop is pure overhead. FLARE, Self-RAG, and Auto-RAG all impose multi-X latency on straightforward questions. The right production pattern routes by query class: a fast classifier decides whether this turn needs agentic retrieval, and only expensive queries pay the cost.
+
+This term is often misused. For example, several 2025 "agentic RAG" products were RAG pipelines with a LangGraph wrapper added. Independent surveys have flagged that roughly 40–60% of enterprise RAG implementations fail to reach production, and mis-selecting the architecture for the workload is a named contributor <a href="#cite-4" class="cite-ref">[4]</a>. Agentic RAG earns its seat in maybe a third of enterprise workloads; hybrid RAG handles the rest.
+
+> **Further reading**: The long-form version of this entry is in the Enterprise RAG pillar at /enterprise-rag. For the protocol-level question of MCP vs RAG, see /comparisons/mcp-vs-rag.
+
+## See Also
+
+- [Model Context Protocol](model-context-protocol.md)
+- [Agent observability](agent-observability.md)
+- [Enterprise RAG pillar](../pillars/enterprise-rag.md)
+- [MCP vs RAG](../comparisons/mcp-vs-rag.md)
+
+## FAQ
+
+**Q: What is agentic RAG?**
+
+Retrieval, but inside the agent's planning loop instead of bolted on front. The agent decides what to retrieve, judges whether the result was any good, and retrieves again if not. Single-shot retrieval is gone. The phrase caught on after the January 2025 arXiv survey by Singh and collaborators (arXiv:2501.09136), though the real techniques are older: FLARE (Jiang et al., 2023) and Self-RAG (Asai et al., ICLR 2024) did the foundational work before the label existed.
+
+**Q: How is agentic RAG different from naive RAG?**
+
+Naive RAG fires one retrieval with fixed parameters and generates on whatever comes back. Wrong retrieval, wrong answer, no recovery path. Agentic RAG treats retrieval as a tool the agent can call repeatedly, with a reflection step between calls judging whether the last result helped. Published 2026 benchmarks put the gap at 25 to 40 percent fewer irrelevant retrievals on multi-hop and ambiguous queries. Which is the entire reason anyone tolerates the extra latency.
+
+**Q: When should I use agentic RAG instead of hybrid RAG?**
+
+Four cases earn the latency tax. Multi-hop questions. Follow-up conversations where turn two depends on turn one's retrieval. Ambiguous intent. High-stakes domains (medical, legal, compliance) where a second look is cheaper than a wrong answer. For "what is our 401(k) match?" agentic RAG is pure overhead. Hybrid RAG (BM25 + dense vectors with cross-encoder re-ranking) handles maybe two-thirds of enterprise workloads faster and cheaper. Route by query class at the front of the pipeline, and only pay the agentic tax where it earns its seat.
+
+**Q: What are the foundational agentic RAG papers?**
+
+Four papers carry the idea. Chronological. FLARE (Jiang et al., arXiv:2305.06983, 2023). Self-RAG (Asai et al., arXiv:2310.11511, ICLR 2024). Auto-RAG (Yu et al., arXiv:2411.19443, November 2024). The agentic-RAG survey by Singh et al. (arXiv:2501.09136, January 2025) is the one that finally gave the pattern its name. For the reasoning-driven generation, read the July 2025 follow-up, "Towards Agentic RAG with Deep Reasoning" (arXiv:2507.09477).
+
+**Q: What is the latency cost of agentic RAG?**
+
+Multi-X. Not a typo. Two to five retrieval calls per turn, plus a reflection LLM pass between each pair. On simple queries that is pure overhead stacked on pure overhead. The engineering lever is not clever; it's a classifier at the front of the pipeline that decides whether this turn needs agentic retrieval or whether a fast hybrid-RAG path suffices. Get the router right and the latency story stops being a problem for the 70% of queries that were never going to benefit from iteration anyway.
+
+**Q: Does agentic RAG replace MCP?**
+
+No. Orthogonal things. Agentic RAG is a strategy for how an agent uses retrieval. MCP is a wire protocol for how an agent calls tools at all. In production the two stack together: an MCP server exposes the retrieval tools (vector stores, SQL engines, knowledge graphs), and agentic RAG is the pattern the agent uses to call them intelligently. One is the pipe, one is the decision-making on top of the pipe.
+
+## Citations
+
+1. **arXiv (Singh, Ehtesham et al.)** — Agentic Retrieval-Augmented Generation: A Survey on Agentic RAG — https://arxiv.org/abs/2501.09136 [accessed 2026-04-17] *(January 2025 survey; introduces the taxonomy of agentic-RAG architectures.)* { #cite-1 }
+2. **arXiv (Jiang et al.)** — Active Retrieval Augmented Generation (FLARE) — https://arxiv.org/abs/2305.06983 [accessed 2026-04-17] *(2023; forward-looking active retrieval triggered by low-confidence tokens.)* { #cite-2 }
+3. **arXiv (Asai, Wu, Wang, Sil, Hajishirzi)** — Self-RAG: Learning to Retrieve, Generate, and Critique through Self-Reflection — https://arxiv.org/abs/2310.11511 [accessed 2026-04-17] *(ICLR 2024; reflection tokens for adaptive on-demand retrieval.)* { #cite-3 }
+4. **Techment** — 10 RAG Architectures in 2026: Enterprise Use Cases & Strategy — https://www.techment.com/blogs/rag-architectures-enterprise-use-cases-2026/ [accessed 2026-04-17] *(Benchmark context: naive-RAG precision ~70–80%; agentic RAG reduces irrelevant retrievals 25–40%.)* { #cite-4 }
+5. **arXiv (Yu et al.)** — Auto-RAG: Autonomous Retrieval-Augmented Generation for Large Language Models — https://arxiv.org/abs/2411.19443 [accessed 2026-04-17] *(November 2024; fully autonomous multi-turn retrieval.)* { #cite-5 }
+6. **arXiv** — Towards Agentic RAG with Deep Reasoning: A Survey of RAG-Reasoning Systems in LLMs — https://arxiv.org/abs/2507.09477 [accessed 2026-04-17] *(July 2025 follow-up survey; reasoning-driven retrieval systems.)* { #cite-6 }
+7. **PMC / NCBI** — Development and evaluation of an agentic LLM-based RAG framework for evidence-based patient education — https://pmc.ncbi.nlm.nih.gov/articles/PMC12306375/ [accessed 2026-04-17] *(Peer-reviewed evaluation of agentic RAG in a high-stakes domain.)* { #cite-7 }
+8. **GitHub (asinghcsu)** — AgenticRAG-Survey: companion repository — https://github.com/asinghcsu/AgenticRAG-Survey [accessed 2026-04-17] *(Code and resources accompanying the Singh et al. 2025 arXiv survey.)* { #cite-8 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/glossary/agentic-rag/](https://www.exploreagentic.ai/glossary/agentic-rag/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/glossary/guardian-agent.md
+++ b/docs/explore-agentic/glossary/guardian-agent.md
@@ -1,0 +1,95 @@
+# Guardian agent
+
+*Also known as: Guardrail agent, Supervisor agent · 7 min · Updated April 17, 2026 · Author Xintian Zhang · Reviewed by Michael Clough*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/glossary/guardian-agent/](https://www.exploreagentic.ai/glossary/guardian-agent/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Definition
+
+A <strong>guardian agent</strong> is an AI system that supervises, intervenes in, or vetoes the actions of other AI systems. Gartner formalised the term in a June 11, 2025 press release and forecast that guardian agents will capture 10 to 15 percent of the agentic-AI market by 2030 <a href="#cite-1" class="cite-ref">[1]</a>. Three functions inside the category. Reviewer. Monitor. Protector. The downstream driver is volume: Gartner projects 70% of AI applications will use multi-agent systems by 2028, which is the number that forces runtime guardianship. In April 2026 the serious implementations are prompt-injection guards, output-schema validators, and policy-check agents that refuse specific tool combinations. Nothing fancier has earned its seat yet.
+
+## What a guardian agent actually is
+
+The phrase is Gartner's, but the pattern is older. Every production agent deployment eventually grows a second agent (or a chain of guardrails) that watches the first. Gartner's framing divides guardian agents into three primary functions <a href="#cite-1" class="cite-ref">[1]</a>: Reviewers identify and review AI-generated output for accuracy and acceptable use; Monitors observe and track AI actions for human or AI follow-up; Protectors adjust or block AI actions and permissions automatically during operations. Prompt injection, ranked LLM01 on the OWASP Top 10 for LLM Applications 2025 <a href="#cite-2" class="cite-ref">[2]</a>, is the attack class most guardian products are built to intercept.
+
+1. **Prompt-injection guards (Protectors)** — Classifiers (sometimes small purpose-trained models, sometimes rule-plus-LLM hybrids) that inspect incoming prompts and tool outputs for injection patterns. Open-source baselines include NVIDIA NeMo Guardrails (v0.20.0 as of January 2026) [3], Llama Guard (Meta), and Lakera's commercial offering.
+2. **Output-schema validators (Reviewers)** — Agents that check the structured output of another agent against a schema before the output is accepted. Useful when the downstream tool will behave badly on malformed input. Guardrails AI is the most widely-deployed open-source implementation.
+3. **Policy-check agents (Protectors)** — Agents that refuse to invoke specific tool combinations. "The ticketing tool and the refund tool must not be called in the same turn" is a one-line policy that prevents a wide class of failure modes. Most MCP gateways now ship this capability natively.
+4. **Red-team orchestrators (adversarial Monitors)** — Microsoft PyRIT (Python Risk Identification Toolkit, MIT-licensed) orchestrates multi-modal, multi-turn attacks against agents to surface injection and data-leak vulnerabilities before deployment [4]. Not strictly a runtime guardian, but an essential companion.
+
+## How to evaluate one
+
+The honest evaluation question for a guardian agent is what happens when the guardian is wrong, and that question has two shapes. A guardian that raises only false positives is a friction tax: it annoys users, slows agents, and eventually gets turned off. A guardian that raises only false negatives is a liability: it is silent until it isn't, and the failure mode is what the guardian was supposed to prevent. Vendors worth talking to publish both rates.
+
+This term is often misused. For example, several 2025 "guardian agent" products are OWASP LLM Top 10 checklists wrapped in a dashboard. The OWASP guidance itself is clear that there is no fool-proof prevention for prompt injection given the stochastic nature of language models <a href="#cite-2" class="cite-ref">[2]</a>; any vendor claiming otherwise is selling something. Defence in depth (input validation plus output filtering plus human-in-the-loop controls for sensitive operations) is the pattern that survives red-teaming.
+
+- False-positive rate on a representative workload: what percent of benign agent actions does the guardian incorrectly block?
+- False-negative rate on a red-team workload: of known-bad actions, what percent does the guardian miss? Microsoft PyRIT publishes a common red-team harness worth asking about.
+- Latency impact per invocation: the cost of running the guardian in line.
+- Replay fidelity: can the guardian's decisions be reproduced and audited after the fact, or is it a black box? This is where OpenTelemetry GenAI observability integration pays off.
+- Multi-turn dialog handling: NeMo Guardrails' Colang language is the reference for conversation-level policy; most alternatives are single-turn only.
+
+## Where the market is in April 2026
+
+The Gartner 10–15% projection is for 2030, not now. In 2026, the category is still emerging: most organizations with production agents use open-source guardrail frameworks (NVIDIA NeMo Guardrails for runtime protection plus Colang dialog control <a href="#cite-3" class="cite-ref">[3]</a>, Guardrails AI for schema validation, Microsoft PyRIT for red-teaming <a href="#cite-4" class="cite-ref">[4]</a>, and Meta's Llama Guard for content classification) rather than a dedicated commercial guardian product. Gartner's June 2025 Security & Risk Management Summit research note names this as a category still forming; a webinar poll cited in the same research found 52% of agent deployments are for internal IT, HR, and accounting, 23% for customer-facing functions <a href="#cite-1" class="cite-ref">[1]</a>.
+
+If you are architecting an agent program in 2026, our recommendation is to design for replaceability. Treat the guardian layer as an abstraction and pick an implementation you can swap in 18 months when the category matures. Locking into a proprietary guardian today is the same class of bet as locking into a proprietary observability vendor in 2014. The NIST AI 600-1 Generative AI Profile (July 2024) flags pre-deployment testing and incident disclosure as two of its four priority considerations <a href="#cite-5" class="cite-ref">[5]</a>; any guardian investment should map to both.
+
+> **Context**: We cover the governance angle of guardian agents in the AI Governance pillar. Think of guardian agents as the runtime expression of a policy document: what happens when your NIST AI RMF MANAGE function has to intervene at millisecond speed rather than in a quarterly committee.
+
+## See Also
+
+- [Agent washing](agent-washing.md)
+- [Agent observability](agent-observability.md)
+- [NIST AI RMF](nist-ai-rmf.md)
+
+## FAQ
+
+**Q: What is a guardian agent?**
+
+An AI system whose job is to supervise, intervene in, or veto the actions of other AI systems. The phrase is Gartner's, formalised in a June 11, 2025 press release. Three functions inside the category. Reviewers, which inspect AI-generated output for accuracy and acceptable use. Monitors, which track AI actions for human or AI follow-up. Protectors, which adjust or block actions automatically during operations. The pattern predates the phrase; Anthropic's Constitutional AI research is the oldest foundational work people keep citing.
+
+**Q: How big will the guardian agent market be?**
+
+Gartner's number is 10 to 15 percent of the agentic-AI market by 2030. The driver is multi-agent adoption, not hype. Gartner also projects that by 2028, 70% of AI applications will use multi-agent systems. That is the volume line. Past that, runtime guardianship stops being optional for anyone shipping to regulated customers. The 2030 market projection is the downstream consequence, not the cause.
+
+**Q: What are the best open-source guardian agent tools in 2026?**
+
+Four worth evaluating. NVIDIA NeMo Guardrails (v0.20.0 as of January 2026; Colang dialog-flow control is the differentiator). Meta Llama Guard for content-safety classification. Guardrails AI for output-schema validation. Microsoft PyRIT for red-teaming and adversarial testing, MIT-licensed. Most production deployments combine two or three of these rather than betting on a single commercial product. The market is too young to pick one winner and the overlap is how you catch what the primary tool misses.
+
+**Q: How do I evaluate a guardian agent?**
+
+Four questions, asked in order. What is the false-positive rate on a representative workload? What is the false-negative rate on a red-team workload? What is the latency overhead per invocation? Are decisions replayable and auditable after the fact? A fifth one matters in any conversational product: does the tool handle multi-turn dialog? NeMo Guardrails' Colang is the reference on that; most alternatives are single-turn only, which you learn the hard way.
+
+**Q: Do guardian agents prevent prompt injection?**
+
+Reduce, not eliminate. That distinction matters. OWASP's LLM Top 10 2025 guidance is explicit that prompt injection cannot be fool-proofed, given the stochastic nature of language models. Any vendor claiming otherwise is selling. The production pattern that survives red-teaming is defence in depth. Input validation. Output filtering. Privilege restrictions. Human-in-the-loop controls for sensitive operations. Continuous red-teaming. Five layers, one of which catches what the other four miss.
+
+**Q: How do guardian agents relate to NIST AI RMF?**
+
+Runtime implementation of two things at once. The NIST AI RMF MANAGE function. And the GOVERN culture of continuous oversight. Pair them together and a guardian agent is what happens when the policy document has to make a decision in milliseconds instead of in a quarterly committee. They also map cleanly to the NIST AI 600-1 Generative AI Profile's priority considerations on pre-deployment testing and incident disclosure, which is the cite that makes most compliance teams sign off.
+
+## Citations
+
+1. **Gartner** — Gartner Predicts that Guardian Agents will Capture 10-15% of the Agentic AI Market by 2030 — https://www.gartner.com/en/newsroom/press-releases/2025-06-11-gartner-predicts-that-guardian-agents-will-capture-10-15-percent-of-the-agentic-ai-market-by-2030 [accessed 2026-04-17] *(June 11, 2025 press release; three functions (Reviewer, Monitor, Protector); 70% multi-agent projection for 2028; 52/23% internal/external use case split.)* { #cite-1 }
+2. **OWASP** — LLM01:2025 Prompt Injection (OWASP Gen AI Security Project) — https://genai.owasp.org/llmrisk/llm01-prompt-injection/ [accessed 2026-04-17] *(OWASP Top 10 for LLM Applications 2025; prompt injection remains the #1 risk.)* { #cite-2 }
+3. **NVIDIA** — NeMo Guardrails (open-source toolkit) — https://github.com/NVIDIA-NeMo/Guardrails [accessed 2026-04-17] *(v0.20.0 as of January 2026; Colang dialog control; jailbreak prevention, multilingual/multimodal safety.)* { #cite-3 }
+4. **Microsoft** — PyRIT: Python Risk Identification Toolkit — https://github.com/Azure/PyRIT [accessed 2026-04-17] *(MIT-licensed red-teaming toolkit; multi-modal and multi-turn attack orchestration.)* { #cite-4 }
+5. **NIST** — NIST AI 600-1: Generative AI Profile — https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf [accessed 2026-04-17] *(July 26, 2024 release; flags pre-deployment testing and incident disclosure as priority considerations.)* { #cite-5 }
+6. **Anthropic** — Constitutional AI: Harmlessness from AI Feedback — https://arxiv.org/abs/2212.08073 [accessed 2026-04-17] *(Foundational Anthropic paper on using an AI system to oversee another AI.)* { #cite-6 }
+7. **Computer Weekly** — Guardian agents: Stopping AI from going rogue — https://www.computerweekly.com/opinion/Guardian-agents-Stopping-AI-from-going-rogue [accessed 2026-04-17] *(Independent analysis of guardian-agent use cases.)* { #cite-7 }
+8. **OWASP** — LLM Prompt Injection Prevention Cheat Sheet — https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html [accessed 2026-04-17] *(Practitioner guidance on mitigation layers.)* { #cite-8 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/glossary/guardian-agent/](https://www.exploreagentic.ai/glossary/guardian-agent/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/glossary/index.md
+++ b/docs/explore-agentic/glossary/index.md
@@ -1,0 +1,83 @@
+# Glossary
+
+> Short, careful entries on the terms that matter in enterprise AI. Each one is dated, cited, and reviewed by a named editor before publication. We skip the terms a general-interest AI glossary already covers and focus on the ones that determine budget and risk.
+
+<div class="grid cards" markdown>
+
+-   **[Model Context Protocol (MCP)](model-context-protocol.md)**
+
+    ---
+
+    The specification, the history, the three roles, and the fourth role that emerged in production.
+
+    *Protocol · 7 min*
+
+-   **[MCP Gateway](mcp-gateway.md)**
+
+    ---
+
+    The authorization- and observability-aware proxy every enterprise ends up building or buying.
+
+    *Protocol · 5 min*
+
+-   **[Agentic RAG](agentic-rag.md)**
+
+    ---
+
+    Retrieval inside a plan. When it earns its seat and when it is a tax.
+
+    *Architecture · 6 min*
+
+-   **[Agent observability](agent-observability.md)**
+
+    ---
+
+    The emerging category. What counts as observable, and what Datadog, Braintrust, and Phoenix are all chasing.
+
+    *Observability · 5 min*
+
+-   **[ISO/IEC 42001:2023](iso-42001.md)**
+
+    ---
+
+    The first certifiable AI management standard. Structure, annexes, certification process, and how it relates to NIST AI RMF.
+
+    *Governance · 8 min*
+
+-   **[NIST AI Risk Management Framework](nist-ai-rmf.md)**
+
+    ---
+
+    The four-function framework (GOVERN, MAP, MEASURE, MANAGE) US federal agencies and most enterprises reference by default.
+
+    *Governance · 6 min*
+
+-   **[Shadow AI](shadow-ai.md)**
+
+    ---
+
+    What every mature governance program discovers at audit: unsanctioned AI tools, SaaS-embedded AI, team-built integrations. How to surface it.
+
+    *Governance · 6 min*
+
+-   **[Agent washing](agent-washing.md)**
+
+    ---
+
+    Gartner's term for products marketed as agentic that are workflow-with-natural-language-input. The five tells we use to screen demos.
+
+    *Governance · 6 min*
+
+-   **[Guardian agent](guardian-agent.md)**
+
+    ---
+
+    The Gartner-coined category for AI systems that supervise other AI systems. Real, narrow, still forming in April 2026.
+
+    *Governance · 5 min*
+
+</div>
+
+---
+
+The glossary is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — the canonical index lives at [www.exploreagentic.ai/glossary/](https://www.exploreagentic.ai/glossary/).

--- a/docs/explore-agentic/glossary/iso-42001.md
+++ b/docs/explore-agentic/glossary/iso-42001.md
@@ -1,0 +1,109 @@
+# ISO/IEC 42001:2023
+
+*Also known as: ISO 42001, ISO AI Management Standard, AIMS standard · 8 min · Updated April 17, 2026 · Author Gloria Qian Zhang · Reviewed by Ryo Hang*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/glossary/iso-42001/](https://www.exploreagentic.ai/glossary/iso-42001/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Definition
+
+<strong>ISO/IEC 42001:2023</strong> is the AI standard with teeth. ISO and IEC published it in December 2023 <a href="#cite-1" class="cite-ref">[1]</a>. The playbook is borrowed from ISO 27001: a written policy, named owners, an inventory the auditor samples, an evaluation cadence the auditor times you against. Only the subject is AI rather than information security. The certified roster as of April 2026 includes AWS, IBM (specifically the Granite models, which is a narrower scope than people assume), BCG, CrowdStrike, CM.com, Swimlane, Meltwater, Vanta, Kandji, and Mimecast <a href="#cite-2" class="cite-ref">[2]</a><a href="#cite-3" class="cite-ref">[3]</a>. The first hundred organizations passed in early 2026. The second hundred move faster.
+
+## Why the standard exists
+
+Before ISO 42001, AI governance was a workaround. Most teams stretched ISO 27001 over anything AI-adjacent and hoped no one pulled the thread. Some bolted on ISO 27701 for privacy. There was usually also a one-page "responsible AI" policy a committee had drafted in 2023 and quietly never updated. Then late 2024 happened. Procurement teams started writing "AI-specific certification" into their RFPs. Nobody had one. ISO 42001 arrived just in time to be the answer.
+
+Publication date: December 2023 <a href="#cite-1" class="cite-ref">[1]</a>. Certifications followed through 2024 and 2025. Schellman became the first ANAB-accredited body in 2024. BSI became the first UKAS-accredited body. DNV, SGS, and TÜV SÜD followed shortly after <a href="#cite-4" class="cite-ref">[4]</a>. The very first organization in the world to certify was KPMG Australia, audited by BSI; a small fact that surprises people who expected a tech company to be first. Adoption built slowly. Roughly 16 AI companies had certified by mid-2025. By the time BCG announced on January 27, 2026 <a href="#cite-5" class="cite-ref">[5]</a>, the global count had crossed 100. In regulated industries and European procurement, "are you 42001 certified or on the path" is now a standard RFP question.
+
+## What is inside the document
+
+The shape of the document is familiar. Ten clauses, with scope and normative references at the front, then the substance: leadership, planning, support, operation, performance evaluation, improvement. Anyone who has implemented ISO 27001 will recognise the bones immediately. Most of that scaffolding is reusable. What makes 42001 a real new standard rather than a 27001 rebrand is in the annexes, which is where the AI-specific obligations live.
+
+*ISO/IEC 42001:2023 · document layout*
+
+| Part | Contents |
+| --- | --- |
+| Clauses 4–10 | The management system itself: leadership, risk planning, operation, evaluation, improvement. Structure is aligned with the ISO High-Level Structure used by every modern ISO management standard. |
+| Annex A | Reference controls, grouped into categories that cover AI policy, internal organization, AI resources, AI impact assessment, AI lifecycle, data for AI, information for third parties, use of AI systems, and third-party / customer relationships. |
+| Annex B | Implementation guidance for each Annex A control. Read this if you want to know what "good" looks like in practice. |
+| Annex C | Catalogue of AI-related risk sources and objectives the management system is expected to address. |
+| Annex D | Explains how ISO 42001 relates to other management systems (ISO 27001, ISO 9001, etc.), useful when you are mapping existing controls to the new standard. |
+
+## Inside an AI Management System
+
+AIMS is the term the standard defines. It is not software. It is not a platform feature. It is a documented system of policies, processes, and evidence that describes how the organization governs AI across its full lifecycle: supplier selection, data acquisition, design, deployment, monitoring, decommissioning. The lifecycle scope is the part teams underestimate.
+
+In every production audit we have heard about, three artefacts show up. A written AI policy with named owners. An inventory of AI systems in use, which absolutely must include the third-party AI now embedded in nearly every SaaS contract (this is the part teams forget). And an evaluation cadence that reruns risk and performance checks on a fixed schedule. The standard formalises all of this as clauses. The language will look familiar to anyone with 27001 audit experience.
+
+## The certification path, end to end
+
+1. **Readiness assessment (typically 1–3 months)** — A gap analysis against the clauses and Annex A controls. Most organizations discover that the policy exists but the inventory does not.
+2. **Stage 1 audit, documentation review (4–6 weeks)** — An accredited certification body reviews your AIMS documentation and flags missing evidence.
+3. **Stage 2 audit, implementation review (2–3 months)** — Auditors sample controls in operation. The inventory must match reality, with change logs. This is where programs that skipped the inventory fail.
+4. **Surveillance audits (annually) and recertification (every 3 years)** — Certification is not a one-time event. It has the same ongoing cost structure as ISO 27001.
+
+## How it sits beside NIST AI RMF and the EU AI Act
+
+ISO 42001 and NIST AI RMF are often pitched as competitors. They are not. ISO 42001 is the management system: structure, roles, meeting cadences, documentation, audit trail. NIST AI RMF is what you do inside that system to assess and manage risk for any specific AI use case, using the GOVERN, MAP, MEASURE, MANAGE functions <a href="#cite-6" class="cite-ref">[6]</a>. NIST publishes a crosswalk mapping its framework to ISO 42001. Organizations running both usually write a combined control-mapping document. The work takes about two days once the ISO 42001 scope is set.
+
+The EU AI Act is the regulatory layer above both. ISO 42001 certification on its own does not satisfy EU AI Act compliance. But a working AIMS maps cleanly to most of the high-risk-system obligations. The Cloud Security Alliance published a January 2025 analysis walking through where the two frameworks help and where they do not <a href="#cite-7" class="cite-ref">[7]</a>.
+
+> **What to do first**: Before you schedule the Stage 1 audit, build the inventory. Every AI system, every third-party AI embedded in SaaS, every model running inside an acquired subsidiary: enumerated, owned, refreshed monthly. A great policy with no inventory fails the audit. A mediocre policy with an honest inventory passes.
+
+## See Also
+
+- [NIST AI RMF](nist-ai-rmf.md)
+- [Shadow AI](shadow-ai.md)
+- [Agent observability](agent-observability.md)
+- [AI Governance pillar](../pillars/ai-governance.md)
+
+## FAQ
+
+**Q: What is ISO/IEC 42001:2023?**
+
+It is the international standard auditors use to certify that an organization governs its AI properly. ISO and IEC published it in December 2023. The thing being certified is the AIMS, which is short for AI Management System. That bundle includes the policies, named owners, inventory, and review cadences your auditor will sample. If you have done ISO 27001, the management-system shape will look familiar. If not, expect 6 to 12 months of work.
+
+**Q: Who is certified against ISO 42001?**
+
+As of April 2026, you can verify ten named-and-public certifications. AWS. IBM (Granite models specifically). BCG. CrowdStrike. CM.com. Swimlane. Meltwater. Vanta. Kandji. Mimecast. The historical first was KPMG Australia, audited by BSI. BCG announced on January 27, 2026 that it had cleared the bar in the first hundred globally certified.
+
+**Q: Who can issue ISO 42001 certifications?**
+
+Only an accredited certification body can issue a valid certificate. Schellman was the first ANAB-accredited body, in 2024. BSI was the first UKAS-accredited. The other major options are DNV, SGS, and TÜV SÜD. Verify accreditation directly with ANAB (US), UKAS (UK), or RvA (Netherlands) before signing the engagement letter. Accreditation is the part that makes the certificate buyable in procurement.
+
+**Q: How does ISO 42001 differ from NIST AI RMF?**
+
+They cover different layers. ISO 42001 is the management system: the structure, roles, processes, and documentation the auditor will sample. NIST AI RMF is the risk-assessment work done inside that system on a specific AI use case, using GOVERN, MAP, MEASURE, MANAGE. NIST publishes an explicit crosswalk to ISO 42001. Most organizations running both end up with one combined control-mapping document. About two days of work, once the ISO 42001 scope is set.
+
+**Q: How long does ISO 42001 certification take?**
+
+Six to twelve months, end to end. The readiness assessment runs 1 to 3 months. Stage 1, the documentation review, is 4 to 6 weeks. Stage 2, the implementation review, is 2 to 3 months. Surveillance audits follow annually. Full recertification is every three years. Teams that already hold ISO 27001 can compress the front end significantly by reusing the existing management system.
+
+**Q: Does ISO 42001 replace the EU AI Act?**
+
+No. ISO 42001 is a voluntary management-system standard. The EU AI Act is binding regulation. Certification does not equal compliance. But a working AIMS lines up cleanly with most of the high-risk-system obligations under the Act. One program, scoped right from the start, can satisfy ISO 42001, NIST AI RMF, and the EU AI Act together.
+
+## Citations
+
+1. **ISO** — ISO/IEC 42001:2023 AI management systems — https://www.iso.org/standard/42001 [accessed 2026-04-17] *(Official ISO standard page; publication December 2023.)* { #cite-1 }
+2. **AWS** — AWS achieves ISO/IEC 42001:2023 AI Management System accredited certification — https://aws.amazon.com/blogs/machine-learning/aws-achieves-iso-iec-420012023-artificial-intelligence-management-system-accredited-certification/ [accessed 2026-04-17] *(AWS announcement of ISO 42001 certification.)* { #cite-2 }
+3. **IBM** — IBM becomes first major open-source AI model developer to earn ISO 42001 certification — https://www.ibm.com/new/announcements/ibm-granite-iso-42001 [accessed 2026-04-17] *(IBM Granite ISO 42001 certification announcement.)* { #cite-3 }
+4. **Schellman** — ISO/IEC 42001 Certification — https://www.schellman.com/services/ai-services/iso-42001 [accessed 2026-04-17] *(Schellman as the first ANAB-accredited certification body (2024).)* { #cite-4 }
+5. **Boston Consulting Group** — BCG Among First 100 Organizations Globally Certified for ISO/IEC 42001 — https://www.bcg.com/news/27january2026-bcg-certified-international-standard-ai-management-systems [accessed 2026-04-17] *(January 27, 2026 announcement; BCG among first 100 certified organizations.)* { #cite-5 }
+6. **NIST** — AI Risk Management Framework — https://www.nist.gov/itl/ai-risk-management-framework [accessed 2026-04-17] *(Canonical NIST AI RMF page with the ISO 42001 crosswalk.)* { #cite-6 }
+7. **Cloud Security Alliance** — How Can ISO/IEC 42001 & NIST AI RMF Help Comply with the EU AI Act — https://cloudsecurityalliance.org/blog/2025/01/29/how-can-iso-iec-42001-nist-ai-rmf-help-comply-with-the-eu-ai-act [accessed 2026-04-17] *(January 29, 2025 CSA analysis mapping the frameworks to EU AI Act obligations.)* { #cite-7 }
+8. **BSI** — ISO 42001 AI Management System — https://www.bsigroup.com/en-US/products-and-services/standards/iso-42001-ai-management-system/ [accessed 2026-04-17] *(First UKAS-accredited certification body; KPMG Australia was the first certified organization.)* { #cite-8 }
+9. **CrowdStrike** — CrowdStrike Achieves ISO 42001 Certification for Responsible AI-Powered Cybersecurity — https://ir.crowdstrike.com/news-releases/news-release-details/crowdstrike-achieves-iso-42001-certification-responsible-ai [accessed 2026-04-17] *(January 2026 certification announcement.)* { #cite-9 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/glossary/iso-42001/](https://www.exploreagentic.ai/glossary/iso-42001/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/glossary/mcp-gateway.md
+++ b/docs/explore-agentic/glossary/mcp-gateway.md
@@ -1,0 +1,108 @@
+# MCP Gateway
+
+*Also known as: MCP proxy, Agent gateway, MCP federation layer · 7 min · Updated April 17, 2026 · Author Mehrdad Faqiri · Reviewed by Gloria Qian Zhang*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/glossary/mcp-gateway/](https://www.exploreagentic.ai/glossary/mcp-gateway/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Definition
+
+An <strong>MCP Gateway</strong> is the proxy that sits between MCP clients and a cluster of MCP servers. It authenticates the caller. It evaluates per-tool policy. It logs the invocation. It holds the enterprise credential so the user never pastes a token. The MCP spec does not define the role; it grew up in production during 2025. The category went public in Q4 2025 when AWS Bedrock AgentCore Gateway went GA on October 13, 2025 <a href="#cite-1" class="cite-ref">[1]</a>. Nobody asked for the pattern. Everyone running more than three servers ended up building it anyway.
+
+## Why the category exists
+
+Three servers is the threshold. Past that, the same four questions arrive on the CISO's desk in sequence. Who is allowed to call which tool, under what conditions? Where is every tool call logged? How do we rate-limit? And the one that actually wakes people up: how do we stop handing user-level credentials to a model at inference time?
+
+The gateway pattern answers all four in one place. Inbound auth (OAuth 2.1 with RFC 8707 resource indicators, per the March 2026 MCP spec). Policy evaluated against request context. Outbound call forwarded with the gateway's own credentials. Full exchange logged. Solo.io's 2025 writeup puts it bluntly: direct-to-server OAuth is "a non-starter for enterprise" at any meaningful scale <a href="#cite-2" class="cite-ref">[2]</a>. Which is roughly what we've watched every team discover on their own, usually around server number five.
+
+## The vendor landscape in April 2026
+
+The serious options divide into three tiers: hyperscaler-native, network-edge, and independent.
+
+*Named MCP gateway offerings, April 2026*
+
+| Vendor | Tier | What ships |
+| --- | --- | --- |
+| AWS Bedrock AgentCore Gateway | Hyperscaler | GA October 13, 2025. Zero-code MCP tool creation from Lambda and OpenAPI; ingress + egress auth; Semantic Tool Selection; 1-click integrations with Salesforce, Slack, Jira, Asana, Zendesk. |
+| Cloudflare MCP Server Portals | Network edge | Runs MCP traffic across Cloudflare's global points-of-presence. Collapses many servers into two portal tools, and Cloudflare reports 99.9% token reduction via its Code Mode work [3]. |
+| Kong Enterprise MCP Gateway | Independent (API-gateway extension) | API gateway that added MCP support; v3.14 added A2A (Agent-to-Agent) support in April 2026. Natural fit for teams already running Kong [4]. |
+| Composio | Independent (integration-led) | 500+ pre-built SaaS integrations exposed as MCP. Strong on breadth; weaker on RBAC and compliance audit trails than governance-first options [5]. |
+| Bifrost | Independent (performance-led) | Go-based; published 11-microsecond overhead at 5,000 req/s. Dual role as LLM gateway and MCP gateway in a single binary [6]. |
+| Zuplo | Independent (TypeScript-first) | Edge-deployed across 300+ PoPs; combines API gateway, AI gateway, and MCP support. Programmable in TypeScript [7]. |
+| Red Hat MCP Gateway, Lunar.dev, Portkey, MintMCP | Independent | Smaller but active. Portkey and Lunar.dev publish the most detailed policy-as-code documentation of the independents [8]. |
+
+## What a serious gateway has
+
+- Per-tool authorization policies, versioned and reviewable like any other policy artefact. AgentCore uses Cedar; Kong uses its declarative plugin config; Lunar and Portkey publish OPA-compatible rules.
+- Centralized credential brokering. The gateway holds the Snowflake PAT, the Jira token, the SharePoint secret. The user never pastes them; the model never receives them in clear text.
+- Per-tool observability: latency, error rate, call volume, traceable to a conversation ID and, ideally, a business outcome. OpenTelemetry semantic conventions for GenAI are the emerging baseline.
+- Egress controls for regulated workloads: region-locked traffic, PII redaction, free-form text filtering. This is the chokepoint that proves PII never left a region.
+- Shadow-MCP detection. Cloudflare Gateway runs multi-layer scans for unauthorized MCP server usage from 2026, worth asking about in any procurement cycle.
+- A2A (Agent-to-Agent) support. Kong shipped this in v3.14 (April 2026); any gateway without it will be a quarter behind for the rest of the year.
+
+## How to evaluate one in 2026
+
+Four questions, asked in order. Show me the policy-as-code API. The DSL or schema that expresses "this caller, calling this tool, under these conditions, against that server." Show me the published latency budget (Bifrost's 11µs overhead at 5k req/s is the current public number to beat). Show me what happens when the tool is itself another MCP server, the composition case where several independents still quietly fall over. Show me customer references running the gateway in front of more than twenty servers. Scale pain doesn't show up until that point.
+
+The category is often mis-sold. Several products marketed as "MCP gateways" in Q4 2025 were LLM proxies with MCP logging grafted on. MintMCP and Integrate.io flagged the mis-labelling in their 2026 guides <a href="#cite-5" class="cite-ref">[5]</a><a href="#cite-9" class="cite-ref">[9]</a>. The sorting test is crude and effective. If the product cannot describe per-tool policy enforcement in writing, it is a proxy. Not a gateway.
+
+> **Explore Agentic editorial note**: We maintain an informal tracker of roughly fifteen MCP gateway vendors. The evaluation framework we use on client work is: policy-as-code, credential brokering, per-tool observability, egress enforcement, and documented behaviour when a tool is itself a federated MCP server. A gateway that lands four of five is deployable today.
+
+## See Also
+
+- [Model Context Protocol](model-context-protocol.md)
+- [Agent observability](agent-observability.md)
+- [Shadow AI](shadow-ai.md)
+- [MCP pillar](../pillars/mcp.md)
+
+## FAQ
+
+**Q: What is an MCP gateway?**
+
+The grown-up proxy between your MCP clients and your MCP servers. Auth-aware. Observability-aware. Policy-aware. Every call gets authenticated, policy gets evaluated per tool, the invocation gets logged, and the enterprise credential stays on the gateway so nobody pastes a Snowflake PAT into a prompt. Egress control lives in the same place. The MCP spec does not define the role, a fact that surprises people. It grew up in production during 2025 after teams ran headfirst into the reality that direct-to-server OAuth does not scale past a handful of servers.
+
+**Q: Do I need an MCP gateway?**
+
+Past three servers in the same environment, almost always yes. Centralized per-tool auth. Full tool-call logs. Credentials held server-side so users never paste tokens into prompts. Egress rules for regulated data. Below three servers, native OAuth 2.1 will carry you. For a while. By server number five you will have rebuilt most of a gateway yourself in anger, which is the tax. We've watched teams pay it on six separate engagements and stopped finding it funny.
+
+**Q: Which MCP gateway should I use in 2026?**
+
+Shortest honest answer: whichever one procurement can get through fastest. In practice that means the gateway from the cloud you already buy from. Two cloud-native defaults. AWS Bedrock AgentCore Gateway (GA October 13, 2025) and Cloudflare MCP Server Portals. The independent shortlist. Kong. Composio. Bifrost. Zuplo. Lunar.dev. Portkey. Then run every candidate through five questions: policy-as-code API, credential brokering, per-tool observability, egress enforcement, and what happens when the target is itself a federated MCP server. Four of five is shippable. Five of five is rare.
+
+**Q: Is an MCP gateway the same as an API gateway?**
+
+No. The difference matters more than the marketing admits. An API gateway routes and authorizes HTTP requests between services. Full stop. An MCP gateway speaks the protocol itself: tool discovery, tool invocation, resource access, prompt sampling. Policy runs at the per-tool level, not the endpoint level. Two lineages converged on the category. Kong and Zuplo came up as API gateways and bolted on MCP support later. AgentCore, Bifrost, and Lunar were MCP-native from day one. The pick is boring: choose the lineage that matches your operational muscle memory.
+
+**Q: How does an MCP gateway handle credentials?**
+
+Two separate flows. That is the whole point. The gateway holds the enterprise credentials: Snowflake PATs, Jira API tokens, SharePoint secrets. It attaches them to the outbound call. The user never pastes them. The model never sees them. Inbound, the gateway authenticates the caller with OAuth 2.1 and PKCE, plus RFC 8707 resource indicators from March 15, 2026. Splitting inbound user auth from outbound system auth is the single biggest security win over direct-to-server MCP. Nothing else is close.
+
+**Q: What is Agent-to-Agent (A2A) support?**
+
+An emerging protocol for agents to discover and invoke other agents. Complementary to MCP, not a replacement. Kong shipped A2A in v3.14 (April 2026). The rest of the field is catching up through the rest of the year. The practical buyer question is short: does your gateway treat a federated agent as just another MCP-style target? Yes, and you are positioned for the next protocol wave. No, and you are budgeting a rework for late 2027. Whether you know it yet or not.
+
+## Citations
+
+1. **AWS** — Introducing Amazon Bedrock AgentCore Gateway — https://aws.amazon.com/blogs/machine-learning/introducing-amazon-bedrock-agentcore-gateway-transforming-enterprise-ai-agent-tool-development/ [accessed 2026-04-17] *(AWS launch post. Zero-code MCP tool creation, ingress + egress auth, Semantic Tool Selection, MCP target type.)* { #cite-1 }
+2. **Solo.io** — MCP Authorization is a Non-Starter for Enterprise — https://www.solo.io/blog/mcp-authorization-is-a-non-starter-for-enterprise [accessed 2026-04-17] *(Analysis of why direct-to-server OAuth does not scale in regulated environments.)* { #cite-2 }
+3. **Cloudflare** — Scaling MCP adoption: our reference architecture for enterprise MCP deployments — https://blog.cloudflare.com/enterprise-mcp/ [accessed 2026-04-17] *(MCP Server Portals; Code Mode collapses many servers into two portal tools; shadow-MCP detection.)* { #cite-3 }
+4. **Kong** — Introducing Kong's Enterprise MCP Gateway for Production-Ready AI — https://konghq.com/blog/product-releases/enterprise-mcp-gateway [accessed 2026-04-17] *(Kong Enterprise MCP Gateway launch; A2A support added in v3.14 (April 2026).)* { #cite-4 }
+5. **MintMCP** — 7 top MCP gateways for enterprise AI infrastructure (2026) — https://www.mintmcp.com/blog/enterprise-ai-infrastructure-mcp [accessed 2026-04-17] *(Vendor review including Composio, Bifrost, Kong, AgentCore, Zuplo; notes the "proxy vs gateway" mis-labelling.)* { #cite-5 }
+6. **Maxim AI** — Best MCP Gateway in 2026: How Bifrost Cuts Token Usage by 50% — https://www.getmaxim.ai/articles/best-mcp-gateway-in-2026-how-bifrost-cuts-token-usage-by-50/ [accessed 2026-04-17] *(Bifrost benchmarks: 11µs overhead at 5,000 requests per second; dual LLM+MCP gateway.)* { #cite-6 }
+7. **Zuplo** — How to Choose the Best AI Gateway (2026 Buyer's Guide) — https://zuplo.com/learning-center/best-ai-gateway-buyers-guide [accessed 2026-04-17] *(Zuplo product + buyer's guide; edge deployment across 300+ points of presence.)* { #cite-7 }
+8. **Red Hat Developer** — Advanced authentication and authorization for MCP Gateway — https://developers.redhat.com/articles/2025/12/12/advanced-authentication-authorization-mcp-gateway [accessed 2026-04-17] *(OPA-style policy enforcement and credential-brokering patterns applied to MCP gateways.)* { #cite-8 }
+9. **Integrate.io** — Best MCP Gateways and AI Agent Security Tools (2026) — https://www.integrate.io/blog/best-mcp-gateways-and-ai-agent-security-tools/ [accessed 2026-04-17] *(2026 roundup; useful cross-check of vendor feature claims.)* { #cite-9 }
+10. **AWS (docs)** — Amazon Bedrock AgentCore Gateway: developer guide — https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html [accessed 2026-04-17] *(Canonical documentation for AgentCore Gateway, target types (Lambda, OpenAPI, Smithy, MCP servers).)* { #cite-10 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/glossary/mcp-gateway/](https://www.exploreagentic.ai/glossary/mcp-gateway/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/glossary/model-context-protocol.md
+++ b/docs/explore-agentic/glossary/model-context-protocol.md
@@ -1,0 +1,96 @@
+# Model Context Protocol (MCP)
+
+*Also known as: MCP · 7 min · Updated April 17, 2026 · Author Alexander · Reviewed by Ryo Hang*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/glossary/model-context-protocol/](https://www.exploreagentic.ai/glossary/model-context-protocol/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Definition
+
+<strong>Model Context Protocol (MCP)</strong> is an open JSON-RPC 2.0 specification that standardizes how language-model clients exchange context and invoke tools on external servers. Anthropic released the first draft on November 25, 2024 <a href="#cite-1" class="cite-ref">[1]</a>, and donated the project to the Agentic AI Foundation under the Linux Foundation on December 9, 2025 <a href="#cite-2" class="cite-ref">[2]</a>. As of March 2026, combined Python and TypeScript SDK downloads passed 97 million per month <a href="#cite-3" class="cite-ref">[3]</a>.
+
+## Where MCP came from
+
+Anthropic open-sourced MCP on November 25, 2024, with reference servers for Google Drive, Slack, GitHub, Git, Postgres, and Puppeteer, and SDKs in Python, TypeScript, C#, and Java <a href="#cite-1" class="cite-ref">[1]</a>. Block and Apollo were the first two named enterprise adopters. The framing was narrow: end the bilateral integration problem where every AI client re-invented its own way to call tools.
+
+Adoption moved faster than the launch deck predicted. By April 2025 monthly SDK downloads had crossed 8 million. By March 2026 the number had reached 97 million, a 970x lift in eighteen months <a href="#cite-3" class="cite-ref">[3]</a>. OpenAI added MCP support in March 2025, Microsoft in July 2025, and AWS through Bedrock AgentCore in October 2025 <a href="#cite-4" class="cite-ref">[4]</a>.
+
+On December 9, 2025, Anthropic announced it would donate MCP to the newly formed Agentic AI Foundation (AAIF), a directed fund under the Linux Foundation co-founded with Block and OpenAI <a href="#cite-2" class="cite-ref">[2]</a>. Supporting members include Google, Microsoft, AWS, Cloudflare, Bloomberg, and Intuit <a href="#cite-5" class="cite-ref">[5]</a>. For CISOs who had quietly flagged single-vendor governance as a procurement risk, that was the threshold event.
+
+## The three roles in the spec, and the fourth that emerged
+
+The specification names three participants. A <strong>client</strong> renders the interaction to the user. Examples include Claude Desktop, Cursor, ChatGPT, Microsoft Copilot, Visual Studio Code, and roughly three hundred others as of April 2026. A <strong>host</strong> runs the model and orchestrates the tool-call loop. A <strong>server</strong> exposes data, prompts, or tools through a JSON-RPC 2.0 surface <a href="#cite-6" class="cite-ref">[6]</a>.
+
+Production deployments added a fourth role the spec does not describe: the <strong>gateway</strong>. A gateway sits between many clients and many servers, authenticates each call, enforces per-tool policy, logs the traffic, and brokers enterprise credentials so the user never pastes a Snowflake PAT into a prompt. AWS ships one as AgentCore Gateway; Cloudflare ships one as MCP Server Portals. We cover the pattern in the MCP Gateway entry.
+
+## Authorization, briefly
+
+The auth surface is the part that moved the most. An MCP server acts as an OAuth 2.1 resource server; the MCP client is an OAuth 2.1 client making protected-resource requests on behalf of the user. Three revisions mattered for procurement: June 2025 split the MCP server from the authorization server and introduced Protected Resource Metadata under RFC 9728; November 2025 made PKCE mandatory and replaced ad-hoc client registration with Client ID Metadata Documents; March 15, 2026 made RFC 8707 resource indicators mandatory to prevent token mis-redemption between tools <a href="#cite-7" class="cite-ref">[7]</a>.
+
+This term is often misused. For example, vendors claiming "MCP auth" that have not implemented RFC 8707 resource indicators are a full spec revision behind as of April 2026. The short due-diligence question: does the server validate the resource indicator on every token?
+
+## Why enterprise buyers care
+
+Before MCP, integration was bilateral. After MCP, tooling is portable: the same GitHub server works in Claude, Cursor, and ChatGPT. That shifts the vendor-lock conversation away from the integration layer (where it was always a dead weight) toward the model and platform layers, where honest procurement discussions can happen.
+
+The Nerq Q1 2026 census indexed 17,468 MCP servers across registries, though only 12.9% scored "high trust" on documentation, maintenance, and reliability <a href="#cite-8" class="cite-ref">[8]</a>. The practical reading: a long tail exists, curation remains a real problem, and programs that vet servers against the AAIF governance process run into fewer surprises.
+
+> **Read the pillar**: The long-form version of this entry (four roles in production, the complete auth timeline, gateway vendor comparisons) is the MCP pillar at /mcp. It carries the same numbered citations this entry does.
+
+## See Also
+
+- [MCP Gateway](mcp-gateway.md)
+- [Agentic RAG](agentic-rag.md)
+- [Agent observability](agent-observability.md)
+- [MCP pillar](../pillars/mcp.md)
+
+## FAQ
+
+**Q: What is the Model Context Protocol (MCP)?**
+
+The wire protocol that lets an AI client call tools and read data from external servers over JSON-RPC 2.0. Anthropic released the first draft on November 25, 2024. Three roles in the spec. Client. Server. Host. Auth is OAuth 2.1. Governance moved to the Agentic AI Foundation, a Linux Foundation directed fund, on December 9, 2025. The supporting members read like a list of companies that rarely sign the same document: Anthropic, OpenAI, Block, Google, Microsoft, AWS, Cloudflare, Bloomberg. Which is the main reason CISOs stopped flagging it as a single-vendor risk.
+
+**Q: Who created MCP and who governs it today?**
+
+Anthropic, on November 25, 2024. Single-vendor origin. CISOs flagged that quietly as a procurement risk for most of 2025, and they were right to. December 9, 2025 closed the objection. Anthropic donated the project to the Agentic AI Foundation (AAIF), a directed fund under the Linux Foundation co-founded with Block and OpenAI. Day-to-day technical direction still sits with the maintainers, guided by the Specification Enhancement Proposal (SEP) process. The neutral-governance conversation now passes the laugh test, which is all most procurement committees were asking for.
+
+**Q: How is MCP different from a REST API or a plugin system?**
+
+A REST API is a bespoke HTTP contract, one per product. A plugin system is vendor-specific by design. MCP is narrower and more useful. A model-facing tool-calling JSON-RPC protocol. Published spec, OAuth 2.1 authorization, SDKs in Python, TypeScript, C#, and Java. The practical payoff is portability. The same GitHub MCP server runs under Claude, ChatGPT, Cursor, Microsoft Copilot, and Visual Studio Code without per-client glue code. That glue is the part that used to eat most of the integration budget.
+
+**Q: How many MCP servers and clients exist?**
+
+The Nerq Q1 2026 census indexed 17,468 servers across registries. Only 12.9% scored high-trust on documentation and maintenance; a long tail exists, and curation is still a real problem. Client support spans roughly 300 products. Claude. ChatGPT. Cursor. Gemini. Microsoft Copilot. Visual Studio Code. Visual Studio 2026 Insiders. Combined Python and TypeScript SDK downloads hit 97 million per month in March 2026, a 970x lift from April 2025's 8 million.
+
+**Q: Does MCP require OAuth?**
+
+For any server exposing protected resources, yes. The current spec treats MCP servers as OAuth 2.1 resource servers. Three revisions shaped what that means in practice. June 2025 split the MCP server from the authorization server under RFC 9728. November 2025 made PKCE mandatory. March 15, 2026 made RFC 8707 resource indicators mandatory. That last one has teeth: the resource parameter must appear in both authorization and token requests, so a token minted for one server cannot be replayed against another. The due-diligence question writes itself. Does your server validate the resource indicator on every token? If the answer hedges, the answer is no.
+
+**Q: What is the difference between MCP and RAG?**
+
+Different layers of the stack. RAG (Retrieval-Augmented Generation) is a pattern for grounding a model's answer in retrieved documents. MCP is a wire protocol for how the model calls tools at all. Orthogonal, not competing. Most production systems end up running both. The MCP server exposes the vector store or SQL engine. The RAG strategy decides how the agent uses it. Pipe on one side, decision-making on top of the pipe. The full side-by-side is at /comparisons/mcp-vs-rag.
+
+## Citations
+
+1. **Anthropic** — Introducing the Model Context Protocol — https://www.anthropic.com/news/model-context-protocol [accessed 2026-04-17] *(November 25, 2024 announcement; reference servers (Drive, Slack, GitHub, Git, Postgres, Puppeteer) and SDK matrix.)* { #cite-1 }
+2. **Anthropic** — Donating the Model Context Protocol and establishing the Agentic AI Foundation — https://www.anthropic.com/news/donating-the-model-context-protocol-and-establishing-of-the-agentic-ai-foundation [accessed 2026-04-17] *(December 9, 2025 donation announcement.)* { #cite-2 }
+3. **Model Context Protocol Blog** — One Year of MCP: November 2025 Spec Release — https://blog.modelcontextprotocol.io/posts/2025-11-25-first-mcp-anniversary/ [accessed 2026-04-17] *(Adoption figures: 97M monthly SDK downloads as of March 2026, 970x lift in 18 months.)* { #cite-3 }
+4. **AWS** — Amazon Bedrock AgentCore is now generally available — https://aws.amazon.com/about-aws/whats-new/2025/10/amazon-bedrock-agentcore-available/ [accessed 2026-04-17] *(October 13, 2025 GA announcement; AgentCore Gateway supports MCP server targets.)* { #cite-4 }
+5. **Linux Foundation** — Linux Foundation Announces the Formation of the Agentic AI Foundation (AAIF) — https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation [accessed 2026-04-17] *(Press release listing founding projects (MCP, goose, AGENTS.md) and supporting members.)* { #cite-5 }
+6. **Model Context Protocol** — Specification, 2025-03-26 revision — https://modelcontextprotocol.io/specification/2025-03-26 [accessed 2026-04-17] *(Canonical spec; defines JSON-RPC 2.0 message shape and the client/server/host roles.)* { #cite-6 }
+7. **Model Context Protocol** — Authorization specification (current draft) — https://modelcontextprotocol.io/specification/draft/basic/authorization [accessed 2026-04-17] *(OAuth 2.1 resource-server model; PKCE mandatory; RFC 8707 resource indicators mandatory from March 15, 2026.)* { #cite-7 }
+8. **Model Context Protocol Blog** — The 2026 MCP Roadmap — https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/ [accessed 2026-04-17] *(Roadmap for transports, agent communication, governance maturation, enterprise readiness.)* { #cite-8 }
+9. **TechCrunch** — OpenAI, Anthropic, and Block join new Linux Foundation effort to standardize the AI agent era — https://techcrunch.com/2025/12/09/openai-anthropic-and-block-join-new-linux-foundation-effort-to-standardize-the-ai-agent-era/ [accessed 2026-04-17] *(December 9, 2025 reporting on the AAIF formation.)* { #cite-9 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/glossary/model-context-protocol/](https://www.exploreagentic.ai/glossary/model-context-protocol/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/glossary/nist-ai-rmf.md
+++ b/docs/explore-agentic/glossary/nist-ai-rmf.md
@@ -1,0 +1,102 @@
+# NIST AI Risk Management Framework
+
+*Also known as: NIST AI RMF, AI RMF 1.0 · 7 min · Updated April 17, 2026 · Author Merve Tengiz · Reviewed by Gloria Qian Zhang*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/glossary/nist-ai-rmf/](https://www.exploreagentic.ai/glossary/nist-ai-rmf/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Definition
+
+The <strong>NIST AI Risk Management Framework</strong> (AI RMF 1.0) is a voluntary risk-management framework published by the US National Institute of Standards and Technology on January 26, 2023, as NIST AI 100-1 <a href="#cite-1" class="cite-ref">[1]</a>. It gives organizations a common vocabulary and a four-function working model (GOVERN, MAP, MEASURE, MANAGE) for identifying and managing AI risk across the lifecycle. Not certifiable. But federal agencies, critical-infrastructure operators, and most US-based enterprises treat it as the default reference anyway. Which is where the teeth actually are.
+
+## The four functions, plainly
+
+The framework is organised around four functions <a href="#cite-2" class="cite-ref">[2]</a>. They are not sequential; they run in parallel across the AI lifecycle, and the standard explicitly describes GOVERN as cross-cutting, operating alongside the other three at all times.
+
+1. **GOVERN** — Cultivate a risk culture inside the organization. Establish policies, accountability structures, roles, and a process for mapping, measuring, and managing AI risk. Applies across the whole lifecycle.
+2. **MAP** — Identify the context and categorise the risks of an AI system: what it is, who it affects, where it is deployed, what could go wrong. MAP comes first in the workflow but is not done once.
+3. **MEASURE** — Analyse, assess, benchmark, and monitor AI risks and their impacts. Quantitative where possible, qualitative where necessary.
+4. **MANAGE** — Allocate resources, prioritise risks, and respond (accept, transfer, avoid, or mitigate). Includes incident response and the communication pathways back to GOVERN.
+
+## The documents, in order
+
+*The NIST AI RMF document family, as of April 2026*
+
+| Date | Document |
+| --- | --- |
+| January 26, 2023 | AI RMF 1.0 (NIST AI 100-1): the foundational framework. Introduced the four functions and the voluntary adoption model [1]. |
+| July 26, 2024 | NIST AI 600-1, the Generative AI Profile. Applied AI RMF to generative models, flagging risks (hallucination, data leakage, CBRN, dangerous capabilities) that the 2023 base document did not name explicitly. Focused on four priority considerations: Governance, Content Provenance, Pre-deployment Testing, and Incident Disclosure [3]. |
+| December 2025 | Draft NIST Cybersecurity Framework Profile for AI (NIST IR 8596 iprd): cross-walks AI RMF to NIST CSF 2.0 [5]. |
+| April 7, 2026 | Concept note for an AI RMF Profile on Trustworthy AI in Critical Infrastructure. Addresses the 16 critical-infrastructure sectors (energy, water, health care, finance, transportation, etc.) and aligns AI risk with OT/ICS resilience and legacy-system constraints [4]. |
+
+## How it relates to ISO/IEC 42001
+
+AI RMF and ISO 42001 are complementary, not alternatives. ISO 42001 defines the management system: what structure, roles, and processes your organization needs. AI RMF defines the risk work you do inside the system, namely how you actually map, measure, and manage specific AI risks.
+
+In practice, organizations running both produce a combined control-mapping document. It takes about two days once the ISO 42001 scope is set. Regulators and auditors increasingly ask for both citations side by side.
+
+## How teams actually use it
+
+- As a vocabulary. The four-function language lets governance, legal, engineering, and procurement talk about the same risks without re-inventing taxonomy every meeting.
+- As an audit anchor. Even when certification is not the goal, pointing to AI RMF controls is the cheapest way to make an external auditor comfortable.
+- As a procurement filter. Public-sector and federally-adjacent buyers increasingly require vendors to reference AI RMF functions in their risk documentation.
+- As an onboarding curriculum. New governance hires can learn the AI RMF functions in a week and immediately contribute to a risk map.
+
+> **If you are starting a governance program**: Read the AI RMF 1.0 core document first (about 48 pages, free). Then read the Generative AI Profile (NIST AI 600-1) if you ship generative features. Then, if relevant, the Critical Infrastructure concept note. ISO 42001 is the next layer; do it after you have a working AI RMF mapping, not before.
+
+## See Also
+
+- [ISO/IEC 42001](iso-42001.md)
+- [AI Governance pillar](../pillars/ai-governance.md)
+- [Shadow AI](shadow-ai.md)
+- [Agent observability](agent-observability.md)
+
+## FAQ
+
+**Q: What is the NIST AI Risk Management Framework?**
+
+A voluntary framework, published as NIST AI 100-1 on January 26, 2023. It gives organizations a common vocabulary and a four-function working model (GOVERN, MAP, MEASURE, MANAGE) for identifying and managing AI risk across the lifecycle. Not certifiable. But federal agencies, critical-infrastructure operators, and most US-based enterprises treat it as the default reference. Voluntary on paper. Defaults drive procurement conversations in practice.
+
+**Q: What are the four functions of the NIST AI RMF?**
+
+Four functions. GOVERN: cross-cutting risk culture, policies, accountability. MAP: identify context, categorise risks. MEASURE: analyse, assess, benchmark, monitor. MANAGE: allocate resources, prioritise, respond (accept, transfer, avoid, mitigate). Not sequential. They run in parallel across the AI lifecycle, and GOVERN operates alongside the other three at all times. That last point is the one teams miss on their first pass.
+
+**Q: What is the NIST AI 600-1 Generative AI Profile?**
+
+NIST AI 600-1, released July 26, 2024. A cross-sectoral profile of the AI RMF for generative AI, pursuant to Executive Order 14110. It adapts the four functions to GAI-specific risks the 2023 base document did not name: hallucination, data leakage, CBRN concerns, disinformation. Four priority considerations. Governance. Content Provenance. Pre-deployment Testing. Incident Disclosure. The last one is the one that makes legal teams read the document twice.
+
+**Q: Is there a NIST AI RMF profile for critical infrastructure?**
+
+Yes, in progress. NIST released a concept note on April 7, 2026 for an AI RMF Profile on Trustworthy AI in Critical Infrastructure. Scope is big. All 16 critical-infrastructure sectors: energy, water, health care, finance, transportation, and the rest. The profile will tailor AI risk management to the operational realities of those sectors. Legacy systems. Physically distributed assets. Resourcing constraints. NIST is forming a Community of Interest to drive the work. If your organization touches any of the 16 sectors, get involved early; the authors listen.
+
+**Q: Is NIST AI RMF certifiable?**
+
+No. Voluntary framework, no certification scheme, no auditor, no certificate. The closest certifiable standard is ISO/IEC 42001. Most organizations running both use them in the same sentence: ISO 42001 provides the certifiable management system, NIST AI RMF provides the risk-assessment work that happens inside it. NIST publishes an explicit ISO 42001 crosswalk to support the pairing. About two days of work to map the two once ISO scope is set.
+
+**Q: How is NIST AI RMF used in federal procurement?**
+
+Heavily. US federal procurement and critical-infrastructure vendor evaluations increasingly require vendors to reference AI RMF functions in their risk documentation. No AI RMF-aligned governance program, no federal contract; that's the short version. The friction shows up earliest in public-sector and federally-adjacent enterprise sales. By the time it reaches the CFO it is a line item in sales velocity, not a policy document.
+
+## Citations
+
+1. **NIST** — AI RMF 1.0: Artificial Intelligence Risk Management Framework (NIST AI 100-1) — https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf [accessed 2026-04-17] *(Canonical January 26, 2023 PDF. 48 pages; defines the four-function core.)* { #cite-1 }
+2. **NIST** — AI Risk Management Framework — https://www.nist.gov/itl/ai-risk-management-framework [accessed 2026-04-17] *(NIST AI RMF landing page; links to playbook, profiles, and ISO 42001 crosswalk.)* { #cite-2 }
+3. **NIST** — NIST AI 600-1: Generative Artificial Intelligence Profile — https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf [accessed 2026-04-17] *(July 26, 2024 release. Pursuant to EO 14110; four priority considerations: Governance, Content Provenance, Pre-deployment Testing, Incident Disclosure.)* { #cite-3 }
+4. **NIST** — Concept Note: AI RMF Profile on Trustworthy AI in Critical Infrastructure — https://www.nist.gov/programs-projects/concept-note-ai-rmf-profile-trustworthy-ai-critical-infrastructure [accessed 2026-04-17] *(April 7, 2026 concept note; invites feedback from critical-infrastructure community.)* { #cite-4 }
+5. **NIST** — Draft NIST Guidelines Rethink Cybersecurity for the AI Era (IR 8596) — https://www.nist.gov/news-events/news/2025/12/draft-nist-guidelines-rethink-cybersecurity-ai-era [accessed 2026-04-17] *(December 2025 draft Cybersecurity Framework Profile for AI; crosswalks AI RMF to CSF 2.0.)* { #cite-5 }
+6. **NIST** — AI RMF Playbook — https://www.nist.gov/itl/ai-risk-management-framework/nist-ai-rmf-playbook [accessed 2026-04-17] *(Living document with suggested actions for each AI RMF subcategory.)* { #cite-6 }
+7. **Wiley Rein LLP** — NIST Releases AI Risk Management Framework, Expected to Be a Critical Tool for Trustworthy AI Deployment — https://www.wileyconnect.com/nist-releases-ai-risk-management-framework-expected-to-be-a-critical-tool-for-trustworthy-ai-deployment [accessed 2026-04-17] *(Legal analysis of AI RMF 1.0 on publication; context for federal procurement impact.)* { #cite-7 }
+8. **Industrial Cyber** — NIST develops Trustworthy AI in Critical Infrastructure Profile — https://industrialcyber.co/nist/nist-develops-trustworthy-ai-in-critical-infrastructure-profile-to-align-risk-resilience-and-infrastructure-security/ [accessed 2026-04-17] *(Coverage of the April 2026 critical-infrastructure profile concept note.)* { #cite-8 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/glossary/nist-ai-rmf/](https://www.exploreagentic.ai/glossary/nist-ai-rmf/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/glossary/shadow-ai.md
+++ b/docs/explore-agentic/glossary/shadow-ai.md
@@ -1,0 +1,97 @@
+# Shadow AI
+
+*Also known as: Unsanctioned AI, Bring-your-own AI · 7 min · Updated April 17, 2026 · Author Gloria Qian Zhang · Reviewed by Michael Clough*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/glossary/shadow-ai/](https://www.exploreagentic.ai/glossary/shadow-ai/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Definition
+
+<strong>Shadow AI</strong> is the use of AI tools (most often consumer generative-AI services, but also SaaS-embedded AI features and model integrations built by individual teams) outside the visibility and control of the organization's IT, security, and governance functions. Every mature AI governance program discovers it. IBM's 2025 Cost of a Data Breach Report found that breaches involving shadow AI cost $670,000 more than standard incidents, with one in five organizations (20%) experiencing a shadow-AI-linked breach <a href="#cite-1" class="cite-ref">[1]</a>.
+
+## What counts as shadow AI
+
+The canonical case is an employee pasting sensitive data into ChatGPT from a personal account, but that is only the visible layer. The 2024 Microsoft and LinkedIn Work Trend Index reported that 78% of AI users brought their own AI to work, and 71% of office workers admitted using AI tools without IT approval <a href="#cite-2" class="cite-ref">[2]</a>. In every AI inventory exercise, three categories consistently surface, and each requires a different remediation path.
+
+- Personal-account use of consumer AI services (ChatGPT, Claude, Gemini, Perplexity) with corporate data. Surfaces from DLP alerts and, occasionally, an amnesty program.
+- SaaS tools that quietly added generative features in a recent release: Notion AI, Slack AI, Zoom AI Companion, Salesforce Einstein GPT, and dozens of smaller tools. Surfaces from procurement and SSO logs.
+- Team-built integrations: a marketing analyst wiring OpenAI into a Google Sheet, a data engineer running a local llama.cpp on production data, an acquired subsidiary running its own models. Surfaces only from network telemetry and conversations.
+
+## Why it is not just shadow IT
+
+Shadow IT is an access-control problem: someone is using a tool without approval. Shadow AI adds two complications that make it materially harder. First, the data leaves: any conversation with an external model potentially trains on, caches, or logs the content you sent, depending on the provider's terms and your account tier. Second, the output comes back: an employee who drafts a contract clause in an unapproved model then pastes that clause into a real document, and nobody knows which clauses were machine-written.
+
+That dual flow (data out, output in) is the part that breaks simple blocking strategies. Samsung's 2023 company-wide ChatGPT ban did not stop AI adoption; it pushed it underground and made the governance problem worse <a href="#cite-3" class="cite-ref">[3]</a>. The working approach is visibility first, policy second. IBM's 2025 data-breach report found that 97% of organizations with shadow-AI-linked breaches lacked proper AI access controls <a href="#cite-1" class="cite-ref">[1]</a>.
+
+## How to surface it
+
+1. **Start with SSO logs** — Enumerate every SaaS tool in the corporate identity catalog that has added a generative feature. The top 200 tools will cover the bulk of the exposure. This is a one-afternoon exercise that most organizations have never run.
+2. **Cross-reference procurement records** — Search the last 24 months of procurement and expense data for strings like "AI", "copilot", "agent", "assistant", "LLM", and "GPT". Each hit is a candidate for the inventory.
+3. **Review DLP egress telemetry** — Most enterprise DLP platforms now flag traffic to consumer AI services. Turn on the category and measure for 30 days. The volume is rarely what leadership expects.
+4. **Run a one-week amnesty** — Ask employees to register the AI tools they actually use, without punishment. You will learn more in a week than in a quarter of top-down discovery.
+5. **Refresh monthly, not annually** — Shadow AI inventories decay. The annual governance refresh is theatre; monthly is the lowest cadence that survives contact with reality.
+
+## What a governance response looks like
+
+Ban-everything approaches fail. Unregulated-everything approaches fail. The governance pattern that works, in practice, has three parts: provide a sanctioned alternative (usually an enterprise LLM with DLP, logging, and retention controls) so employees have a legitimate path; publish a plain-language use policy describing what data can and cannot leave the sanctioned alternative; and monitor for drift with the inventory process above.
+
+Jarvis, like every serious enterprise LLM platform, exists partly to make the sanctioned-alternative story credible: DLP, RBAC, audit logs, and multi-model routing in one layer. That is not the point of this entry; we mention it only because we would be dishonest if we pretended the sanctioned-alternative slot was filled by a competitor on this site.
+
+> **The single best habit**: Put shadow-AI inventory on the same monthly cadence as patch compliance. One owner, one dashboard, same meeting. Governance programs that treat it as a "project" rediscover the same surface area six months later; programs that treat it as a rolling obligation don't.
+
+## See Also
+
+- [AI Governance pillar](../pillars/ai-governance.md)
+- [ISO/IEC 42001](iso-42001.md)
+- [NIST AI RMF](nist-ai-rmf.md)
+- [MCP Gateway](mcp-gateway.md)
+
+## FAQ
+
+**Q: What is shadow AI?**
+
+The use of AI tools outside the visibility and control of IT, security, and governance. Consumer services: ChatGPT, Claude, Gemini, Perplexity. SaaS-embedded AI features. Team-built integrations a data engineer wired up on a Tuesday. Shadow IT, with two extra problems nobody budgeted for. The data leaves the organization (to provider servers, caches, or training sets). The machine-generated output returns into real documents with no audit trail. Both directions are a problem; the second one is the one that bites quietly.
+
+**Q: How costly is shadow AI?**
+
+Costly enough to change the conversation. IBM's 2025 Cost of a Data Breach Report put the average shadow-AI breach at $4.63 million. That's $670,000 above a standard incident. One in five organizations (20%) reported a shadow-AI-linked breach. Of those, 97% lacked proper AI access controls. The exposure skewed toward customer PII and intellectual property, which are the two categories that turn a breach into a regulator conversation.
+
+**Q: How widespread is shadow AI?**
+
+Widespread enough that "surface area" is the wrong question. The 2024 Microsoft and LinkedIn Work Trend Index put 78% of AI users bringing their own AI to work. 71% of office workers admitted to using AI tools without IT approval. More recent 2025 data pegs shadow-AI usage at around 37% of staff as a persistent corporate-security concern. Which means any governance program that assumes employees will wait for a sanctioned alternative is already six months behind.
+
+**Q: Can I just block ChatGPT to stop shadow AI?**
+
+No. Samsung tried a company-wide ChatGPT ban in 2023. The ban did not stop adoption. It pushed it onto personal devices, where DLP could not see any of it. The pattern that works in 2026 has three moves. Provide a sanctioned enterprise alternative (ChatGPT Enterprise, Microsoft Copilot, or an internal LLM platform). Publish a plain-language use policy people will actually read. Monitor for drift on the same cadence as patch compliance. Banning without an alternative is the shortest path to losing visibility entirely.
+
+**Q: How do I surface shadow AI in my organization?**
+
+Five steps, in order. Start with SSO logs; the top 200 SaaS tools cover most of the exposure. Cross-reference the last 24 months of procurement records for strings like 'AI', 'copilot', 'agent', 'assistant', 'LLM', 'GPT'. Turn on DLP egress telemetry to consumer AI services and measure for 30 days. Run a one-week amnesty where employees register what they actually use, no punishment. Then refresh monthly, not annually. Annual discovery is theatre; monthly is the lowest cadence that survives contact with reality.
+
+**Q: What tools help detect shadow AI?**
+
+Several, each solving a different slice. Microsoft Purview AI Hub is the most mature option for Microsoft 365 environments. Cloudflare Gateway's shadow-MCP scans, rolled out in 2026, extend detection to MCP servers specifically. Nudge Security. Torii. Vectra. Proofpoint. Each publishes shadow-AI-specific detection features, and the right answer is usually two of them, not one; the overlap is how you catch the thing the primary tool misses.
+
+## Citations
+
+1. **IBM** — Cost of a Data Breach Report 2025 — https://www.ibm.com/reports/data-breach [accessed 2026-04-17] *(Shadow AI added $670K to the average breach cost; 20% of organizations reported shadow-AI-linked breaches; 97% of those lacked AI access controls.)* { #cite-1 }
+2. **Microsoft** — 2025 Annual Work Trend Index — https://news.microsoft.com/annual-work-trend-index-2025/ [accessed 2026-04-17] *(2024 Work Trend Index data: 78% of AI users bring their own AI; 71% use AI without IT approval.)* { #cite-2 }
+3. **CloudEagle** — ChatGPT Enterprise Security: How To Govern Your AI in 2026 — https://www.cloudeagle.ai/blogs/chatgpt-enterprise-security [accessed 2026-04-17] *(Samsung 2023 company-wide ChatGPT ban case study.)* { #cite-3 }
+4. **IBM Newsroom** — 13% Of Organizations Reported Breaches Of AI Models, 97% Lacked AI Access Controls — https://newsroom.ibm.com/2025-07-30-ibm-report-13-of-organizations-reported-breaches-of-ai-models-or-applications,-97-of-which-reported-lacking-proper-ai-access-controls [accessed 2026-04-17] *(July 30, 2025 press release.)* { #cite-4 }
+5. **Microsoft (Edge Blog)** — Protect your enterprise from shadow AI: Announcements at RSAC 2026 — https://blogs.windows.com/msedgedev/2026/03/23/protect-your-enterprise-from-shadow-ai-and-more-announcements-at-rsac-2026/ [accessed 2026-04-17] *(March 23, 2026 Microsoft briefing on enterprise shadow-AI detection.)* { #cite-5 }
+6. **Microsoft** — Microsoft Purview (AI Hub) — https://www.microsoft.com/en-us/security/business/microsoft-purview [accessed 2026-04-17] *(Purview AI Hub for SaaS-embedded AI discovery and DLP.)* { #cite-6 }
+7. **Kiteworks** — How Shadow AI Costs Companies $670K Extra: IBM's 2025 Breach Report — https://www.kiteworks.com/cybersecurity-risk-management/ibm-2025-data-breach-report-ai-risks/ [accessed 2026-04-17] *(Analysis of shadow-AI breach cost premium.)* { #cite-7 }
+8. **Nudge Security** — Shadow AI: The emerging security threat in IBM's 2025 Cost of a Data Breach Report — https://www.nudgesecurity.com/post/shadow-ai-the-emerging-security-threat-in-ibms-2025-cost-of-a-data-breach-report [accessed 2026-04-17] *(Practitioner analysis of shadow-AI governance gaps.)* { #cite-8 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/glossary/shadow-ai/](https://www.exploreagentic.ai/glossary/shadow-ai/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/index.md
+++ b/docs/explore-agentic/index.md
@@ -1,0 +1,60 @@
+# Explore Agentic Jarvis
+
+> Field guides, glossary entries, and side-by-sides on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG. Reading material curated alongside the Jarvis Registry — every page is dated, cited, and reviewed before publication.
+
+!!! info "About this section"
+
+    Articles in this tab are sourced from [Explore Agentic](https://www.exploreagentic.ai), the editorial site published by ASCENDING Inc. — the same company that builds Jarvis. Comparisons that include Jarvis are flagged on the row and on the page.
+
+## Library
+
+<div class="grid cards" markdown>
+
+-   :material-pillar:{ .lg .middle } &nbsp; **Pillars**
+
+    ---
+
+    Long-read field guides on the four pillars: agentic AI runtimes, the Model Context Protocol, AI governance, and enterprise RAG.
+
+    [:octicons-arrow-right-24: Read pillars](pillars/index.md)
+
+-   :material-book-open-page-variant:{ .lg .middle } &nbsp; **Glossary**
+
+    ---
+
+    Short, careful entries on the terms that actually move budget and risk in 2026 enterprise AI procurement.
+
+    [:octicons-arrow-right-24: Browse glossary](glossary/index.md)
+
+-   :material-compare-horizontal:{ .lg .middle } &nbsp; **Comparisons**
+
+    ---
+
+    Honest side-by-sides — including where Jarvis loses. Built from public docs, AWS Marketplace listings, and analyst commentary.
+
+    [:octicons-arrow-right-24: See comparisons](comparisons/index.md)
+
+-   :material-clipboard-check-outline:{ .lg .middle } &nbsp; **Playbooks**
+
+    ---
+
+    Step-by-step guides for the work people quietly need to do: measuring ROI, picking a gateway, running an internal eval.
+
+    [:octicons-arrow-right-24: Read playbooks](playbooks/index.md)
+
+</div>
+
+## Editorial disclosure
+
+Explore Agentic is published by ASCENDING Inc., which also builds Jarvis AI and Jarvis Registry. Any page on this site that mentions Jarvis or a direct competitor surfaces this disclosure at the top of the page. Comparison tables involving Jarvis flag the Jarvis row.
+
+---
+
+## Visit Explore Agentic
+
+The articles in this tab are mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — the canonical home for our long-reads, glossary, comparisons, and playbooks. Each page below links back to its original source.
+
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)
+- **Jarvis on Explore Agentic**: [www.exploreagentic.ai/jarvis/](https://www.exploreagentic.ai/jarvis/)
+- **About the publisher (ASCENDING)**: [www.exploreagentic.ai/about/](https://www.exploreagentic.ai/about/)

--- a/docs/explore-agentic/pillars/agentic-ai.md
+++ b/docs/explore-agentic/pillars/agentic-ai.md
@@ -1,0 +1,159 @@
+# Agentic AI, minus the agent-washing
+
+> A field guide to autonomous agents in 2026: the five tells that separate real agentic AI from a rebadged chatbot, the runtimes that matter (Strands, Microsoft Agent Framework, LangGraph, CrewAI, OpenAI Agents SDK), and the workloads where agents earn their keep.
+
+*Pillar · Agentic AI · 18 minutes · Updated April 17, 2026 · Author Michael Clough · Reviewed by Ryo Hang*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/agentic-ai/](https://www.exploreagentic.ai/agentic-ai/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Intro
+
+The phrase <strong>agentic AI</strong> covers too much ground. It is a research agenda, a product category, a budget line, and (most of the time in vendor decks) last year's chatbot with a new deck cover. Gartner put numbers on the noise in June 2025: roughly 130 of the several thousand vendors claiming agentic capability ship anything that qualifies, and over 40% of agentic AI projects are forecast to be cancelled by the end of 2027 <a href="#cite-1" class="cite-ref">[1]</a>. That is the backdrop for everything below.
+
+This pillar walks the category from the definition down to the runtimes. The useful distinction is not agent versus not-agent. It is between systems that can rewrite their own plan mid-execution and systems that cannot. That line predicts which workloads get automated, which earn their seven-figure platform bills, and which keep a human in the loop for reasons no amount of tool-use fine-tuning will fix <a href="#cite-2" class="cite-ref">[2]</a>.
+
+## TL;DR
+
+- An agent is a loop that observes, reasons, acts, and can replan without a human click. Everything else is a workflow with a language model attached.
+- Gartner estimates only about 130 of the thousands of self-described agentic vendors are real; over 40% of agentic AI projects will be cancelled by end of 2027 on cost, unclear value, or inadequate risk controls <a href="#cite-1" class="cite-ref">[1]</a>.
+- The runtime field consolidated in 2025. LangGraph 1.0 (Oct 2025), AWS Strands Agents 1.0 (July 15, 2025), Microsoft Agent Framework public preview (Oct 1, 2025) and 1.0 GA (April 3, 2026), OpenAI Agents SDK (March 2025), and CrewAI now cover roughly every serious enterprise procurement <a href="#cite-3" class="cite-ref">[3]</a><a href="#cite-4" class="cite-ref">[4]</a><a href="#cite-5" class="cite-ref">[5]</a>.
+- Agents are earning their keep in bounded, evidence-rich workflows. Salesforce's own Agentforce deployment handled 1.5M+ support cases and generated $1.7M of new sales pipeline in year one <a href="#cite-6" class="cite-ref">[6]</a>.
+- Guardian agents (AI systems that supervise other AI systems) will hold 10-15% of the agentic market by 2030 per Gartner <a href="#cite-7" class="cite-ref">[7]</a>. The category is real; the marketing around it is still early.
+
+## Stats
+
+- **~130 / thousands** — real agentic vendors vs. claimants (Gartner, Jun 2025) *(Anushree Verma, Gartner Sr Director Analyst, on agent washing. Source [1].)*
+- **Jul 15, 2025** — AWS Strands Agents 1.0 shipped *(Production-ready multi-agent orchestration with Swarms, Graphs, Agents-as-Tools, Handoffs. Source [4].)*
+- **Apr 3, 2026** — Microsoft Agent Framework 1.0 GA *(AutoGen + Semantic Kernel convergence; public preview was October 1, 2025. Source [5].)*
+- **10-15% by 2030** — guardian-agent share of agentic market *(Gartner's June 11, 2025 prediction. Source [7].)*
+
+## 01. What qualifies as an agent
+
+Strip the marketing. An agent is a loop: a system that observes state, decides the next action with some freedom of choice, and can revise that decision when new information arrives. The last clause is where most <em>agentic</em> products fail the definition. They replan only when a human clicks a button, which makes them workflow engines with a nicer frontend.
+
+Russell and Norvig formalised the taxonomy a quarter-century ago: simple reflex, model-based, goal-based, utility-based, learning. The terms survive because they still map onto shipping code. Most enterprise deployments in April 2026 are <strong>goal-based agents with a utility function bolted on</strong>: a planning model that scores candidate actions, a tool-use harness that can retry or substitute a tool, and a memory store that lets the agent carry context across turns without asking the user to paste it back.
+
+The tell that matters in a procurement meeting is simpler than the taxonomy suggests. Ask the vendor what happens when step three of a five-step plan fails. If the answer is <em>the user gets an error</em>, it is not an agent. If the answer is <em>the planner re-scores, picks an alternative tool, and continues</em>, it is. Write that into the evaluation rubric before the demo starts.
+
+> The question is not whether it is an agent. The question is whether it can change its mind without asking permission.
+
+## 02. The runtime field consolidated faster than expected
+
+As of April 2026, five runtimes cover most serious enterprise procurement. <strong>LangGraph</strong> is the LangChain team's stateful graph runtime; its 1.0 release landed in October 2025 and the LangGraph Platform is generally available for long-running deployments, with nearly 400 companies running agents on it through beta <a href="#cite-3" class="cite-ref">[3]</a>. <strong>AWS Strands Agents</strong> shipped 1.0 on July 15, 2025 with four orchestration patterns (Swarms, Graphs, Agents-as-Tools, Handoffs) and model-agnostic support across Bedrock, Anthropic, Ollama, Meta, and LiteLLM providers <a href="#cite-4" class="cite-ref">[4]</a>.
+
+<strong>Microsoft Agent Framework</strong> entered public preview on October 1, 2025 and shipped 1.0 GA on April 3, 2026, explicitly the convergence of AutoGen and Semantic Kernel into one SDK, with A2A and MCP interop baked in <a href="#cite-5" class="cite-ref">[5]</a>. <strong>OpenAI's Agents SDK</strong> launched in March 2025 alongside the Responses API, which the company now recommends over Chat Completions for new work; the older Assistants API is deprecated with a sunset date of August 26, 2026 <a href="#cite-8" class="cite-ref">[8]</a>. <strong>CrewAI</strong> is the independent holdout; its AMP suite and Flows architecture power a claimed 1.4 billion agentic automations at customers including PwC, IBM, Capgemini, and NVIDIA <a href="#cite-9" class="cite-ref">[9]</a>.
+
+Worth noticing: the hyperscalers converged on open-source SDKs with commercial runtimes, not closed platforms. That is a different industry structure than we had in early 2025, and it changes the exit-cost calculation on every procurement.
+
+*Production agent runtimes, April 2026. Status and source links verified via vendor documentation.*
+
+| Runtime | Backing org | Milestone | Strength |
+| --- | --- | --- | --- |
+| LangGraph | LangChain | 1.0 Oct 2025; Platform GA | Stateful graphs, durable execution, strong OSS community |
+| AWS Strands Agents | AWS Open Source | 1.0 GA Jul 15, 2025 | Model-agnostic, native Bedrock AgentCore integration |
+| Microsoft Agent Framework | Microsoft | Preview Oct 1, 2025; 1.0 GA Apr 3, 2026 | AutoGen + Semantic Kernel, .NET + Python, MCP/A2A |
+| OpenAI Agents SDK | OpenAI | Mar 2025; Responses API default | Built-in web_search, file_search, computer_use, MCP |
+| CrewAI + AMP | CrewAI Inc. | Enterprise-GA; on-prem + cloud | Role-based multi-agent, explicit enterprise tenancy |
+
+## 03. Where agents are earning their keep
+
+The honest list of production-grade agentic workloads is shorter than the conference circuit suggests, and long enough to justify a category. What they share: narrow schemas, structured audit trails, and an outcome metric that closes the loop without a human reviewer in the inner path.
+
+Salesforce's own year-one Agentforce deployment is the clearest public scorecard. The service agent handled more than 1.5 million support requests (the majority resolved without humans) while the SDR agent worked over 43,000 leads and generated $1.7 million in new sales pipeline <a href="#cite-6" class="cite-ref">[6]</a>. Across the broader Agentforce base (18,000+ customers in 124 countries), Salesforce reports over $100 million in annualised cost savings and a 34% productivity lift. Those are vendor figures, but the per-workload specificity of the breakdown is the part to read.
+
+The counter-example every 2026 steering committee cites is <strong>Klarna</strong>. The company claimed its AI assistant had done the work of 700 customer-service agents in 2024; by mid-2025 it began rehiring humans after edge cases, emotional interactions, and multi-step resolutions dragged satisfaction scores down <a href="#cite-10" class="cite-ref">[10]</a>. The lesson is not that agents fail. It is that agents fail on exactly the workloads where <em>complexity</em> is uncorrelated with <em>volume</em>. Pick the wrong workload and scale becomes the enemy.
+
+*Agentic workloads with documented production deployment. Sources: Salesforce Agentforce metrics page, ServiceNow + Moveworks combined customer library, public case studies.*
+
+| Workload | Why it works | Guardrail in place |
+| --- | --- | --- |
+| IT ticket triage and routing | Narrow schema, strong priors | Human approval on tier 2+ escalation |
+| Invoice reconciliation | Structured inputs, complete audit trail | Threshold-gated autonomous close |
+| Compliance document review | Repetitive, low stakes per item | Spot-check sampling at 7-10% |
+| Sales-lead enrichment & routing | Tolerant of imperfect decisions | Outcome metric closes the loop |
+| L1 internal HR/IT support | Bounded intents, logged ground truth | Escalation on confidence drop |
+
+## 04. Five tells of agent washing
+
+Gartner's Anushree Verma named the phenomenon in June 2025. <em>Agent washing</em> is workflow automation, RPA, or chat UX rebranded as agentic capability, and it is the reason Gartner forecasts 40%+ of agentic AI projects to be cancelled by the end of 2027 <a href="#cite-1" class="cite-ref">[1]</a>. The good news: the tells are observable in a forty-minute demo if you know what to look for.
+
+We screen every vendor against the five below. Four or more and the product is a rules engine with a language model bolted on. A review team should agree on scoring before the demo; drift on the <em>replanning</em> criterion alone can turn a 2/5 into a 4/5 depending on who was watching.
+
+- **The demo uses the same three happy-path queries every run.** — Ask for the failure-mode log. Shipped products keep one; prototypes do not.
+- **No eval suite is publicly documented.** — Not a blog post. A numbered suite, versioned, with a changelog and a nightly run posted to a channel.
+- **Replanning requires a human click.** — Watch the state machine. If every branch needs user intent to advance, it is a workflow with conversation on top.
+- **Tool failures surface as user-facing errors.** — An agent that cannot retry, substitute, or escalate a failing tool is not reasoning about tool use in any meaningful sense.
+- **Pricing is per seat, not per successful outcome.** — Outcome-priced agents exist; Agentforce is explicit about it. Seat-priced ones are usually chatbots with a project manager.
+
+## 05. The economics, written by finance not marketing
+
+Serious agentic deployments are not cheap. Industry commentary through 2025 put enterprise first-year program cost in the seven-to-eight-figure range, once you add platform licence, integration partner, and the redirected staff time buyers routinely forget. The programs that survive into year two share one trait. They measure savings against one specific instrumented workflow and report the number to the CFO, on time, without adjustment. The ones that do not, do not renew.
+
+Productivity-minute arithmetic (<em>30 minutes saved per employee per week</em>) is how the first wave embarrassed itself. The March 10, 2025 ServiceNow acquisition of Moveworks at $2.85 billion is a useful data point on what the market pays for a working agentic tier at the employee layer; the deal closed on December 15, 2025 <a href="#cite-11" class="cite-ref">[11]</a>. Futurum's 1H 2026 enterprise-AI reports and CXToday's Agentforce coverage both show the vocabulary shift: <em>direct financial impact</em> is displacing <em>productivity gains</em> in analyst write-ups, which mirrors what buyers now demand in procurement.
+
+Our editorial position, for the record: measure one workflow, instrument the before and after, and refuse to scale the program until you can show a defensible dollar number on the first. Teams that skip the measurement step do not fail at procurement. They fail at renewal.
+
+> **Further reading on this site**: The [AI-agent ROI playbook](../playbooks/ai-agent-roi.md) lays out the CFO-ready framework with a spreadsheet and three questions finance will ask at first review. Agent observability, the category Datadog and LangSmith are building, has its own [glossary entry](../glossary/agent-observability.md). For the plumbing most of these agents rely on, see our [MCP pillar](mcp.md).
+
+## 06. Observability is the part that keeps them running
+
+A production agent without observability is a prototype that pages on-call. The category matured fast in 2025. LangSmith added end-to-end native OpenTelemetry support to its SDK, letting teams pipe agent traces into Datadog, Grafana, Jaeger, or any OTel-compliant backend <a href="#cite-12" class="cite-ref">[12]</a>. AgentCore on AWS and Foundry observability on Azure ship with the same OTel spec so traces cross cloud boundaries without translation.
+
+The specific signals that matter are unglamorous. Per-tool latency and per-tool error rate tell you whether the tool harness is the bottleneck. Per-step outcome flags tell you whether the planner is choosing good actions. Replan counts per conversation tell you whether the agent is thrashing. If a vendor cannot show you all three on a default dashboard, the observability story is a slide deck.
+
+> **Editorial judgment**: Agent observability is where the next wave of procurement pain is hiding. The platform teams we have seen ship cleanly in 2026 all negotiated observability into the initial contract rather than retrofitting it in year two. That one clause has a bigger effect on year-two renewal economics than any other single line item: more than licence discount, more than integration credits. Put it in the RFP.
+
+## FAQ
+
+**Q: What is agentic AI, in one paragraph?**
+
+An agent is a loop. Observe, reason, act, revise the plan mid-run when new information shows up. That last clause is where most products fail the definition. The procurement test is shorter than any taxonomy: can it replan without a human click? Gartner ran the numbers in June 2025 and they were brutal. Roughly 130 vendors meet the bar out of the thousands who claim it <a href="#cite-1" class="cite-ref">[1]</a>. Over 40% of agentic projects will be cancelled by end of 2027, usually on cost, unclear value, or risk controls nobody thought about until the security review (the part buyers forget). Everything else is a workflow with a language model glued on.
+
+**Q: Which agent runtimes should an enterprise team evaluate in 2026?**
+
+Five names cover most procurement. LangGraph. AWS Strands Agents. Microsoft Agent Framework. OpenAI Agents SDK. CrewAI. LangGraph 1.0 shipped in October 2025 with the Platform GA behind it <a href="#cite-3" class="cite-ref">[3]</a>. Strands hit 1.0 on July 15, 2025 with four orchestration patterns (Swarms, Graphs, Agents-as-Tools, Handoffs) <a href="#cite-4" class="cite-ref">[4]</a>. Microsoft Agent Framework went to public preview October 1, 2025 and reached 1.0 GA on April 3, 2026; the convergence of AutoGen and Semantic Kernel into one SDK <a href="#cite-5" class="cite-ref">[5]</a>. OpenAI's Agents SDK launched March 2025 alongside the Responses API, now the default for new work <a href="#cite-8" class="cite-ref">[8]</a>. CrewAI is the independent holdout, still the procurement winner where role-based multi-agent on-prem is the requirement <a href="#cite-9" class="cite-ref">[9]</a>. The pattern we see most: one framework per cloud, federate the rest via MCP.
+
+**Q: What is agent washing and how do I spot it?**
+
+Agent washing is RPA with a chat window. Or workflow automation with LLM garnish. Gartner's Anushree Verma named it in mid-2025 and the term stuck <a href="#cite-1" class="cite-ref">[1]</a>. Five tells, all watchable inside a forty-minute demo. The demo reuses three happy-path queries every run. No public eval suite exists (a blog post does not count). Replanning needs a human click. Tool failures come back as user-facing errors. Pricing is per seat, not per outcome. Four or more and the product is a rules engine with a language model bolted on the front. Score the rubric before the demo starts; drift on the <em>replanning</em> criterion is the part that flips a 2/5 into a 4/5 depending on who was watching.
+
+**Q: Where do agents earn their keep?**
+
+Bounded workflows. Narrow schemas. Logged ground truth. IT ticket triage. Invoice reconciliation. Compliance document review. Sales-lead enrichment. L1 internal HR/IT support. Those are the ones paying back. Salesforce's year-one Agentforce run is the clearest public scorecard we have: 1.5M+ support cases handled (most without humans), 43,000+ leads worked, $1.7M of new sales pipeline <a href="#cite-6" class="cite-ref">[6]</a>. Klarna is the counter-example every 2026 steering committee cites. Volume without complexity is automatable. Complexity without volume is not. Klarna mis-read the line and started rehiring humans by mid-2025 <a href="#cite-10" class="cite-ref">[10]</a>, a caution the buyers who picked the wrong workload now rehearse on every slide.
+
+**Q: What are guardian agents, and are they real?**
+
+A guardian watches another agent and can veto it. That is the one-line version. Gartner projects the category will hold 10 to 15% of the agentic market by 2030 <a href="#cite-7" class="cite-ref">[7]</a>. Products shipping today are narrow, which is fine. Prompt-injection guardrails. Output-schema validators. Policy-check agents that refuse disallowed tool combinations. Evaluate one by asking what happens when the guardian gets it wrong. A guardian with only false positives is an annoyance. A guardian with only false negatives is a liability. The procurement question buyers forget to ask, every time.
+
+**Q: How does agentic AI relate to MCP and RAG?**
+
+Three layers of the same stack, not competitors. MCP is the wire protocol an agent uses to call tools and fetch context: the plumbing. See our [MCP pillar](mcp.md). RAG is a retrieval pattern for grounding a model in a document corpus. <em>Agentic RAG</em> places that retrieval inside a planning loop so the agent decides what to fetch next — see the [agentic RAG glossary entry](../glossary/agentic-rag.md). Most production systems we review run all three. An agent on top. MCP underneath. RAG as one of several tools the agent can reach for. The part that surprises first-time buyers: the architecture converges within a year of serious deployment. Implementation trade-offs live in our [MCP vs RAG comparison](../comparisons/mcp-vs-rag.md).
+
+## Citations
+
+1. **Gartner** — Gartner Predicts Over 40% of Agentic AI Projects Will Be Canceled by End of 2027 — https://www.gartner.com/en/newsroom/press-releases/2025-06-25-gartner-predicts-over-40-percent-of-agentic-ai-projects-will-be-canceled-by-end-of-2027 [accessed 2026-04-17] *(June 25, 2025 press release. Quotes Anushree Verma, Sr Director Analyst. Source for the 40% projection and context on agent washing and vendor count.)* { #cite-1 }
+2. **Russell & Norvig** — Artificial Intelligence: A Modern Approach (agent taxonomy) — https://aima.cs.berkeley.edu/ [accessed 2026-04-17] *(Canonical textbook reference for simple-reflex / model-based / goal-based / utility-based / learning agent taxonomy.)* { #cite-2 }
+3. **LangChain** — LangGraph Platform is now Generally Available — https://www.langchain.com/blog/langgraph-platform-ga [accessed 2026-04-17] *(LangGraph Platform GA announcement. Nearly 400 companies deployed agents during beta; source for durable execution and production posture.)* { #cite-3 }
+4. **AWS Open Source Blog** — Introducing Strands Agents 1.0: Production-Ready Multi-Agent Orchestration Made Simple — https://aws.amazon.com/blogs/opensource/introducing-strands-agents-1-0-production-ready-multi-agent-orchestration-made-simple/ [accessed 2026-04-17] *(July 15, 2025 Strands Agents 1.0 release. Four orchestration patterns (Swarms, Graphs, Agents-as-Tools, Handoffs) and contributing partners (Accenture, Anthropic, Langfuse, mem0.ai, Meta, PwC, Ragas.io, Tavily).)* { #cite-4 }
+5. **Microsoft** — Introducing Microsoft Agent Framework — https://azure.microsoft.com/en-us/blog/introducing-microsoft-agent-framework/ [accessed 2026-04-17] *(October 1, 2025 public preview announcement; AutoGen + Semantic Kernel convergence. 1.0 GA followed on April 3, 2026.)* { #cite-5 }
+6. **Salesforce** — From Pilot to Playbook: What We Learned from Our First Year Using Agentforce — https://www.salesforce.com/news/stories/first-year-agentforce-customer-zero/ [accessed 2026-04-17] *(Customer Zero year-one numbers: 1.5M+ support cases handled, 43,000+ leads worked, $1.7M new sales pipeline.)* { #cite-6 }
+7. **Gartner** — Gartner Predicts that Guardian Agents will Capture 10-15% of the Agentic AI Market by 2030 — https://www.gartner.com/en/newsroom/press-releases/2025-06-11-gartner-predicts-that-guardian-agents-will-capture-10-15-percent-of-the-agentic-ai-market-by-2030 [accessed 2026-04-17] *(June 11, 2025 Gartner press release. Definition of guardian agents and market-share projection for 2030.)* { #cite-7 }
+8. **OpenAI** — New tools for building agents (Responses API and Agents SDK) — https://openai.com/index/new-tools-for-building-agents/ [accessed 2026-04-17] *(March 2025 launch of Responses API, Agents SDK, and built-in tools (web_search, file_search, computer_use). Assistants API deprecation sunset: August 26, 2026.)* { #cite-8 }
+9. **CrewAI** — CrewAI Enterprise and the AMP suite — https://crewai.com/ [accessed 2026-04-17] *(CrewAI homepage; referenced for claimed 1.4B agentic automations and enterprise customer list (PwC, IBM, Capgemini, NVIDIA).)* { #cite-9 }
+10. **CNBC** — Klarna CEO says AI helped company shrink workforce by 40% — https://www.cnbc.com/2025/05/14/klarna-ceo-says-ai-helped-company-shrink-workforce-by-40percent.html [accessed 2026-04-17] *(May 14, 2025 CNBC coverage of Klarna workforce reduction; subsequent reporting on Klarna's pilot to rehire human agents for complex interactions.)* { #cite-10 }
+11. **TechCrunch** — ServiceNow buys Moveworks for $2.85B to grow its AI portfolio — https://techcrunch.com/2025/03/10/servicenow-buys-moveworks-for-2-85b-to-grow-its-ai-portfolio/ [accessed 2026-04-17] *(March 10, 2025 acquisition announcement. Closed December 15, 2025 per Moveworks and ServiceNow press releases.)* { #cite-11 }
+12. **LangChain** — Introducing End-to-End OpenTelemetry Support in LangSmith — https://blog.langchain.com/end-to-end-opentelemetry-langsmith/ [accessed 2026-04-17] *(LangSmith native OTel support; interoperates with Datadog, Grafana, Jaeger, and other OTel-compliant backends.)* { #cite-12 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/agentic-ai/](https://www.exploreagentic.ai/agentic-ai/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/pillars/ai-governance.md
+++ b/docs/explore-agentic/pillars/ai-governance.md
@@ -1,0 +1,150 @@
+# Governance, written by people who had to file the paperwork
+
+> A working AI governance program in 2026: ISO 42001 certified vendors, the NIST AI RMF Generative AI Profile, EU AI Act enforcement dates, the OWASP LLM Top 10, and the governance platforms CISOs are actually procuring.
+
+*Pillar · AI Governance · 22 minutes · Updated April 17, 2026 · Author Gloria Qian Zhang · Reviewed by Mehrdad Faqiri*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/ai-governance/](https://www.exploreagentic.ai/ai-governance/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Intro
+
+AI governance is unfashionable, until the audit, when it becomes the only thing anyone talks about. As of April 2026 the audit is no longer hypothetical. The EU AI Act's enforcement regime for general-purpose AI providers took effect on August 2, 2025, with the full high-risk obligations and Commission enforcement powers landing on August 2, 2026 <a href="#cite-1" class="cite-ref">[1]</a>. ISO 42001, the first certifiable AI management standard, now has Anthropic (certified January 6, 2025), Microsoft Azure AI Foundry, AWS, Google, Snowflake, and KPMG in its issued-certificate column <a href="#cite-2" class="cite-ref">[2]</a><a href="#cite-3" class="cite-ref">[3]</a>.
+
+This pillar is the working version of a mature program: three artefacts every CISO needs on file, the two standards that anchor most audits, what the EU AI Act asks of providers versus deployers, the OWASP LLM Top 10 as a threat model, and the governance platform landscape. The pattern we see consistently in programs that pass an audit: a policy with teeth, a practical inventory of in-use AI, and a steering group with the authority to decommission systems that fail evaluation <a href="#cite-4" class="cite-ref">[4]</a>.
+
+## TL;DR
+
+- Three artefacts or the audit fails: a written AI policy, a maintained AI inventory, and an eval cadence with named owners. Shortcut any of the three and the finding appears in writing.
+- ISO 42001 (published Dec 2023) is the certifiable standard. Anthropic, Microsoft Azure AI Foundry, AWS, Google, Snowflake, and KPMG hold active certificates as of early 2026 <a href="#cite-2" class="cite-ref">[2]</a><a href="#cite-3" class="cite-ref">[3]</a>.
+- NIST AI RMF is the US framework CISOs reference. NIST-AI-600-1, the Generative AI Profile (July 26, 2024), enumerates 13 generative-AI risks and 400+ actions <a href="#cite-5" class="cite-ref">[5]</a>.
+- EU AI Act: GPAI obligations in force August 2, 2025; full high-risk regime and penalties from August 2, 2026 <a href="#cite-1" class="cite-ref">[1]</a>.
+- Shadow AI is measurable, not theoretical. Gartner's 2025 CISO survey found 69% of organisations suspect or have evidence of employees using prohibited public GenAI tools; UpGuard put the worker figure above 80% <a href="#cite-6" class="cite-ref">[6]</a>.
+- The OWASP LLM Top 10 (2025 edition) leads with prompt injection and expanded <em>excessive agency</em>, the explicit governance bridge into agentic AI <a href="#cite-7" class="cite-ref">[7]</a>.
+
+## Stats
+
+- **Jan 6, 2025** — Anthropic ISO 42001 certificate issued *(Certified by Schellman Compliance, LLC; first frontier lab on the standard. Source [2].)*
+- **Aug 2, 2026** — EU AI Act high-risk + enforcement live *(Commission enforcement powers and penalties against GPAI providers begin. Source [1].)*
+- **13 risks / 400+ actions** — NIST-AI-600-1 Generative AI Profile *(Published July 26, 2024; NIST public working group input from 2,500 participants. Source [5].)*
+- **69% / >80%** — organisations / workers using unsanctioned GenAI *(Gartner 2025 CISO survey and UpGuard shadow-AI research. Source [6].)*
+
+## 01. The three artefacts every program needs
+
+A <strong>policy</strong> is not a deck. It is a written document, approved by the same committee that approves access-control policy, with named owners and a review cadence. It identifies prohibited use (employee data in public chat tools, for instance), high-risk use that requires steering-group approval, and the default path for low-risk use with logging. The policy that survives contact with reality fits on two pages and names a human for every decision.
+
+An <strong>inventory</strong> is not a spreadsheet on the deputy's desktop. It is a maintained register, refreshed monthly, covering first-party AI, shadow AI, third-party AI embedded in SaaS tools, and models running inside acquired companies. Gartner's 2025 CISO survey put the share of organisations with suspected or confirmed prohibited GenAI use at 69%, and the inventory is how that number stops being a rumour <a href="#cite-6" class="cite-ref">[6]</a>.
+
+An <strong>eval cadence</strong> is not a launch-day checklist. It is a recurring obligation on the owners of each system to rerun a defined suite (accuracy, safety, bias, prompt-injection, PII-leak) and to post the deltas. The NIST-AI-600-1 Generative AI Profile gives you the starter list of 13 risks and 400+ specific actions to evaluate against <a href="#cite-5" class="cite-ref">[5]</a>. Our editorial position: a program without <em>nightly</em> eval automation passes its first audit and fails its second.
+
+> A policy without an inventory fails the audit. An inventory without a policy passes it. The non-negotiable one is the inventory.
+
+## 02. ISO 42001 and the NIST AI RMF, side by side
+
+<strong>ISO/IEC 42001:2023</strong> is the first certifiable AI management-system standard, published in December 2023. Certification has moved from nice-to-have to table stakes faster than most predicted. Anthropic received its certificate on January 6, 2025 from Schellman Compliance, LLC <a href="#cite-2" class="cite-ref">[2]</a>; Microsoft's Azure AI Foundry Models and Security Copilot followed, issued by Mastermind <a href="#cite-3" class="cite-ref">[3]</a>. AWS, Google, Snowflake, and KPMG hold active certificates. When a European regulator asks <em>who certifies your AI management system</em>, ISO 42001 is the answer that makes the follow-up short.
+
+<strong>NIST AI RMF</strong> is the US voluntary framework most CISOs reference. The January 2023 core is paired with NIST-AI-600-1, the Generative AI Profile released July 26, 2024, which maps 13 concrete generative-AI risks (from CBRN information to data privacy to harmful bias) to more than 400 actions a developer or deployer can take <a href="#cite-5" class="cite-ref">[5]</a>. NIST published a concept note for a Critical-Infrastructure Profile on April 7, 2026, the next wave of sector-specific guidance.
+
+The two do not conflict. ISO 42001 tells you what the management system looks like. NIST AI RMF tells you what risks to evaluate inside it. Enterprises running both build a combined control-mapping document. Two days of work. It pays for itself the first time a customer or auditor asks for evidence, the part procurement teams never plan for until the RFP lands.
+
+*Anchoring AI standards in force, April 2026. Links point to canonical sources.*
+
+| Standard | Publisher | Status | Scope |
+| --- | --- | --- | --- |
+| ISO/IEC 42001:2023 | ISO / IEC | Published Dec 2023; certifiable | AI management system (policy, controls, audit surface) |
+| NIST AI RMF 1.0 + 600-1 Generative AI Profile | NIST | Core 2023; Gen-AI Profile Jul 26, 2024 | Voluntary risk framework; 13 gen-AI risks, 400+ actions |
+| EU AI Act (Regulation 2024/1689) | European Union | GPAI in force Aug 2, 2025; full Aug 2, 2026 | Binding law; risk-tiered obligations on providers and deployers |
+| OWASP LLM Top 10 (2025) | OWASP Gen AI Security Project | Published 2025 | Threat model: prompt injection, excessive agency, system-prompt leakage |
+
+## 03. EU AI Act enforcement, the dates that matter
+
+Regulation (EU) 2024/1689, the EU AI Act, entered into force August 1, 2024, but the compliance work is stepwise. <strong>August 2, 2025</strong> marked entry into application of the obligations for providers of general-purpose AI models and the institutional governance provisions <a href="#cite-1" class="cite-ref">[1]</a>. Any GPAI model placed on the EU market after that date falls under the new regime immediately.
+
+<strong>August 2, 2026</strong> is the date governance teams should have circled in red. The full obligations for high-risk AI systems apply, and the European Commission's enforcement powers, including penalties against GPAI providers, begin. Models already on the market before August 2025 have until August 2, 2027 to conform, which is the grandfathering clause most deployers mis-read <a href="#cite-1" class="cite-ref">[1]</a>.
+
+The practical effect for most enterprises: treat the procurement pipeline as the primary control. Require vendors to disclose whether their model falls under GPAI obligations, whether it is classified high-risk for your use case, and what evidence they will provide for your Annex IV technical documentation. That evidence package is the artefact that disappears first in a sloppy vendor selection and surfaces most expensively in an audit.
+
+> **Practical procurement clause**: We have started recommending a one-paragraph addendum for every AI vendor contract signed after April 2026: the vendor warrants continued compliance with the EU AI Act obligations applicable to its classification, provides the technical documentation required under Annex IV on request, and notifies the deployer within 30 days of any change in classification. Legal teams push back. Security teams thank you in August.
+
+## 04. Shadow AI is an inventory problem with measurable scale
+
+Shadow AI, meaning employees using AI tools without IT approval, is the governance surface most programs under-estimate. Gartner's 2025 CISO survey found 69% of organisations suspect or have evidence of prohibited public GenAI use <a href="#cite-6" class="cite-ref">[6]</a>. UpGuard's research put worker-level usage above 80%, including nearly 90% of security professionals themselves. WalkMe's 2025 enterprise survey reported 78% of workers using unapproved AI with only 7.5% receiving extensive training. These are not fringe figures.
+
+You cannot police shadow AI with a policy alone. You surface it with four inputs every CISO already has: SSO logs to enumerate SaaS tools with generative features, network telemetry to catch direct API traffic, procurement records filtered for AI-adjacent vocabulary, and a short amnesty window that asks employees to self-register. Every program we have reviewed in 2025-2026 found its largest exposure in one of those four channels, not in the clever leak the compliance team worried about.
+
+- **Start with SSO logs** — Enumerate every SaaS tool with generative features. The top 200 cover most of the risk; the long tail mostly does not.
+- **Add procurement records** — Cross-reference anything with 'AI', 'copilot', 'agent', 'assistant', or 'GPT' in purchases made in the last 24 months.
+- **Run a one-week amnesty** — Ask employees to register tools they use with no consequence for historical use. One week beats a quarter of top-down discovery.
+- **Refresh monthly, not annually** — Inventory decays. The annual refresh is theatre; monthly is the lowest cadence that survives contact with reality.
+- **Instrument agentic tool calls via MCP gateway logs** — For agents, the gateway is the chokepoint: every tool call is observable. See our [MCP pillar](mcp.md) for the architecture.
+
+## 05. The OWASP LLM Top 10 as a threat model
+
+The OWASP Gen AI Security Project publishes the <strong>Top 10 for LLM Applications</strong>; the 2025 edition is the current baseline most red teams run against <a href="#cite-7" class="cite-ref">[7]</a>. Prompt injection (LLM01:2025) retains the top position, which tracks with every internal pen-test result we have seen. The expanded <em>Excessive Agency</em> entry (LLM06:2025) is the direct governance bridge into agentic AI. OWASP breaks it into excessive functionality, excessive permissions, and excessive autonomy, each with a distinct mitigation.
+
+System Prompt Leakage is new in 2025 and worth a dedicated policy clause. RAG-related risks (vector and embedding weaknesses) earned a prominent position on the back of survey data showing 53% of companies relying on RAG and agentic pipelines rather than fine-tuning. Map each of the ten to a control in your ISO 42001 Statement of Applicability. That mapping is what auditors actually read.
+
+- **LLM01 Prompt Injection** — Still top. Mitigate with input filtering, output constraints, and (for agents) tool-level authorization at the gateway.
+- **LLM06 Excessive Agency** — Limit tool scope, enforce least-privilege credentials, require human-in-the-loop for high-impact actions.
+- **LLM07 System Prompt Leakage (new)** — Assume the system prompt is extractable. Never place credentials or secrets in it.
+- **LLM08 Vector and Embedding Weaknesses** — Poisoned embeddings and retrieval exploits. Validate ingestion sources; isolate retrieval by tenancy.
+- **LLM09 Misinformation** — Groundedness eval on every production release. Tie to the eval cadence in chapter 01.
+
+## 06. AI governance platforms: the procurable category
+
+The platform category matured in 2025. Gartner's 2025 Market Guide for AI Governance Platforms named the serious vendors; the shortlist most CISOs now run is stable: <strong>Credo AI</strong> (Fast Company <em>Most Innovative 2026</em>) <a href="#cite-8" class="cite-ref">[8]</a>, <strong>Holistic AI</strong>, <strong>Monitaur</strong> (Forrester Strong Performer, Q3 2025) <a href="#cite-9" class="cite-ref">[9]</a>, and <strong>Fairly</strong>.
+
+Buy what fits the programme you already have. If the driver is EU AI Act readiness, Credo AI and Holistic AI are the common landing spots. If the driver is regulated-industry audit rigour, Monitaur's record-first posture fits better. Seven-figure first-year program cost is typical for enterprise tenancies.
+
+> **Further reading on this site**: Our [MCP pillar](mcp.md) covers the gateway layer. The [ISO 42001 glossary entry](../glossary/iso-42001.md) is the 900-word explainer. For observability, see the [agent observability](../glossary/agent-observability.md) entry.
+
+## FAQ
+
+**Q: What are the three artefacts of a working AI governance program?**
+
+Three artefacts, nothing optional. A written <strong>policy</strong>. A maintained <strong>inventory</strong> of every AI in use, refreshed monthly. An <strong>eval cadence</strong> with named owners and a posted schedule. ISO 42001 names all three as clauses. NIST-AI-600-1 supplies the risk content that goes inside them <a href="#cite-4" class="cite-ref">[4]</a><a href="#cite-5" class="cite-ref">[5]</a>. Programs missing any one pass their first audit on paperwork. They fail the second. The auditor samples the inventory, finds the third-party AI nobody registered, and the finding lands in writing, the part steering committees always under-estimate.
+
+**Q: Which enterprise AI vendors are ISO 42001 certified as of April 2026?**
+
+A handful of names, and the list matters. Anthropic, certified January 6, 2025 by Schellman Compliance, LLC: first frontier lab on the standard <a href="#cite-2" class="cite-ref">[2]</a>. Microsoft Azure AI Foundry Models and Security Copilot, issued by Mastermind <a href="#cite-3" class="cite-ref">[3]</a>. AWS. Google. Snowflake. KPMG. OpenAI as a corporate entity had not published an ISO 42001 certificate as of this update, a gap European procurement teams notice even when the contracting team does not.
+
+**Q: What are the key EU AI Act enforcement dates?**
+
+Four dates, in order. Entry into force: August 1, 2024. GPAI obligations live: August 2, 2025. Full high-risk regime plus Commission enforcement powers: August 2, 2026. Grandfathering to August 2, 2027 for GPAI already on the market before August 2025 <a href="#cite-1" class="cite-ref">[1]</a>. That grandfathering clause is the one most deployers mis-read, the part legal surfaces six months late. Write August 2, 2026 in red on the war-room wall. It matters more than the August 1 entry-into-force people quote in decks.
+
+**Q: How do ISO 42001 and NIST AI RMF fit together?**
+
+They cover different layers of the same work. ISO 42001 defines the certifiable AI management system: structure, roles, documented processes, the audit surface. NIST AI RMF (paired with the 600-1 Generative AI Profile) supplies the risk content you evaluate inside that system on specific AI use cases <a href="#cite-5" class="cite-ref">[5]</a>. Teams running both produce one combined control-mapping document. About two days of work once the ISO 42001 scope is set. The part buyers do not expect: auditors and customers now ask for both citations side by side, not one or the other.
+
+**Q: What is shadow AI and how widespread is it?**
+
+Shadow AI is employee use of AI tools outside the IT approval path. Gartner's 2025 CISO survey found 69% of organisations suspect or have evidence of prohibited GenAI use. UpGuard research put worker-level usage above 80%, and nearly 90% of security professionals themselves <a href="#cite-6" class="cite-ref">[6]</a>. Not fringe numbers. The response is inventory, not prohibition. Start with SSO logs, add procurement records, run a one-week amnesty. The inventory you end up with is always bigger than the one the governance team guessed.
+
+**Q: What does the OWASP LLM Top 10 (2025) prioritise?**
+
+Prompt Injection (LLM01) holds the top slot. It tracks with every internal pen-test result we have seen. Excessive Agency (LLM06) splits into excessive functionality, permissions, and autonomy, the direct governance bridge into agentic AI. System Prompt Leakage is new as LLM07; assume the system prompt is extractable and never put credentials in it. Vector and embedding weaknesses earned prominence on RAG-adoption data (53% of companies now lean on retrieval over fine-tuning) <a href="#cite-7" class="cite-ref">[7]</a>. Map each entry to a control in your ISO 42001 Statement of Applicability. That mapping is what auditors read line by line.
+
+## Citations
+
+1. **European Commission** — Guidelines for providers of general-purpose AI models (EU AI Act timeline) — https://digital-strategy.ec.europa.eu/en/policies/guidelines-gpai-providers [accessed 2026-04-17] *(Canonical EU source. GPAI obligations in force Aug 2, 2025; full high-risk regime from Aug 2, 2026; grandfathering to Aug 2, 2027.)* { #cite-1 }
+2. **Anthropic** — Anthropic achieves ISO 42001 certification for responsible AI — https://www.anthropic.com/news/anthropic-achieves-iso-42001-certification-for-responsible-ai [accessed 2026-04-17] *(Certificate effective January 6, 2025; issued by Schellman Compliance, LLC.)* { #cite-2 }
+3. **Microsoft** — Azure AI Foundry Models and Security Copilot achieve ISO/IEC 42001:2023 certification — https://azure.microsoft.com/en-us/blog/microsoft-azure-ai-foundry-models-and-microsoft-security-copilot-achieve-iso-iec-420012023-certification/ [accessed 2026-04-17] *(Microsoft ISO 42001 announcement; issued by Mastermind.)* { #cite-3 }
+4. **ISO** — ISO/IEC 42001:2023 AI Management system — https://www.iso.org/standard/42001 [accessed 2026-04-17] *(Canonical ISO catalogue page.)* { #cite-4 }
+5. **NIST** — NIST-AI-600-1, AI RMF: Generative AI Profile — https://www.nist.gov/publications/artificial-intelligence-risk-management-framework-generative-artificial-intelligence [accessed 2026-04-17] *(Published July 26, 2024. 13 risks, 400+ actions.)* { #cite-5 }
+6. **Cybersecurity Dive / UpGuard** — Shadow AI is widespread, and executives use it the most — https://www.cybersecuritydive.com/news/shadow-ai-employee-trust-upguard/805280/ [accessed 2026-04-17] *(UpGuard: 80%+ workers, 90%+ of security pros use unapproved AI. Gartner 2025 CISO survey: 69% of orgs.)* { #cite-6 }
+7. **OWASP Gen AI Security Project** — OWASP Top 10 for LLM Applications 2025 — https://genai.owasp.org/llm-top-10/ [accessed 2026-04-17] *(2025 edition. LLM01 Prompt Injection, LLM06 Excessive Agency, LLM07 System Prompt Leakage (new).)* { #cite-7 }
+8. **Credo AI** — Credo AI in Gartner Market Guide for AI Governance Platforms (2025) — https://www.credo.ai/blog/credo-ai-recognized-in-the-gartner-r-market-guide-for-ai-governance-platforms-2025 [accessed 2026-04-17] *(Gartner 2025 Market Guide; Fast Company Most Innovative 2026.)* { #cite-8 }
+9. **Monitaur** — Monitaur: AI Governance for Regulated Industries — https://www.monitaur.ai/ [accessed 2026-04-17] *(Forrester Strong Performer, Q3 2025.)* { #cite-9 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/ai-governance/](https://www.exploreagentic.ai/ai-governance/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/pillars/enterprise-rag.md
+++ b/docs/explore-agentic/pillars/enterprise-rag.md
@@ -1,0 +1,161 @@
+# Retrieval is still the hardest part of the stack
+
+> Production RAG in 2026: chunk strategies including late chunking, the embedding model landscape (OpenAI text-embedding-3, Cohere Embed v4, Voyage 3/4), re-rankers, the RAGAS eval framework, vector database selection, and when agentic RAG earns its seat.
+
+*Pillar · Enterprise RAG · 17 minutes · Updated April 17, 2026 · Author Wenjia (Soraya) Zheng · Reviewed by Ziyi Tao*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/enterprise-rag/](https://www.exploreagentic.ai/enterprise-rag/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Intro
+
+The easy part of <strong>enterprise RAG</strong> is the chat interface. The hard part, still, in 2026, is everything upstream. Which documents to index, how to chunk, which embedding model and re-ranker to trust, and how to know when the system is wrong. Since Jina AI's September 2024 <em>late chunking</em> paper <a href="#cite-1" class="cite-ref">[1]</a> and Voyage 4's Mixture-of-Experts release in January 2026 <a href="#cite-2" class="cite-ref">[2]</a>, every part of this pipeline has moved. This pillar walks the whole thing and skips what every tutorial already covers.
+
+Two editorial positions up front. Chunk strategy matters more than model choice on most corpora. And evaluation, specifically a <strong>named, versioned, nightly-run RAGAS-style eval set</strong> <a href="#cite-3" class="cite-ref">[3]</a>, is what separates RAG teams that ship from RAG teams that argue about which embedding model is <em>best</em> for six months. Everything below assumes the eval discipline is in place.
+
+## TL;DR
+
+- Chunk strategy matters more than model choice on most corpora. <em>Late chunking</em> (Jina AI, arXiv 2409.04701, Sep 7 2024) preserves context by embedding the full document first and chunking the token sequence afterwards <a href="#cite-1" class="cite-ref">[1]</a>.
+- Embedding leaders as of April 2026: Voyage 4 (MoE, shared-space, Jan 2026) <a href="#cite-2" class="cite-ref">[2]</a>, Cohere Embed v4 (multimodal, 128K context) <a href="#cite-4" class="cite-ref">[4]</a>, OpenAI text-embedding-3-large with Matryoshka dimensions <a href="#cite-5" class="cite-ref">[5]</a>.
+- Re-rankers remain the single highest-ROI component most teams skip. Cohere Rerank 3.5 (on Bedrock via Rerank API) is the default procurement path; improvements are largest on constrained and semi-structured queries <a href="#cite-6" class="cite-ref">[6]</a>.
+- RAGAS is the open-source framework most teams standardise on. Metrics include Faithfulness, Context Precision, Context Recall, Response Relevancy, and an agentic suite (Tool Call F1, Agent Goal Accuracy) <a href="#cite-3" class="cite-ref">[3]</a>.
+- Vector-database shortlist in April 2026: Pinecone (managed, SOC 2 Type II, ISO 27001, HIPAA-attested), Weaviate (hybrid-search native, SOC 2 Type II + HIPAA on AWS), Qdrant (Rust, fastest at 10M+ vectors under concurrency) <a href="#cite-7" class="cite-ref">[7]</a>.
+- Agentic RAG earns its seat on multi-hop and ambiguous queries; it is a tax on simple lookups. See the [agentic RAG glossary entry](../glossary/agentic-rag.md).
+
+## Stats
+
+- **Sep 7, 2024** — Jina late chunking paper published *(arXiv 2409.04701. Context preserved by embedding whole document before splitting. Source [1].)*
+- **Jan 2026** — Voyage 4 MoE release *(Shared embedding space across 4-large/4-lite; allows mixed-accuracy indexing without re-embedding. Source [2].)*
+- **128K tokens** — Cohere Embed v4 context window *(Multimodal (text, image, mixed); shared embedding space. Source [4].)*
+- **2-5x QPS** — Qdrant vs Weaviate at 10M+ vectors *(Measured on filtered queries at equivalent recall; 2025 third-party benchmarks. Source [7].)*
+
+## 01. Chunk strategy: fixed, semantic, and late
+
+In the public RAG post-mortems we have read (engineering blogs from LinkedIn, Databricks, Pinecone, LlamaIndex, and dozens of smaller teams) chunking is by a wide margin the most-cited root cause of poor retrieval. Splits that broke semantic units, splits that were too large and diluted relevance scores, splits that orphaned a reference from its antecedent. The fix is almost never a different embedding model. The fix is a better splitter.
+
+Three families of chunking dominate in 2026. <strong>Fixed-size recursive-character</strong> is the default in most frameworks and works fine for pure prose. <strong>Semantic chunking</strong> (cluster adjacent sentences by cosine distance and cut at local maxima) improves retrieval on technical documents and is the upgrade most teams take first. <strong>Late chunking</strong>, published by Jina AI in September 2024 as arXiv 2409.04701 <a href="#cite-1" class="cite-ref">[1]</a>, is the interesting new primitive: embed the entire long document first with a long-context model, then split the token sequence into chunks and mean-pool each slice. Because every chunk embedding saw the full surrounding context, long-distance dependencies survive.
+
+Format-aware splitting is still table stakes. PDFs with tables get table-aware chunking; code gets AST-aware chunking; markdown gets section-aware chunking. Generic recursive-character splitters work for prose and only prose. The practical recipe: semantic chunking for prose, late chunking when retrieval quality is the bottleneck and you can afford a long-context embedding model, format-specialised splitters everywhere else.
+
+> Late chunking is the first genuinely new idea in RAG retrieval in two years. Everything else is tuning.
+
+## 02. The embedding model landscape in April 2026
+
+The embedding field consolidated around three vendors plus a strong open-source tail. <strong>Voyage AI</strong> shipped Voyage 4 on January 15, 2026. It is a Mixture-of-Experts architecture with a <em>shared embedding space</em> across 4-large, 4, and 4-lite, which means you can index documents with the large model and query with the lite model without re-embedding <a href="#cite-2" class="cite-ref">[2]</a>. Voyage 3-large already topped Cohere v4 and OpenAI 3-large on a number of MTEB tasks in January 2025 <a href="#cite-8" class="cite-ref">[8]</a>.
+
+<strong>Cohere Embed v4</strong> is multimodal, embedding text, images, and mixed-modality content into the same vector space, with a 128,000-token context window, which is the feature that makes it competitive for enterprise document RAG on long PDFs and scanned tables <a href="#cite-4" class="cite-ref">[4]</a>. <strong>OpenAI text-embedding-3-large</strong> ($0.13 per million tokens) remains a common default, and the Matryoshka variable-dimension support introduced in 2024 is now standard in the category <a href="#cite-5" class="cite-ref">[5]</a>.
+
+Open-source defaults for air-gapped deployments: BGE-M3 (multilingual, hybrid sparse+dense) and the Jina v3 family (long-context, late-chunking-ready). MTEB scores as of Q1 2026 cluster Voyage 4 > Cohere v4 > OpenAI 3-large > BGE-M3; enterprise workloads vary, but the ordering is consistent enough to use as a starting default.
+
+*Embedding model leaders, April 2026. Prices are published list; context window is in tokens.*
+
+| Model | Vendor / release | Context | Key differentiator |
+| --- | --- | --- | --- |
+| Voyage 4-large | Voyage AI, Jan 15 2026 | 32K | MoE architecture; shared embedding space with lite variants |
+| Cohere Embed v4 | Cohere, 2025 | 128K | Multimodal text+image in one vector space |
+| OpenAI text-embedding-3-large | OpenAI, 2024 | 8K | Matryoshka variable dimensions; $0.13/M tokens |
+| Jina Embeddings v3 | Jina AI, 2024 | 8K | Late-chunking-ready; open source weights |
+| BGE-M3 | BAAI, 2024 | 8K | Open source; hybrid sparse + dense; multilingual |
+
+## 03. Re-rankers are the cheapest big improvement
+
+The re-ranker is a second pass over retrieved candidates: take the top 50 from your vector search, re-score them with a cross-encoder, and keep the top 5. It is not glamorous. It is, empirically, the single highest-ROI component most teams skip.
+
+<strong>Cohere Rerank 3.5</strong> is the default procurement path as of April 2026, available in Amazon Bedrock through the Rerank API and in Pinecone and Elasticsearch integrations <a href="#cite-6" class="cite-ref">[6]</a>. Cohere's own benchmarks show the largest improvements over Rerank v2 on constrained queries and semi-structured JSON; on generic prose benchmarks the lift is more modest. Rerank 3 Nimble is 3-5x faster than Rerank 3 with comparable accuracy on BEIR, worth evaluating when latency budget is tight.
+
+Alternatives: <strong>Jina reranker-v2</strong> (open weights, competitive on short queries), <strong>mixedbread-ai/mxbai-rerank-large-v1</strong> (open source, strong on multilingual), and custom fine-tuned cross-encoders where the corpus is weird enough to justify the training investment. Latency cost for all commercial re-rankers is measured in a few hundred milliseconds per query, invisible to the end user on a conversational interface.
+
+> Model choice is the conversation everyone wants to have. Chunking and re-ranking are the changes that actually move the benchmark.
+
+## 04. Evaluation with RAGAS is the whole game
+
+Teams ship or stall on evals. Teams with a named eval set (a specific corpus of queries with expected answers, run nightly) can answer <em>is this better?</em> with a number. Teams without one argue and wait for a product manager to decide.
+
+The open-source framework most teams standardise on is <strong>RAGAS</strong> (arXiv 2309.15217). It offers reference-free metrics including Faithfulness, Context Precision, Context Recall, Context Entities Recall, Response Relevancy, Answer Accuracy, Factual Correctness, and Semantic Similarity, plus agentic metrics like Tool Call F1 and Agent Goal Accuracy <a href="#cite-3" class="cite-ref">[3]</a>. Faithfulness and Context Precision are the two that disagree most often in practice. A response can be fully grounded in retrieved context that was itself irrelevant. Track both or fool yourself.
+
+Scale the eval set with the program. Minimum viable: 100 queries with graded answers. Mature: 2,000 queries covering every failure mode observed in production. Update weekly, run nightly, post the delta to a Slack channel. Every model change, prompt change, and chunker change ships with an eval-delta comment or it does not ship. LLM-as-judge saves annotation cost but drifts; calibrate quarterly against human graders.
+
+- **Start with failures** — Seed the eval set with queries users complained about, not queries that worked. Bias towards the corpus edges.
+- **Use four tiers, not binary** — Binary correct/incorrect loses signal. Four tiers (incorrect / partial / correct-with-caveat / correct) calibrates in two hours of annotator training.
+- **Track Faithfulness and Context Precision separately** — A high-Faithfulness / low-Precision pair flags groundedness against the wrong evidence. Common early-stage failure.
+- **LLM-as-judge is fine, once calibrated** — Calibrate quarterly against human graders. Model drift between GPT-4-class versions is real and can flip your sign.
+- **Publish the delta** — Every change posts an eval-delta to the channel. No change ships silently; that rule is what separates real programs from theatre.
+
+## 05. Vector databases in production, April 2026
+
+The managed shortlist settled on three. <strong>Pinecone</strong> is the managed-simplicity option (SOC 2 Type II, ISO 27001, GDPR-aligned, with an external HIPAA attestation), and in BYOC mode clusters run inside the customer's own AWS, Azure, or GCP account for hard isolation <a href="#cite-7" class="cite-ref">[7]</a>. <strong>Weaviate</strong> is the flexible hybrid-search powerhouse; Weaviate Enterprise Cloud gained HIPAA compliance on AWS in 2025 and ships tenant-aware classes, lifecycle endpoints, and ACLs for multitenant deployments.
+
+<strong>Qdrant</strong> is the performance-first option: Rust-native, SOC 2 Type II, with a markedly advanced filtering engine that lets complex metadata queries execute before the vector search. At 10M+ vectors with concurrent filtered queries, third-party benchmarks put Qdrant at 2-5x higher QPS than Weaviate on equivalent hardware at the same recall target. Open-source alternatives worth evaluating: Milvus (CNCF-graduated), pgvector for teams already on Postgres, and Chroma for prototyping.
+
+Hybrid search, which combines vector similarity, keyword search, and metadata filters in one query, is the feature to verify in procurement. Weaviate and Qdrant include it by default; Pinecone added sparse-dense hybrid support through native integrations. If you need HIPAA, the shortlist narrows quickly; if you need on-prem isolation, Qdrant and Milvus are the common answers.
+
+*Vector database enterprise posture, April 2026. Compliance claims verified against vendor trust pages.*
+
+| Database | Model | Compliance | Strength |
+| --- | --- | --- | --- |
+| Pinecone | Fully managed; BYOC | SOC 2 II, ISO 27001, HIPAA attested, GDPR | Zero-ops managed; fast time-to-value |
+| Weaviate | Managed + self-host | SOC 2 II, HIPAA on AWS (2025) | Hybrid search native; strong multitenancy |
+| Qdrant | Managed + self-host | SOC 2 II; HIPAA-ready | Rust performance; best filtered-query QPS |
+| Milvus | Self-host (CNCF) | Customer-configurable | Open source; GPU-accelerated at scale |
+| pgvector | Postgres extension | Inherited from Postgres | Stay on existing database; simple ops |
+
+## 06. When agentic RAG earns its seat
+
+Agentic RAG is retrieval placed inside a planning loop. The agent decides what to retrieve, judges whether the retrieval was good enough, and retrieves again (or chooses a different index) if not. The cost is latency and token spend; the benefit is accuracy on multi-hop questions and ambiguous intent.
+
+Add the agentic layer when the workload asks for it. Four triggers. Users ask follow-ups that depend on the previous retrieval. The correct answer requires joining two corpora. Intent is ambiguous and you would rather the system clarify than guess. Retrieval must decide among multiple typed sources (structured DB, unstructured document store, API). For simple lookups, agentic RAG is a tax: three extra seconds and a bigger token bill for no accuracy gain. The trigger list is short, which is the part most steering committees forget to check before shipping.
+
+The governance implication: agentic RAG exposes new failure modes (retrieval loops, prompt injection via retrieved content) that OWASP LLM06 <em>Excessive Agency</em> and LLM08 <em>Vector and Embedding Weaknesses</em> specifically call out. Wire agentic RAG through the MCP gateway (see our [MCP](mcp.md) and [AI Governance](ai-governance.md) pillars) so tool calls are auditable and policy-governed.
+
+> **Further reading on this site**: The [agentic RAG glossary entry](../glossary/agentic-rag.md) has the plain-language version with a diagram. For the protocol layer below, see our [MCP pillar](mcp.md). For eval and governance posture, see our [AI Governance pillar](ai-governance.md). Head-to-head coverage lives in the [MCP vs RAG comparison](../comparisons/mcp-vs-rag.md).
+
+## FAQ
+
+**Q: What is late chunking in RAG?**
+
+Late chunking flips the order of two steps. Embed the whole long document first with a long-context model, then split the token sequence into chunks and mean-pool each slice. Jina AI published the technique on September 7, 2024 as arXiv 2409.04701 <a href="#cite-1" class="cite-ref">[1]</a>. Because every chunk embedding saw the full surrounding context, long-distance dependencies survive, the exact failure mode that sinks classic chunk-then-embed pipelines. The first genuinely new idea in retrieval in two years, which is why it was the one people argued about at conferences.
+
+**Q: Which embedding model should I use for enterprise RAG in 2026?**
+
+Three commercial defaults, plus open source for the air-gapped case. Voyage 4-large (January 15, 2026; MoE with a shared embedding space across the family) <a href="#cite-2" class="cite-ref">[2]</a> is the current MTEB leader. Cohere Embed v4 wins if you need multimodal (text plus image) at a 128K context window <a href="#cite-4" class="cite-ref">[4]</a>. OpenAI text-embedding-3-large remains the safe default at $0.13 per million tokens <a href="#cite-5" class="cite-ref">[5]</a>. For air-gapped: BGE-M3 or Jina v3. The ordering is consistent enough across enterprise corpora to use as a starting point, the part teams skip when they argue about model choice for six months.
+
+**Q: Do I need a re-ranker?**
+
+Almost certainly yes. It is the highest-ROI upgrade most RAG teams skip. Take the top 50 from your vector search, re-score with a cross-encoder, keep the top 5. Cohere Rerank 3.5 (via Amazon Bedrock's Rerank API) is the default procurement path; the lift is largest on constrained and semi-structured queries <a href="#cite-6" class="cite-ref">[6]</a>. Latency cost is a few hundred milliseconds per query, invisible on a conversational interface. The part RAG teams admit only privately: they spent a quarter arguing about embedding models before trying a re-ranker.
+
+**Q: How should I evaluate a production RAG system?**
+
+Use RAGAS as the baseline framework (arXiv 2309.15217) <a href="#cite-3" class="cite-ref">[3]</a>. Track four metrics at minimum. Faithfulness. Context Precision. Context Recall. Response Relevancy. Minimum-viable eval set is 100 graded queries. Mature looks more like 2,000, covering every observed failure mode. Run nightly. Post deltas to a public channel. No change ships without an eval-delta, the one rule that separates real programs from theatre.
+
+**Q: Pinecone, Weaviate, or Qdrant?**
+
+Three answers, one question each. Pinecone for zero-ops managed with SOC 2 Type II, ISO 27001, HIPAA-attested. Weaviate for hybrid-search native with strong multitenancy and HIPAA-on-AWS added in 2025. Qdrant for raw performance: Rust-native, 2 to 5x higher QPS than Weaviate at 10M+ vectors on filtered queries per third-party 2025 benchmarks <a href="#cite-7" class="cite-ref">[7]</a>. Milvus and pgvector are the open-source names worth a short-list. If you need HIPAA the list narrows fast. If you need on-prem isolation, the two open-source names are usually where teams land.
+
+**Q: When does agentic RAG earn its seat?**
+
+Four situations. Users ask follow-ups that depend on previous retrievals. The correct answer requires joining two corpora. Intent is ambiguous and you would rather the system clarify than guess. Retrieval must choose among multiple typed sources (structured DB, unstructured store, API). For simple lookups, agentic RAG is a tax: three extra seconds and a bigger token bill for no accuracy gain. The trap teams walk into: wiring agentic retrieval on top of a single store that never needed it. See the [agentic RAG glossary entry](../glossary/agentic-rag.md).
+
+## Citations
+
+1. **arXiv / Jina AI** — Late Chunking: Contextual Chunk Embeddings Using Long-Context Embedding Models — https://arxiv.org/abs/2409.04701 [accessed 2026-04-17] *(Published September 7, 2024. Authors Günther, Mohr, Wang, Xiao (Jina AI). Code: https://github.com/jina-ai/late-chunking.)* { #cite-1 }
+2. **Voyage AI** — The Voyage 4 model family: shared embedding space with MoE architecture — https://blog.voyageai.com/2026/01/15/voyage-4/ [accessed 2026-04-17] *(January 15, 2026 release. First production embedding model with MoE; shared embedding space across 4-large/4/4-lite.)* { #cite-2 }
+3. **RAGAS** — Ragas: Automated Evaluation of Retrieval Augmented Generation — https://docs.ragas.io/en/stable/ [accessed 2026-04-17] *(Framework documentation. Core paper arXiv 2309.15217. Metrics: Faithfulness, Context Precision/Recall, Response Relevancy, Tool Call F1, Agent Goal Accuracy.)* { #cite-3 }
+4. **Cohere** — Cohere Embed v4 (multimodal, 128K-token context) — https://docs.cohere.com/docs/cohere-embed [accessed 2026-04-17] *(Cohere Embed v4 documentation. Text + image in shared embedding space; 128K token context window.)* { #cite-4 }
+5. **OpenAI** — New embedding models (text-embedding-3-large / 3-small) — https://openai.com/index/new-embedding-models-and-api-updates/ [accessed 2026-04-17] *(OpenAI's text-embedding-3 family launch. Matryoshka variable dimensions; $0.13/M tokens for 3-large, $0.02/M for 3-small.)* { #cite-5 }
+6. **AWS (Cohere)** — Cohere Rerank 3.5 is now available in Amazon Bedrock through Rerank API — https://aws.amazon.com/blogs/machine-learning/cohere-rerank-3-5-is-now-available-in-amazon-bedrock-through-rerank-api/ [accessed 2026-04-17] *(Cohere Rerank 3.5 availability via Bedrock Rerank API. Notable lift on constrained queries and semi-structured JSON.)* { #cite-6 }
+7. **Xenoss** — Pinecone vs Qdrant vs Weaviate: enterprise vector database comparison — https://xenoss.io/blog/vector-database-comparison-pinecone-qdrant-weaviate [accessed 2026-04-17] *(Third-party 2025 comparison. SOC 2/ISO/HIPAA claims, BYOC, multitenancy, hybrid search, 2-5x Qdrant QPS on filtered queries.)* { #cite-7 }
+8. **Voyage AI** — voyage-3-large: the new state-of-the-art general-purpose embedding model — https://blog.voyageai.com/2025/01/07/voyage-3-large/ [accessed 2026-04-17] *(January 7, 2025 release. Voyage 3-large topped Cohere v4 and OpenAI 3-large on a number of MTEB tasks.)* { #cite-8 }
+9. **Jina AI** — Late Chunking in Long-Context Embedding Models (product notes) — https://jina.ai/news/late-chunking-in-long-context-embedding-models/ [accessed 2026-04-17] *(Jina AI late-chunking product notes; implementation available in jina-embeddings-v3 API with up to 8,192 tokens.)* { #cite-9 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/enterprise-rag/](https://www.exploreagentic.ai/enterprise-rag/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/pillars/index.md
+++ b/docs/explore-agentic/pillars/index.md
@@ -1,0 +1,51 @@
+# Pillars
+
+> Four long-read field guides on the categories that determine 2026 enterprise AI architecture. Each one is dated, cited, and reviewed by a named editor before publication.
+
+<div class="grid cards" markdown>
+
+-   :material-robot-outline:{ .lg .middle } &nbsp; **Agentic AI, minus the agent-washing**
+
+    ---
+
+    The five tells that separate real agentic AI from a rebadged chatbot, the runtimes that matter (Strands, Microsoft Agent Framework, LangGraph, CrewAI, OpenAI Agents SDK), and the workloads where agents earn their keep.
+
+    *Pillar N°01 · 18 min · Updated April 2026*
+
+    [:octicons-arrow-right-24: Read pillar](agentic-ai.md)
+
+-   :material-protocol:{ .lg .middle } &nbsp; **Model Context Protocol (MCP)**
+
+    ---
+
+    The protocol Anthropic published in November 2024, the four roles that emerged in production, the auth timeline procurement teams care about, and the gateway pattern every serious deployment lands on.
+
+    *Pillar N°02 · 15 min · Updated April 2026*
+
+    [:octicons-arrow-right-24: Read pillar](mcp.md)
+
+-   :material-shield-check-outline:{ .lg .middle } &nbsp; **AI Governance**
+
+    ---
+
+    Where ISO 42001, the NIST AI RMF, and EU AI Act timelines actually intersect. The clauses that show up in 2026 RFPs and the operating model auditors expect to see.
+
+    *Pillar N°03 · 17 min · Updated April 2026*
+
+    [:octicons-arrow-right-24: Read pillar](ai-governance.md)
+
+-   :material-database-search-outline:{ .lg .middle } &nbsp; **Enterprise RAG**
+
+    ---
+
+    Hybrid retrieval, agentic RAG, and the eval discipline that separates production-grade pipelines from demoware. With the workloads where RAG earns its seat and where it's pure tax.
+
+    *Pillar N°04 · 18 min · Updated April 2026*
+
+    [:octicons-arrow-right-24: Read pillar](enterprise-rag.md)
+
+</div>
+
+---
+
+The pillars are mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — read the canonical versions at [www.exploreagentic.ai/agentic-ai/](https://www.exploreagentic.ai/agentic-ai/), [/mcp/](https://www.exploreagentic.ai/mcp/), [/ai-governance/](https://www.exploreagentic.ai/ai-governance/), and [/enterprise-rag/](https://www.exploreagentic.ai/enterprise-rag/).

--- a/docs/explore-agentic/pillars/mcp.md
+++ b/docs/explore-agentic/pillars/mcp.md
@@ -1,0 +1,134 @@
+# Model Context Protocol, sixteen months in
+
+> Anthropic open-sourced MCP on November 25, 2024. Sixteen months later it has 97 million monthly SDK downloads, a Linux Foundation home, and an OAuth 2.1 authorization spec that finally satisfies most CISOs. Field guide for platform teams shipping it now.
+
+*Pillar · Model Context Protocol · 14 minutes · Updated April 17, 2026 · Author Alexander · Reviewed by Elias Saljuki*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/mcp/](https://www.exploreagentic.ai/mcp/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## Intro
+
+Open the modelcontextprotocol.io home page <a href="#cite-1" class="cite-ref">[1]</a> and you will not find a manifesto. You will find an RFC index, an SDK matrix in seven languages, and a list of 10,000+ public servers. Sixteen months after Anthropic announced it on November 25, 2024 <a href="#cite-2" class="cite-ref">[2]</a>, MCP has become what its early backers said it would: a JSON-RPC interface for letting models call tools and read data, governed in public, used by everyone with a chat product.
+
+This pillar is the working version of the field map. It covers the four roles in production, the auth spec evolution that finally landed in March 2026 <a href="#cite-3" class="cite-ref">[3]</a>, the gateway category that AWS and Microsoft both shipped this year, and the questions a platform team should ask before its third MCP server.
+
+## TL;DR
+
+- MCP defines three protocol roles: client (the app), server (the tool/data surface), host (the model runtime). Gateways are a fourth, ops-driven role that every multi-server program ends up building or buying.
+- 97 million monthly SDK downloads and over 10,000 active servers as of December 2025, per Anthropic and the Linux Foundation announcement <a href="#cite-4" class="cite-ref">[4]</a>.
+- Donated to the Agentic AI Foundation under the Linux Foundation on December 9, 2025. Co-founded by Anthropic, Block, and OpenAI; backed by Google, Microsoft, AWS, Cloudflare, and Bloomberg.
+- The OAuth 2.1 authorization model became fully usable for enterprise deployments in the November 2025 spec revision (PKCE mandatory, Client ID Metadata Documents) and tightened in March 2026 with mandatory RFC 8707 resource indicators <a href="#cite-3" class="cite-ref">[3]</a>.
+- AWS Bedrock AgentCore went GA on October 13, 2025, with MCP server targets and an open-source AgentCore MCP server in nine regions <a href="#cite-5" class="cite-ref">[5]</a>. Microsoft Foundry MCP Server is in preview at mcp.ai.azure.com, Entra-authenticated <a href="#cite-6" class="cite-ref">[6]</a>.
+
+## Stats
+
+- **Nov 25, 2024** — Anthropic open-sources MCP *(Anthropic announcement of the spec, SDKs, and reference servers (Google Drive, Slack, GitHub, Postgres). Source [2].)*
+- **Dec 9, 2025** — Donated to the Agentic AI Foundation *(Anthropic's announcement of the AAIF (Linux Foundation directed fund) co-founded with Block and OpenAI. Source [4].)*
+- **97M / 10K** — Monthly SDK downloads / active servers *(Public adoption figures cited by Anthropic and the Linux Foundation as of December 2025.)*
+- **2026-03-15** — Latest spec revision *(RFC 8707 resource indicators became mandatory to mitigate token mis-redemption. Source [3].)*
+
+## 01. The three protocol roles, plus the one ops added
+
+The spec defines three participants <a href="#cite-1" class="cite-ref">[1]</a>. A <strong>client</strong> renders the conversation or workflow to the user: Claude Desktop, Cursor, ChatGPT, Microsoft Copilot, and roughly two dozen others. A <strong>server</strong> exposes data, prompts, or tools through a JSON-RPC surface. A <strong>host</strong> runs the model and orchestrates tool calls. Any of the three can be swapped independently. In practice, enterprises rarely want all three swappable; the procurement value is in pinning two and varying one.
+
+The emergent fourth role is the <strong>gateway</strong>. A gateway is an authorization- and observability-aware proxy that sits between a set of clients and a set of MCP servers. It enforces policy on every tool call, logs the call to a system the audit team can read, and brokers the credentials that the end user should never paste into a prompt. AWS shipped one as AgentCore Gateway <a href="#cite-5" class="cite-ref">[5]</a>. Cloudflare ships one as MCP Server Portals <a href="#cite-7" class="cite-ref">[7]</a>. Most platform teams that buy neither end up building one.
+
+*The four roles in a production MCP deployment, April 2026*
+
+| Role | Spec status | Responsibility | Who owns it |
+| --- | --- | --- | --- |
+| Client | Spec-defined | Renders the conversation, collects input, presents tool affordances | Product team or vendor |
+| Host | Spec-defined | Runs the model; orchestrates the tool-call loop | Platform team |
+| Server | Spec-defined | Implements the JSON-RPC surface; exposes data, prompts, tools | Domain team (HR, Finance, IT) |
+| Gateway | Emergent | Authenticates, authorizes, logs, rate-limits across many servers | Platform + Security, jointly |
+
+## 02. What shipped between November 2024 and April 2026
+
+Twelve months of unusually orderly releases. The original Anthropic announcement landed November 25, 2024, with reference servers for Google Drive, Slack, GitHub, Git, Postgres, and Puppeteer, and SDKs in Python, TypeScript, C#, and Java <a href="#cite-2" class="cite-ref">[2]</a>. Block and Apollo were the first two named enterprise adopters in the same announcement.
+
+In March 2025 the spec gained OAuth 2.1 authorization. In June 2025 it formally split MCP servers from authorization servers and required Protected Resource Metadata under RFC 9728 <a href="#cite-8" class="cite-ref">[8]</a>. In November 2025 it adopted Client ID Metadata Documents and made PKCE non-negotiable for every client. Each revision survived a public RFC; none broke the wire format.
+
+On December 9, 2025, Anthropic announced the donation of MCP to a new Agentic AI Foundation under the Linux Foundation, co-founded with Block and OpenAI <a href="#cite-4" class="cite-ref">[4]</a>. Google, Microsoft, AWS, Cloudflare, Bloomberg, and Intuit signed on as supporting members. The neutral-governance question that some CISOs had been quietly raising in security reviews stopped being a question.
+
+> The wire format barely moved in sixteen months. The auth surface changed almost every quarter, and that is the part that determined whether you could deploy this in a regulated environment.
+
+## 03. Authorization, the part security review reads
+
+If your security team has been asking for the auth model in writing, the answer in April 2026 is straightforward enough to pin to a slide. An MCP server acts as an OAuth 2.1 resource server. The MCP client is an OAuth 2.1 client making protected-resource requests on behalf of the user. The host runtime never sees long-lived credentials. <a href="#cite-3" class="cite-ref">[3]</a>
+
+Three concrete things changed in the last six months that matter for procurement. First, the November 2025 spec made PKCE mandatory across all clients (not optional, not configurable). Second, Client ID Metadata Documents replaced ad hoc client registration, which is the change that lets you publish a single client manifest and have every MCP server you talk to validate it identically. Third, the March 15, 2026 revision mandated RFC 8707 resource indicators to prevent token mis-redemption (the attack class where a token issued for tool A is replayed against tool B). <a href="#cite-3" class="cite-ref">[3]</a>
+
+If you are evaluating MCP servers from third parties, the short due-diligence list: do they implement Protected Resource Metadata under RFC 9728, do they enforce PKCE, and do they validate the resource indicator on every token. A vendor that cannot answer these three questions in writing has not read the current spec.
+
+> **What this means in procurement**: When AWS shipped AgentCore Gateway GA in October 2025 with Cognito-backed OAuth, and Microsoft shipped Foundry MCP Server in preview hosted at mcp.ai.azure.com with Entra-only auth and on-behalf-of token flows, both were specifically aligning to the protocol-level auth spec, not inventing their own. That convergence is what made auth a procurement-answerable question instead of a research project.
+
+## 04. Gateways: where most of the 2026 budget is going
+
+Every platform team with more than three MCP servers ends up building or buying a gateway. The reasons are unexciting: per-tool authorization, a single point at which to log every call, a centralized rate-limit, and a hard boundary at which to enforce egress rules. The MCP spec does not require a gateway. Production deployment patterns do.
+
+The vendor list grew quickly. AWS Bedrock AgentCore Gateway became GA on October 13, 2025, in nine regions, and now connects to MCP servers as named targets <a href="#cite-5" class="cite-ref">[5]</a>. Cloudflare's MCP Server Portals consolidate authorized servers behind a single endpoint <a href="#cite-7" class="cite-ref">[7]</a>. The independent landscape includes Kong, Composio, Bifrost, and Zuplo, plus a long tail of in-house gateways at companies that started before the products existed. Most options shipped between September 2025 and Q1 2026. Assume the comparison shifts every quarter.
+
+- **Tool-level authorization, written as policy** — Which users, under which conditions, can invoke which tools on which servers. Versioned, reviewable, expressed as code (Cedar in AgentCore's case).
+- **Credential brokering** — The gateway holds the Snowflake PAT, the Jira token, the SharePoint secret. The user never sees them; the model never receives them in clear text.
+- **Call observability** — Per-tool latency, per-tool error rate, per-tool outcome flag. Traceable back to a conversation ID and, where possible, to a business event in the calling system.
+- **Egress enforcement** — For regulated workloads, the gateway is the chokepoint that proves PII never left a region and free-form text was never exfiltrated through a tool call.
+
+## 05. If your team is starting MCP work this quarter
+
+Pick one workflow that already has a real metric. Stand up one MCP server for it. Front the server with whichever gateway your procurement team can get through fastest; that almost certainly means whichever cloud you already buy from, which means AgentCore Gateway on AWS or the Foundry MCP Server on Azure. Instrument every tool call with an outcome flag from the first deployment. The programs that scaled in 2025 looked like this. The ones that did not scaled the registry first and the use case second.
+
+Two things to skip in the first sixty days. Do not try to publish a server catalog before you have a working green call graph for the first server. Do not write your own authorization layer; use the spec's OAuth 2.1 + RFC 8707 model and the gateway's enforcement of it. Both shortcuts seem like accelerators and almost always cost a quarter.
+
+> **Further reading on this site**: Vendor evaluation rubric for MCP gateways: /glossary/mcp-gateway. Comparison of MCP and RAG (the two protocols people most often confuse): /comparisons/mcp-vs-rag. Field analysis of AgentCore vs Foundry as MCP hosting platforms: /insights/aws-agentcore-vs-azure-ai-foundry.
+
+## FAQ
+
+**Q: What is the Model Context Protocol (MCP)?**
+
+MCP is an open JSON-RPC specification, originally released by Anthropic on November 25, 2024 <a href="#cite-2" class="cite-ref">[2]</a>, that lets a language-model client call tools and read data from an external server in a uniform way. It defines three roles: client (the app), server (the tool/data surface), and host (the model runtime). The protocol was donated to the Agentic AI Foundation under the Linux Foundation on December 9, 2025 <a href="#cite-4" class="cite-ref">[4]</a>.
+
+**Q: Who governs MCP today?**
+
+Since December 9, 2025, MCP is governed by the Agentic AI Foundation (AAIF), a directed fund hosted by the Linux Foundation. The AAIF was co-founded by Anthropic, Block, and OpenAI, with supporting members including Google, Microsoft, AWS, Cloudflare, Bloomberg, and Intuit <a href="#cite-4" class="cite-ref">[4]</a>. Day-to-day technical direction stays with the project's maintainers; the foundation handles funding, IP, and trademarks.
+
+**Q: How does MCP authentication and authorization work?**
+
+An MCP server acts as an OAuth 2.1 resource server; the MCP client is an OAuth 2.1 client making requests on behalf of the user. As of the March 15, 2026 spec revision, three things are mandatory: PKCE on every client, Protected Resource Metadata under RFC 9728, and resource indicators under RFC 8707 to prevent token mis-redemption between tools <a href="#cite-3" class="cite-ref">[3]</a>. Both AWS AgentCore Gateway and Microsoft Foundry MCP Server align to this spec rather than implementing custom auth.
+
+**Q: Do I need an MCP gateway?**
+
+Once you operate more than three MCP servers in the same environment, the answer is almost always yes. Gateways centralize per-tool authorization, log every tool call, broker enterprise credentials so the user never pastes tokens into prompts, and enforce egress rules for regulated data. AWS Bedrock AgentCore Gateway (GA October 13, 2025) <a href="#cite-5" class="cite-ref">[5]</a> and Cloudflare MCP Server Portals <a href="#cite-7" class="cite-ref">[7]</a> are the two cloud-native options. Independent vendors include Kong, Composio, Bifrost, and Zuplo.
+
+**Q: How is MCP different from RAG?**
+
+RAG (Retrieval-Augmented Generation) is a pattern for grounding a model's response in a retrieved document set; MCP is a wire protocol for letting a model call tools and fetch context. They solve different problems and are usually used together. A full comparison with implementation guidance is at /comparisons/mcp-vs-rag.
+
+**Q: Which AI clients support MCP?**
+
+As of December 2025, MCP has first-class client support across Claude (Anthropic), ChatGPT (OpenAI), Cursor, Gemini, Microsoft Copilot, Visual Studio Code, Visual Studio 2026 Insiders, and approximately twenty other clients <a href="#cite-4" class="cite-ref">[4]</a>. The protocol's monthly SDK downloads passed 97 million in the same window. Adoption is broad enough that vendor-lock concerns no longer block enterprise procurement.
+
+## Citations
+
+1. **Model Context Protocol** — Authorization specification (current) — https://modelcontextprotocol.io/specification/draft/basic/authorization [accessed 2026-04-17] *(Canonical spec home; SDK matrix and server registry index linked from this page.)* { #cite-1 }
+2. **Anthropic** — Introducing the Model Context Protocol — https://www.anthropic.com/news/model-context-protocol [accessed 2026-04-17] *(Original Nov 25, 2024 announcement; lists initial reference servers (Drive, Slack, GitHub, Postgres) and SDKs (Python, TypeScript, C#, Java).)* { #cite-2 }
+3. **dasroot.net (Maciej Kocon)** — The New MCP Authorization Specification — OAuth 2.1, Resource Indicators — https://dasroot.net/posts/2026/04/mcp-authorization-specification-oauth-2-1-resource-indicators/ [accessed 2026-04-17] *(Walkthrough of the March 15, 2026 spec revision and the RFC 8707 resource-indicators mandate.)* { #cite-3 }
+4. **Anthropic** — Donating the Model Context Protocol and establishing the Agentic AI Foundation — https://www.anthropic.com/news/donating-the-model-context-protocol-and-establishing-of-the-agentic-ai-foundation [accessed 2026-04-17] *(Dec 9, 2025 announcement; lists supporting members and the 97M / 10K adoption figures cited above.)* { #cite-4 }
+5. **AWS** — Amazon Bedrock AgentCore is now generally available — https://aws.amazon.com/about-aws/whats-new/2025/10/amazon-bedrock-agentcore-available/ [accessed 2026-04-17] *(October 13, 2025 GA announcement; nine-region availability and AgentCore Gateway MCP server targets.)* { #cite-5 }
+6. **Microsoft** — Announcing Foundry MCP Server (preview) in the cloud — https://devblogs.microsoft.com/foundry/announcing-foundry-mcp-server-preview-speeding-up-ai-dev-with-microsoft-foundry/ [accessed 2026-04-17] *(Microsoft Foundry MCP Server preview at https://mcp.ai.azure.com with Entra ID OBO auth.)* { #cite-6 }
+7. **Cloudflare** — Scaling MCP adoption: reference architecture for enterprise MCP deployments — https://blog.cloudflare.com/enterprise-mcp/ [accessed 2026-04-17] *(Cloudflare MCP Server Portals + the gateway-as-aggregation pattern.)* { #cite-7 }
+8. **Auth0 (Okta)** — Model Context Protocol Spec Updates from June 2025 — All About Auth — https://auth0.com/blog/mcp-specs-update-all-about-auth/ [accessed 2026-04-17] *(June 2025 split of MCP servers from authorization servers; introduction of Protected Resource Metadata (RFC 9728).)* { #cite-8 }
+9. **Linux Foundation** — Linux Foundation Announces the Formation of the Agentic AI Foundation (AAIF) — https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation [accessed 2026-04-17] *(Foundation press release; founding projects (MCP, goose, AGENTS.md) and supporting member list.)* { #cite-9 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/mcp/](https://www.exploreagentic.ai/mcp/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/playbooks/ai-agent-roi.md
+++ b/docs/explore-agentic/playbooks/ai-agent-roi.md
@@ -1,0 +1,120 @@
+# How to measure AI agent ROI without embarrassing yourself
+
+> A ten-week, CFO-ready framework for measuring AI agent ROI. Productivity-minute arithmetic is why the first wave of agent programs lost their renewal. This playbook (baseline first, direct P&L second, quarterly report third) is the replacement we now run with customers.
+
+*Playbook · Governance · 2026 Quarterly · 12 minutes · Updated April 12, 2026 · Author Michael Clough · Reviewed by Merve Tengiz*
+
+!!! info "Originally published on Explore Agentic"
+
+    The canonical version of this article lives at [www.exploreagentic.ai/playbooks/ai-agent-roi/](https://www.exploreagentic.ai/playbooks/ai-agent-roi/). Browse the full library of pillars, glossary entries, comparisons, and playbooks at [www.exploreagentic.ai](https://www.exploreagentic.ai/).
+
+
+## TL;DR
+
+- Productivity-minute arithmetic is the trap. Finance will never approve renewals on "thirty minutes saved per employee per week." Gartner projects over 40% of agentic AI projects will be cancelled by end of 2027, with ROI confusion the most-cited cause <a href="#cite-1" class="cite-ref">[1]</a>.
+- The framework that survives is direct P&L: cycle-time reduction on one named workflow, cost-per-resolution, revenue-per-lead. Futurum's 1H 2026 survey of 830 IT decision-makers shows direct-financial-impact nearly doubled to 21.7% as the primary ROI metric, while productivity gains collapsed from 23.8% to 18.0% <a href="#cite-2" class="cite-ref">[2]</a>.
+- Instrument the workflow before the agent ships. Four to eight weeks of baseline beats any post-hoc benefits model. This is also the Forrester Total Economic Impact (TEI) methodology's first move <a href="#cite-3" class="cite-ref">[3]</a>.
+- Report quarterly, not ad hoc. The programs that clear year-two renewal have a fixed cadence, a fixed format, and a finance partner who signed off before the agent shipped. McKinsey's November 2025 state-of-AI report found only ~39% of firms see enterprise-level EBIT impact despite 88% adopting AI <a href="#cite-4" class="cite-ref">[4]</a>.
+
+## Why productivity-minute arithmetic fails
+
+The first wave of agentic programs (roughly 2023 through 2025) was sold on productivity-minute arithmetic. "Thirty minutes saved per employee per week, times headcount, times the hourly rate, equals $X." The math is arithmetic. Finance does not believe it. Finance is right.
+
+Saved minutes almost never convert to reduced headcount, reduced overtime, or any line on the P&L. They convert to other work. Sometimes useful. Sometimes not. Always unmeasured. At renewal, the CFO asks what the agent did to the income statement. The answer is vapor.
+
+The market already priced this in. Gartner's June 25, 2025 note: more than 40% of agentic AI projects cancelled by end of 2027. Named drivers: escalating costs, unclear business value, inadequate risk controls <a href="#cite-1" class="cite-ref">[1]</a>. Futurum polled 830 IT decision-makers on February 17, 2026. Productivity gains dropped 5.8 points as the primary success metric year-over-year. Direct financial impact (revenue growth plus bottom-line profitability) nearly doubled to 21.7% <a href="#cite-2" class="cite-ref">[2]</a>. Signal is unambiguous. CFO language is replacing CIO language at the renewal table.
+
+> The productivity argument was the right metric for the GenAI pilot phase, but the market has matured. Enterprises are now demanding that every AI capability connect directly to revenue growth or margin improvement. — Keith Kirkpatrick, Futurum Group · Feb 17, 2026
+
+## The three questions that decide renewal
+
+Three questions. They now appear almost verbatim in public RFPs, earnings-call Q&A, and the CFO letters we read in procurement. McKinsey's November 2025 reporting: only about 39% of firms see enterprise-level EBIT impact from AI, despite 88% using it somewhere <a href="#cite-4" class="cite-ref">[4]</a>. The questions are the ones finance has to ask. What changed. What stopped being paid for. Where is the evidence. If your program cannot answer them before the renewal meeting, budget a hard conversation.
+
+1. **Which specific workflow changed, and by how much?** — Not "we deployed an AI assistant." A named workflow (ticket-to-resolution cycle time in the HR ticketing queue, invoice-match rate in AP, mean time to first draft on a regulatory filing) with a before number, an after number, and a confidence interval. Forrester's TEI methodology requires a composite organization built from named interviewees for exactly this reason: the workflow has to be specific enough to audit <a href="#cite-3" class="cite-ref">[3]</a>.
+2. **What did we stop paying for?** — Headcount reduced, overtime reduced, vendors retired, contractors unbooked, seat licenses dropped. If none of these, the saving is counterfactual, and counterfactual savings rarely survive a second-year budget review. McKinsey's November 2025 read was blunt: workflow redesign, not chatbot deployment, is the variable that correlates with EBIT impact <a href="#cite-4" class="cite-ref">[4]</a>.
+3. **Where is the evidence?** — A dashboard, a monthly report, a baseline signed off by the workflow owner and the finance partner before the agent shipped. Trace-level evidence helps: AgentCore Observability routes every span into CloudWatch for audit <a href="#cite-5" class="cite-ref">[5]</a>; LangSmith produces per-call cost breakdowns with P50/P99 latency and per-model token spend <a href="#cite-6" class="cite-ref">[6]</a>. "Our team feels faster" does not clear finance.
+
+## The ten-week playbook
+
+The sequence we run with enterprise customers on ASCENDING's Jarvis deployments. Not the only one that works. The one that has survived the most renewal conversations. Each step maps to a HowTo schema step in the page metadata. Follow them in order. Skip none.
+
+Two things to notice about the shape. Measurement starts in week 1, not week 6. Ship the agent before you have a baseline and you will spend the renewal rebuilding one from memory. The finance partner is in the room from week 3, not week 10. Most programs skip this step. It is the one that correlates best with renewal success in our experience.
+
+1. **Week 1: Pick one workflow with a real existing metric** — Ticket-to-resolution cycle time, mean time to first draft, invoice-match rate, lead-to-MQL latency. The workflow must already have a number someone is tracking; if it doesn't, the first agent to deploy against it will generate the metric and grade its own homework. Workflow owner signs off in writing.
+2. **Weeks 2–3: Instrument the baseline** — Four weeks of the current workflow measured the way it will be measured post-deployment. This is the step Forrester's TEI methodology calls "due diligence," and Forrester requires it before modelling <a href="#cite-3" class="cite-ref">[3]</a>. Baseline cycle time, baseline cost per unit, baseline error rate, baseline SLA breach count. Persist to a system the finance team can read directly, not a shared spreadsheet.
+3. **Week 3: Recruit the finance partner** — A named person in FP&A or the divisional CFO's office who will sit in the steering group through year two. They agree the three renewal questions on record before any agent code ships. This is the step most programs skip; it is also the single strongest predictor of renewal success we have observed across the Jarvis deployment portfolio.
+4. **Weeks 4–6: Ship the agent behind a gateway** — A narrow agent against the one chosen workflow, fronted by an MCP gateway so every tool call is authorized, logged, and cost-attributed from day one. AWS Bedrock AgentCore (GA October 13, 2025) and Microsoft Foundry MCP Server (preview, hosted at mcp.ai.azure.com) both emit trace-level observability by default <a href="#cite-5" class="cite-ref">[5]</a>. Do not build your own trace pipeline in the first sixty days.
+5. **Weeks 6–8: Measure variance against baseline** — Same metric definitions, same data plane, same owner. Compute cycle-time reduction, cost-per-unit delta, error-rate delta, and, critically, the dollar conversion. If the cycle-time reduction did not reduce headcount, overtime, contractor spend, or a vendor line item, label the saving counterfactual in the report. Do not hide this column.
+6. **Week 9: Write the CFO report** — Two pages. Page one: the three questions, answered with numbers. Page two: the cost of the program (platform license, integration partner, redirected staff time, observability spend, all of it). The finance partner edits the draft before distribution. Format survives into quarter two unchanged.
+7. **Week 10 onward: Report quarterly, forever** — Same date, same shape, same distribution list every quarter. The CFO should not have to ask. The programs that clear year-two renewal have reported four consecutive quarters on the same cadence; the programs that lose renewal sent a single ad-hoc deck in month ten. Treat the cadence as a contract, not a courtesy.
+
+## Instrument the workflow before the agent ships
+
+One predictor beats all others. Was the workflow instrumented before the agent shipped? A baseline of cycle time, cost per unit, and error rate, logged in a system the CFO can audit. Not a slide deck. Not a Notion page. Not a conversation someone remembers.
+
+The baseline is harder than it sounds. You have to convince a workflow owner to measure their team's work for four to eight weeks before you help them. It is the least interesting slide in the deck. That is why it gets skipped, and why so many programs quietly fail at renewal. Forrester's TEI methodology <a href="#cite-3" class="cite-ref">[3]</a> builds a "composite organization" from multiple customer interviews precisely because self-reported post-hoc numbers do not survive audit. The baseline has to pre-date the treatment.
+
+Observability is the procurement-answerable half. AWS Bedrock AgentCore Observability routes trace, span, and token-cost data through CloudWatch dashboards with per-session rollups <a href="#cite-5" class="cite-ref">[5]</a>. LangSmith publishes a model-pricing map and produces per-call cost data with P50/P99 latency on its $39/seat/month Plus tier and custom Enterprise tier <a href="#cite-6" class="cite-ref">[6]</a>. Neither tool answers the dollar-impact question. Both give you the telemetry to answer it yourself. Which is what finance actually needs.
+
+> **Tool selection, plainly**: If you are already on AWS, AgentCore Observability is the path of least procurement resistance; trace data lands in CloudWatch and your security team already has CloudWatch policy. If you are multi-cloud or want detailed per-prompt cost attribution, LangSmith is the fastest way to get P50/P99 latency and token-cost views into a finance-readable format. Neither replaces the human step: the baseline has to be signed off by the workflow owner before the agent runs.
+
+## Report quarterly, not ad hoc
+
+Programs that survive renewal report on a fixed cadence. Quarterly is the minimum that survives contact with reality. Monthly is better if the workflow moves fast. The format matters less than the cadence. What matters is that the CFO receives a report on the same date, in the same shape, every quarter, without having to ask.
+
+Two pages is the right length. Page one answers the three renewal questions with numbers. Page two is the full cost stack: platform license, integration partner, redirected staff time, observability and gateway spend, model-inference tokens. The finance partner edits the draft. You send the final. By quarter four, the report writes itself. By year two, the CFO forwards it to their board.
+
+Why four reports and not two? It is a fair question. The practical answer: McKinsey's November 2025 state-of-AI report found only about a third of firms have scaled AI across the organisation, despite 88% using it somewhere <a href="#cite-4" class="cite-ref">[4]</a>. The most visible difference between the two groups is reporting cadence. Programs that report twice a year get cancelled on year-end budget resets.
+
+## How-To Steps
+
+1. **Pick one workflow with an existing metric** — Select one named workflow that already has a tracked number (e.g., ticket-to-resolution cycle time, invoice-match rate, lead-to-MQL latency). The workflow owner signs off in writing before week 2.
+2. **Instrument the baseline for four weeks** — Four weeks of baseline. Same metric definitions you will use after the agent ships. Persist to a system finance can read directly. Mirrors the due-diligence step in Forrester's TEI methodology.
+3. **Recruit a named finance partner** — One person in FP&A or the divisional CFO's office. They sit in the steering group through year two. Agree the three renewal questions (what changed, what stopped being paid for, where is the evidence) in writing before any agent code ships.
+4. **Ship a narrow agent behind an MCP gateway** — Deploy a single-purpose agent against the chosen workflow, fronted by an MCP gateway (AWS Bedrock AgentCore or Microsoft Foundry MCP Server) so every tool call is authorized, logged, and cost-attributed from day one.
+5. **Measure variance against baseline** — Same metric definitions. Same data plane. Same owner. Compute cycle-time reduction, cost-per-unit delta, error-rate delta, and a dollar conversion. If the saving did not move headcount, overtime, contractor spend, or a vendor line, label it counterfactual.
+6. **Write a two-page CFO report** — Page one: the three renewal questions, answered with numbers. Page two: the full cost stack (license, integration partner, redirected staff, observability spend, token costs). The finance partner edits the draft before distribution.
+7. **Report on a fixed quarterly cadence** — Same date, same shape, same distribution list every quarter. The CFO should not have to ask. Four consecutive quarters of reporting is the strongest predictor of year-two renewal success we have observed.
+
+## FAQ
+
+**Q: How long does it take to measure AI agent ROI properly?**
+
+Ten weeks to the first CFO-ready report. Not six. Shape of it: weeks 1-3 are baseline plus finance-partner onboarding, weeks 4-6 ship a narrow agent behind a gateway, weeks 6-8 measure variance, week 9 writes two pages, week 10 onward is quarterly forever. The tempting shortcut is skipping the baseline. Teams that skip it lose renewal. Same teams, same order. Forrester's full TEI methodology runs longer than ten weeks <a href="#cite-3" class="cite-ref">[3]</a>. Ten is the floor that still survives a finance read.
+
+**Q: What metrics actually matter for AI agent ROI?**
+
+The ones the CFO already tracks. Cycle-time reduction on one named workflow. Cost-per-resolution. Cost-per-invoice. Cost-per-lead. Error-rate delta. And a dollar conversion that lands on a real P&L line: headcount, overtime, contractor spend, a vendor contract you stopped renewing. Futurum polled 830 IT decision-makers on February 17, 2026. Direct financial impact nearly doubled year-over-year to 21.7% as the primary ROI metric. Productivity-minute metrics lost 5.8 points <a href="#cite-2" class="cite-ref">[2]</a>. If your number is "minutes saved per employee per week," you are measuring the thing the CFO has stopped accepting.
+
+**Q: Is productivity-minute arithmetic ever a valid way to measure AI ROI?**
+
+Rarely. Never as the primary metric. It has one honest use: internal steering. Which teams adopted the tool, where resistance sits, who quietly stopped using it in month three. Useful for the program manager. Not useful for finance. McKinsey's November 2025 read is blunt. 88% of firms use AI somewhere. Only about 39% see enterprise-level EBIT impact. The variable that correlates with EBIT is workflow redesign, not minutes-saved <a href="#cite-4" class="cite-ref">[4]</a>. If productivity is your only number, assume the Gartner cancellation curve (40%+ of agentic projects dead by end of 2027) has your program in scope <a href="#cite-1" class="cite-ref">[1]</a>.
+
+**Q: What tools do I need to measure agent ROI?**
+
+Three layers, plus one human. Layer one: a workflow metric system finance can audit directly. Your ITSM, ERP, or CRM. Not a new product. Layer two: agent observability. On AWS, AgentCore Observability (GA October 13, 2025, trace and span into CloudWatch) is the path of least procurement resistance <a href="#cite-5" class="cite-ref">[5]</a>. Multi-cloud or per-prompt cost attribution: LangSmith publishes per-call cost plus P50/P99 latency on the $39/seat/month Plus tier <a href="#cite-6" class="cite-ref">[6]</a>. Layer three: the full cost stack. AgentCore pricing is consumption-based across four lines (orchestration, inference, retrieval, observability). You pay for all four, not just the model <a href="#cite-7" class="cite-ref">[7]</a>. The human layer is the named finance partner, in the room from week 3. Not a tool. Not optional.
+
+**Q: How do I handle counterfactual savings in the ROI report?**
+
+Label them. Do not bank them. Cycle time dropped 30%, but no headcount, overtime, contractor line, or vendor contract moved with it? The saving is real in time and invisible on the P&L. Add a column called "counterfactual." Show the number. Name the category. Let finance decide whether any portion rolls into the dollar total. Hiding the distinction is the fastest way to burn credibility with FP&A. Credibility is what renews the program. One more thing: do not promote a counterfactual figure in the executive summary. Finance will catch it. The CFO will remember.
+
+## Citations
+
+1. **Gartner** — Gartner Predicts Over 40% of Agentic AI Projects Will Be Canceled by End of 2027 — https://www.gartner.com/en/newsroom/press-releases/2025-06-25-gartner-predicts-over-40-percent-of-agentic-ai-projects-will-be-canceled-by-end-of-2027 [accessed 2026-04-17] *(June 25, 2025 press release. Names escalating costs, unclear business value, and inadequate risk controls as the drivers of cancellation.)* { #cite-1 }
+2. **The Futurum Group** — Enterprise AI ROI Shifts as Agentic Priorities Surge — https://futurumgroup.com/press-release/enterprise-ai-roi-shifts-as-agentic-priorities-surge/ [accessed 2026-04-17] *(February 17, 2026 press release summarizing the 1H 2026 Enterprise Software Decision Maker Survey (n=830). Productivity gains 23.8% to 18.0% as primary ROI metric; direct financial impact nearly doubled to 21.7%.)* { #cite-2 }
+3. **Forrester Research** — The Total Economic Impact (TEI) Methodology — https://www.forrester.com/policies/tei/ [accessed 2026-04-17] *(Forrester's public methodology page. Four-component model (benefits, costs, flexibility, risk); composite organization built from named customer interviews; due-diligence baseline required before modelling.)* { #cite-3 }
+4. **McKinsey & Company (QuantumBlack)** — The state of AI in 2025: Agents, innovation, and transformation — https://www.mckinsey.com/capabilities/quantumblack/our-insights/the-state-of-ai [accessed 2026-04-17] *(November 2025 report. 88% of organisations use AI in at least one function; only ~39% see enterprise-level EBIT impact; workflow redesign correlates most strongly with EBIT outcome.)* { #cite-4 }
+5. **Amazon Web Services** — Observe your agent applications on Amazon Bedrock AgentCore Observability — https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability.html [accessed 2026-04-17] *(Official AgentCore Observability documentation. CloudWatch-backed trace, span, token-usage, latency, session-duration and error-rate dashboards. GA October 13, 2025.)* { #cite-5 }
+6. **LangChain (LangSmith)** — LangSmith Plans and Pricing — https://www.langchain.com/pricing [accessed 2026-04-17] *(Developer (free, 5K traces/month), Plus ($39/seat/month, 10K traces), Enterprise (custom). Per-call cost tracking, P50/P99 latency, token-usage aggregation.)* { #cite-6 }
+7. **Amazon Bedrock AgentCore** — Amazon Bedrock AgentCore Pricing — https://aws.amazon.com/bedrock/agentcore/pricing/ [accessed 2026-04-17] *(Consumption-based pricing with no minimums. Token-priced built-in evaluators; orchestration, inference, retrieval, and observability billed separately.)* { #cite-7 }
+
+
+---
+
+## Continue reading on Explore Agentic
+
+This article is mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — a curated reading list on agentic AI, the Model Context Protocol, AI governance, and enterprise RAG, published by ASCENDING Inc.
+
+- **Read the original**: [www.exploreagentic.ai/playbooks/ai-agent-roi/](https://www.exploreagentic.ai/playbooks/ai-agent-roi/)
+- **Library home**: [www.exploreagentic.ai](https://www.exploreagentic.ai/)
+- **Pillars index**: [www.exploreagentic.ai/#pillars](https://www.exploreagentic.ai/#pillars)

--- a/docs/explore-agentic/playbooks/index.md
+++ b/docs/explore-agentic/playbooks/index.md
@@ -1,0 +1,19 @@
+# Playbooks
+
+> Step-by-step guides for the work people quietly need to do: measuring ROI, picking a gateway, running an internal eval. Each one ships with named reviewers and a citation list.
+
+<div class="grid cards" markdown>
+
+-   :material-finance:{ .lg .middle } &nbsp; **[How to measure AI agent ROI without embarrassing yourself](ai-agent-roi.md)**
+
+    ---
+
+    The CFO-side framework we now recommend. A ten-week, CFO-ready playbook: baseline first, direct P&L second, quarterly report third — the replacement for productivity-minute arithmetic that lost the first wave of agent programs their renewal.
+
+    *Playbook · Governance · April 2026 · 12 min*
+
+</div>
+
+---
+
+The playbooks are mirrored from [Explore Agentic](https://www.exploreagentic.ai/) — the canonical index lives at [www.exploreagentic.ai/playbooks/](https://www.exploreagentic.ai/playbooks/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,37 @@ nav:
     - Federation Guide: design/federation.md
     - Federation API: design/federation-api.md
     - DB Persistence: design/mcp_db_persistence_design.md
+  - Explore Agentic Jarvis:
+    - Overview: explore-agentic/index.md
+    - Pillars:
+      - Overview: explore-agentic/pillars/index.md
+      - Agentic AI: explore-agentic/pillars/agentic-ai.md
+      - Model Context Protocol: explore-agentic/pillars/mcp.md
+      - AI Governance: explore-agentic/pillars/ai-governance.md
+      - Enterprise RAG: explore-agentic/pillars/enterprise-rag.md
+    - Glossary:
+      - Overview: explore-agentic/glossary/index.md
+      - Model Context Protocol: explore-agentic/glossary/model-context-protocol.md
+      - MCP Gateway: explore-agentic/glossary/mcp-gateway.md
+      - Agentic RAG: explore-agentic/glossary/agentic-rag.md
+      - Agent Observability: explore-agentic/glossary/agent-observability.md
+      - ISO/IEC 42001:2023: explore-agentic/glossary/iso-42001.md
+      - NIST AI RMF: explore-agentic/glossary/nist-ai-rmf.md
+      - Shadow AI: explore-agentic/glossary/shadow-ai.md
+      - Agent Washing: explore-agentic/glossary/agent-washing.md
+      - Guardian Agent: explore-agentic/glossary/guardian-agent.md
+    - Comparisons:
+      - Overview: explore-agentic/comparisons/index.md
+      - Jarvis vs Moveworks: explore-agentic/comparisons/jarvis-vs-moveworks.md
+      - Jarvis vs Glean: explore-agentic/comparisons/jarvis-vs-glean.md
+      - Jarvis vs Copilot Studio: explore-agentic/comparisons/jarvis-vs-copilot-studio.md
+      - Moveworks vs Glean: explore-agentic/comparisons/moveworks-vs-glean.md
+      - MCP vs RAG: explore-agentic/comparisons/mcp-vs-rag.md
+      - Agentforce vs Copilot Studio: explore-agentic/comparisons/agentforce-vs-copilot-studio.md
+      - Agentspace vs Copilot: explore-agentic/comparisons/agentspace-vs-copilot.md
+    - Playbooks:
+      - Overview: explore-agentic/playbooks/index.md
+      - Measure AI Agent ROI: explore-agentic/playbooks/ai-agent-roi.md
   - Project:
     - Contributing: CONTRIBUTING.md
     - License: LICENSE.md


### PR DESCRIPTION
Add a new "Explore Agentic Jarvis" tab to the documentation site, mirroring the editorial library from exploreagentic.ai:

- 4 pillars (Agentic AI, MCP, AI Governance, Enterprise RAG)
- 9 glossary entries
- 7 side-by-side comparisons
- 1 ROI playbook
- Section overview pages with grid-card landing layout

Each article includes a top-of-page canonical callout and a bottom-of-page footer linking to the original on exploreagentic.ai. Cross-article references are rewritten to MkDocs directory URLs; citation references are anchored so [N] links jump in-page.