### PR TITLE
fix:Replace status == "active" query filters with the correct enabled…

### DIFF
--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_executor.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_executor.py
@@ -288,7 +288,7 @@ def make_a2a_pool_executor(
         if selected_path is None:
             paths = [f"/{k.lstrip('/')}" for k in pool_keys]
             agents = await A2AAgent.find(
-                {"path": {"$in": paths}, "status": "active"},
+                {"path": {"$in": paths}, "isEnabled": True},
             ).to_list()
 
             if accessible_agent_ids is not None:
@@ -296,9 +296,9 @@ def make_a2a_pool_executor(
 
             if not agents:
                 return StepOutput(
-                    content=f"No accessible active A2A agents for pool {pool_keys!r}",
+                    content=f"No accessible enabled A2A agents for pool {pool_keys!r}",
                     success=False,
-                    error="pool resolution failed: no accessible active agents",
+                    error="pool resolution failed: no accessible enabled agents",
                 )
 
             selected_agent = await _select_agent_with_llm(agents, task, selector_agent)
@@ -309,12 +309,12 @@ def make_a2a_pool_executor(
             state[cache_key] = selected_path
             logger.info("pool %r → selected agent %r", node_name, selected_path)
         else:
-            selected_agent = await A2AAgent.find_one({"path": selected_path, "status": "active"})
+            selected_agent = await A2AAgent.find_one({"path": selected_path, "isEnabled": True})
             if selected_agent is None:
                 return StepOutput(
-                    content=f"Selected agent {selected_path!r} is no longer active",
+                    content=f"Selected agent {selected_path!r} is no longer enabled",
                     success=False,
-                    error=f"pool retry failed: agent {selected_path!r} not found or inactive",
+                    error=f"pool retry failed: agent {selected_path!r} not found or disabled",
                 )
             if accessible_agent_ids is not None and str(selected_agent.id) not in accessible_agent_ids:
                 return StepOutput(

--- a/registry-pkgs/src/registry_pkgs/workflows/executor_resolver.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/executor_resolver.py
@@ -163,7 +163,7 @@ async def _resolve_executor(
 
     mcp_server = await ExtendedMCPServer.find_one(
         ExtendedMCPServer.serverName == key,
-        ExtendedMCPServer.status == "active",
+        {"config.enabled": True},
     )
     if mcp_server is not None:
         logger.debug("executor_key %r → MCP server %r", key, mcp_server.serverName)
@@ -172,7 +172,7 @@ async def _resolve_executor(
     path = f"/{key}" if not key.startswith("/") else key
     a2a_agent = await A2AAgent.find_one(
         A2AAgent.path == path,
-        A2AAgent.status == "active",
+        {"isEnabled": True},
     )
     if a2a_agent is not None:
         if accessible_agent_ids is not None and str(a2a_agent.id) not in accessible_agent_ids:
@@ -184,6 +184,6 @@ async def _resolve_executor(
 
     raise KeyError(
         f"executor_key {key!r} not resolved: "
-        f"no active MCP server with serverName={key!r} "
-        f"or A2A agent with path={path!r}"
+        f"no enabled MCP server with serverName={key!r} "
+        f"or enabled A2A agent with path={path!r}"
     )

--- a/registry-pkgs/tests/unit/workflow/test_executor_resolver.py
+++ b/registry-pkgs/tests/unit/workflow/test_executor_resolver.py
@@ -85,7 +85,6 @@ class TestExecutorResolver:
         """Patch Beanie field expressions used in find_one() calls."""
         monkeypatch.setattr(executor_resolver.ExtendedMCPServer, "serverName", _FieldExpr("serverName"), raising=False)
         monkeypatch.setattr(executor_resolver.A2AAgent, "path", _FieldExpr("path"), raising=False)
-        # Both MCP and A2A enabled checks use raw dicts — no field patch needed
 
     @pytest.mark.asyncio
     async def test_build_executor_registry_deduplicates_keys(self, monkeypatch: pytest.MonkeyPatch):

--- a/registry-pkgs/tests/unit/workflow/test_executor_resolver.py
+++ b/registry-pkgs/tests/unit/workflow/test_executor_resolver.py
@@ -84,9 +84,8 @@ class TestExecutorResolver:
     def _patch_beanie_filters(monkeypatch: pytest.MonkeyPatch) -> None:
         """Patch Beanie field expressions used in find_one() calls."""
         monkeypatch.setattr(executor_resolver.ExtendedMCPServer, "serverName", _FieldExpr("serverName"), raising=False)
-        monkeypatch.setattr(executor_resolver.ExtendedMCPServer, "status", _FieldExpr("status"), raising=False)
         monkeypatch.setattr(executor_resolver.A2AAgent, "path", _FieldExpr("path"), raising=False)
-        monkeypatch.setattr(executor_resolver.A2AAgent, "status", _FieldExpr("status"), raising=False)
+        # Both MCP and A2A enabled checks use raw dicts — no field patch needed
 
     @pytest.mark.asyncio
     async def test_build_executor_registry_deduplicates_keys(self, monkeypatch: pytest.MonkeyPatch):
@@ -492,3 +491,75 @@ class TestLoadAccessibleAgentIds:
         )
 
         assert registry == {"alpha": {"agent-1"}}
+
+
+@pytest.mark.unit
+class TestA2APoolExecutorQueries:
+    """Ensure make_a2a_pool_executor queries use isEnabled, not status."""
+
+    @pytest.mark.asyncio
+    async def test_pool_initial_selection_queries_by_is_enabled(self, monkeypatch: pytest.MonkeyPatch):
+        """Initial pool query must filter on isEnabled=True, not status='active'."""
+        captured_queries: list = []
+
+        async def fake_to_list():
+            return []
+
+        class FakeFind:
+            def __init__(self, query):
+                captured_queries.append(query)
+
+            def to_list(self):
+                return fake_to_list()
+
+        # Patch Agent so make_a2a_pool_executor doesn't validate the model arg
+        monkeypatch.setattr(a2a_exec, "Agent", lambda **kwargs: SimpleNamespace())
+        monkeypatch.setattr(a2a_exec.A2AAgent, "find", FakeFind)
+
+        executor = a2a_exec.make_a2a_pool_executor(
+            node_name="test-pool",
+            pool_keys=["agent-a", "agent-b"],
+            selector_llm=SimpleNamespace(),
+            jwt_config=_jwt_config(),
+            accessible_agent_ids=None,
+        )
+
+        result = await executor(SimpleNamespace(input="hello", previous_step_content=None), {})
+
+        assert result.success is False  # no agents found → pool resolution failed
+        assert len(captured_queries) == 1, "expected exactly one find() call"
+        query = captured_queries[0]
+        assert "status" not in query, f"status filter found in pool query: {query}"
+        assert query.get("isEnabled") is True, f"isEnabled=True not in pool query: {query}"
+
+    @pytest.mark.asyncio
+    async def test_pool_retry_path_queries_by_is_enabled(self, monkeypatch: pytest.MonkeyPatch):
+        """Retry path (selected_path already cached) must filter on isEnabled=True."""
+        captured_args: list = []
+
+        async def fake_find_one(*args, **kwargs):
+            captured_args.extend(args)
+            return None  # agent gone → triggers error StepOutput
+
+        # Patch Agent so make_a2a_pool_executor doesn't validate the model arg
+        monkeypatch.setattr(a2a_exec, "Agent", lambda **kwargs: SimpleNamespace())
+        monkeypatch.setattr(a2a_exec.A2AAgent, "find_one", fake_find_one)
+
+        executor = a2a_exec.make_a2a_pool_executor(
+            node_name="retry-pool",
+            pool_keys=["agent-a"],
+            selector_llm=SimpleNamespace(),
+            jwt_config=_jwt_config(),
+            accessible_agent_ids=None,
+        )
+
+        # Pre-fill cache to simulate retry path
+        state = {"a2a_target_retry-pool": "/agent-a"}
+        result = await executor(SimpleNamespace(input="hello", previous_step_content=None), state)
+
+        assert result.success is False
+        assert "not found or disabled" in result.error
+        assert len(captured_args) >= 1
+        args_str = str(captured_args)
+        assert "status" not in args_str, f"status filter found in retry query: {captured_args}"
+        assert "isEnabled" in args_str, f"isEnabled not in retry query: {captured_args}"

--- a/scripts/run_workflow_by_id.py
+++ b/scripts/run_workflow_by_id.py
@@ -104,7 +104,7 @@ async def _print_definition_agents(definition_id: str) -> None:
         # Try MCP server first
         mcp = await ExtendedMCPServer.find_one(
             ExtendedMCPServer.serverName == key,
-            ExtendedMCPServer.status == "active",
+            {"config.enabled": True},
         )
         if mcp is not None:
             url = mcp.config.get("url") if mcp.config else None
@@ -115,7 +115,7 @@ async def _print_definition_agents(definition_id: str) -> None:
         path = f"/{key}" if not key.startswith("/") else key
         agent = await A2AAgent.find_one(
             A2AAgent.path == path,
-            A2AAgent.status == "active",
+            {"isEnabled": True},
         )
         if agent is not None:
             base_url = agent_base_url(agent)
@@ -132,13 +132,13 @@ async def _print_definition_agents(definition_id: str) -> None:
 
 
 async def _list_all_agents() -> None:
-    """List every active A2A agent (mirrors scripts/get_url.py)."""
-    agents = await A2AAgent.find({"status": "active"}).to_list()
+    """List every enabled A2A agent (mirrors scripts/get_url.py)."""
+    agents = await A2AAgent.find({"isEnabled": True}).to_list()
     if not agents:
-        print("No active A2A agents found.")
+        print("No enabled A2A agents found.")
         return
 
-    print("── Active A2A agents ────────────────────────────────────")
+    print("── Enabled A2A agents ──────────────────────────────────")
     for a in agents:
         base_url = agent_base_url(a)
         provider = (a.federationMetadata or {}).get("providerType", "—")

--- a/scripts/save_workflow_definition.py
+++ b/scripts/save_workflow_definition.py
@@ -148,8 +148,8 @@ def _a2a_agent_summary(agent: A2AAgent) -> str:
 
 
 async def _active_executor_keys() -> tuple[list[str], list[str], list[A2AAgent]]:
-    mcp_servers = await ExtendedMCPServer.find(ExtendedMCPServer.status == "active").to_list()
-    a2a_agents = await A2AAgent.find(A2AAgent.status == "active").to_list()
+    mcp_servers = await ExtendedMCPServer.find({"config.enabled": True}).to_list()
+    a2a_agents = await A2AAgent.find({"isEnabled": True}).to_list()
     mcp_keys = sorted(server.serverName for server in mcp_servers if server.config.get("enabled") is True)
     a2a_keys = sorted(agent.path.lstrip("/") for agent in a2a_agents)
     return mcp_keys, a2a_keys, a2a_agents
@@ -208,7 +208,7 @@ async def _print_node_agent_details(nodes: list[WorkflowNode]) -> None:
     if not referenced_paths:
         return
 
-    agents = await A2AAgent.find({"path": {"$in": sorted(referenced_paths)}, "status": "active"}).to_list()
+    agents = await A2AAgent.find({"path": {"$in": sorted(referenced_paths)}, "isEnabled": True}).to_list()
     if not agents:
         return
 

--- a/scripts/save_workflow_definition.py
+++ b/scripts/save_workflow_definition.py
@@ -150,7 +150,7 @@ def _a2a_agent_summary(agent: A2AAgent) -> str:
 async def _active_executor_keys() -> tuple[list[str], list[str], list[A2AAgent]]:
     mcp_servers = await ExtendedMCPServer.find({"config.enabled": True}).to_list()
     a2a_agents = await A2AAgent.find({"isEnabled": True}).to_list()
-    mcp_keys = sorted(server.serverName for server in mcp_servers if server.config.get("enabled") is True)
+    mcp_keys = sorted(server.serverName for server in mcp_servers)
     a2a_keys = sorted(agent.path.lstrip("/") for agent in a2a_agents)
     return mcp_keys, a2a_keys, a2a_agents
 


### PR DESCRIPTION
…-condition fields ({"config.enabled": True} for MCP servers, {"isEnabled": True} for A2A agents) across workflow executors and utility scripts