### PR TITLE
feat(refresh): refactor server/agent capabilities refresh endpoints

### DIFF
--- a/auth-server/tests/integration/test_well_known_routes.py
+++ b/auth-server/tests/integration/test_well_known_routes.py
@@ -191,7 +191,7 @@ class TestWellKnownRoutes:
             "servers-read",
             "agents-read",
             "agents-write",
-            "server-write",
+            "servers-write",  # 更新：从 server-write（单数）改为 servers-write（复数）
             "servers-share",
             "agents-share",
             "system-ops",

--- a/docs/design/a2a-agent-api-design.md
+++ b/docs/design/a2a-agent-api-design.md
@@ -540,7 +540,115 @@ The `wellKnown` object contains sync status only (no URL):
 
 ---
 
-### 9. Sync Well-Known
+### 9. Refresh Agent Capabilities
+
+**Endpoint**: `POST /api/v1/agents/{agent_id}/refresh`
+
+**Description**: Refresh agent capabilities (skills) by fetching the latest agent card from the agent's `.well-known/agent-card.json` endpoint. This provides a consistent API experience with MCP server refresh (`/servers/{id}/refresh`).
+
+**Request Body**: None
+
+**Response**: `200 OK`
+```json
+{
+  "id": "507f1f77bcf86cd799439011",
+  "path": "/code-reviewer",
+  "name": "Code Review Agent",
+  "description": "AI-powered code review assistant",
+  "url": "https://example.com/agents/code-reviewer",
+  "version": "1.1.0",
+  "protocolVersion": "1.0",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false
+  },
+  "numSkills": 3,
+  "skills": [
+    {
+      "id": "code-analysis",
+      "name": "Code Analysis",
+      "description": "Analyze code quality",
+      "tags": ["analysis", "quality"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "bug-detection",
+      "name": "Bug Detection",
+      "description": "Detect potential bugs",
+      "tags": ["bugs", "detection"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "security-scan",
+      "name": "Security Scan",
+      "description": "Scan for security vulnerabilities",
+      "tags": ["security", "vulnerabilities"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    }
+  ],
+  "securitySchemes": {...},
+  "preferredTransport": "HTTP+JSON",
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["application/json"],
+  "provider": {...},
+  "tags": ["code", "review"],
+  "status": "active",
+  "enabled": true,
+  "config": {
+    "title": "Code Review Agent",
+    "description": "AI-powered code review assistant",
+    "url": "https://example.com/agents/code-reviewer",
+    "type": "jsonrpc"
+  },
+  "permissions": {
+    "VIEW": true,
+    "EDIT": true,
+    "DELETE": true,
+    "SHARE": true
+  },
+  "author": "507f1f77bcf86cd799439012",
+  "wellKnown": {
+    "enabled": true,
+    "lastSyncAt": "2024-01-20T15:45:00Z",
+    "lastSyncStatus": "success",
+    "lastSyncVersion": "1.1.0"
+  },
+  "createdAt": "2024-01-15T10:30:00Z",
+  "updatedAt": "2024-01-20T15:45:00Z"
+}
+```
+
+**Features**:
+- Fetches latest agent card from well-known endpoint using A2A SDK
+- Updates agent capabilities (skills, version, etc.) in MongoDB
+- Automatically syncs to Weaviate vector database
+- Updates `wellKnown.lastSyncAt` and `wellKnown.lastSyncStatus`
+- Returns full agent detail response (consistent with MCP server refresh API)
+
+**Use Cases**:
+- Manual capability refresh: User clicks refresh button to get latest skills
+- Periodic updates: Scheduled refresh to keep agent capabilities up-to-date
+- Post-deployment sync: Refresh after agent is updated on the remote server
+- Frontend integration: Display last refresh time and refresh button on agent card
+
+**Error Responses**:
+- `400 Bad Request`: Well-known sync not enabled or not configured
+- `404 Not Found`: Agent not found or agent card not found at well-known endpoint
+- `502 Bad Gateway`: Upstream errors or parse errors from remote agent
+- `503 Service Unavailable`: Network/transport errors accessing remote agent
+
+**Permission**: Requires EDIT permission
+
+**Comparison with `/wellknown` endpoint**:
+- `/refresh`: Returns full `AgentDetailResponse` (consistent with server refresh)
+- `/wellknown`: Returns detailed `WellKnownSyncResponse` with change tracking
+
+---
+
+### 10. Sync Well-Known
 
 **Endpoint**: `POST /api/v1/agents/{agent_id}/wellknown`
 
@@ -564,7 +672,7 @@ The `wellKnown` object contains sync status only (no URL):
 
 ---
 
-### 10. Get Agent Card (Well-Known)
+### 11. Get Agent Card (Well-Known)
 
 **Endpoint**: `GET /api/v1/agents/.well-known/agent-cards?url={agent_url}`
 

--- a/docs/design/mcp_db_persistence_design.md
+++ b/docs/design/mcp_db_persistence_design.md
@@ -812,7 +812,7 @@ Response 200:
 - Different from `tool_functions` OpenAI format stored in the database
 ```
 
-**8. Refresh Server Health**
+**8. Refresh Server Capabilities**
 ```http
 POST /api/v1/servers/{server_id}/refresh
 Authorization: Bearer <token>
@@ -820,22 +820,33 @@ Authorization: Bearer <token>
 Response 200:
 {
   "id": "674e1a2b3c4d5e6f7a8b9c0d",
-  "server_name": "github",
+  "serverName": "github",
   "path": "/mcp/github",
   "status": "active",
-  "last_connected": "2026-01-04T16:20:00Z",
-  "last_error": null,
-  "error_message": null,
-  "num_tools": 4,
+  "lastConnected": "2026-01-04T16:20:00Z",
+  "lastError": null,
+  "errorMessage": null,
+  "numTools": 4,
   "capabilities": "{\"experimental\":{},\"prompts\":{\"listChanged\":true},\"resources\":{\"subscribe\":false,\"listChanged\":true}}",
   "tools": "tavily_search, tavily_extract, tavily_crawl, tavily_map",
-  "init_duration": 168,
-  "updated_at": "2026-01-04T16:20:00Z"
+  "initDuration": 168,
+  "updatedAt": "2026-01-04T16:20:00Z"
+}
+
+Response 400 (Refresh Failed):
+{
+  "error": "capabilities_refresh_failed",
+  "message": "Failed to retrieve capabilities from server: Connection timeout"
 }
 
 **Note:**
-- Uses `ServerDetailResponse` schema with snake_case fields
-- Health refresh reconnects to the MCP server and updates tools/capabilities if they changed
+- Uses `ServerDetailResponse` schema with camelCase fields (via `response_model_by_alias=True`)
+- This endpoint refreshes server capabilities (prompts, resources, tools) by fetching them from the MCP server
+- Successfully retrieved data is saved to MongoDB and automatically synced to Weaviate vector database
+- The `status` field in the server document is NOT updated by this endpoint (it's deprecated for capability tracking)
+- The `lastConnected` field is ONLY updated when the refresh succeeds (not updated on failure)
+- Returns the full server detail response on success, or an error response on failure
+- Frontend can show a success/error alert based on the HTTP status code (200 = success, 400 = failed)
 ```
 
 #### Token Management Endpoints

--- a/registry-pkgs/src/registry_pkgs/scopes.yml
+++ b/registry-pkgs/src/registry_pkgs/scopes.yml
@@ -16,9 +16,9 @@
 group_mappings:
   jarvis-registry-admin:
     - servers-read
+    - servers-write
     - agents-read
     - agents-write
-    - server-write
     - federations-read
     - federations-write
     - federations-share
@@ -36,9 +36,9 @@ group_mappings:
     - workflows-control
   jarvis-registry-power-user:
     - servers-read
+    - servers-write
     - agents-read
     - agents-write
-    - server-write
     - federations-read
     - federations-write
     - federations-share
@@ -55,9 +55,9 @@ group_mappings:
     - workflows-control
   jarvis-registry-user:
     - servers-read
+    - servers-write
     - agents-read
     - agents-write
-    - server-write
     - federations-read
     - federations-write
     - workflows-read
@@ -90,7 +90,21 @@ servers-read:
   - action: get_server_tools
     method: GET
     endpoint: /servers/{server_id}/tools
-  - action: refresh_server_health
+
+servers-write:
+  - action: register_service
+    method: POST
+    endpoint: /servers
+  - action: modify_service
+    method: PATCH
+    endpoint: /servers/{server_id}
+  - action: delete_service
+    method: DELETE
+    endpoint: /servers/{server_id}
+  - action: toggle_service
+    method: POST
+    endpoint: /servers/{server_id}/toggle
+  - action: refresh_server_capabilities
     method: POST
     endpoint: /servers/{server_id}/refresh
 
@@ -139,20 +153,6 @@ agents-write:
   - action: sync_wellknown
     method: POST
     endpoint: /agents/{agent_id}/wellknown
-
-server-write:
-  - action: register_service
-    method: POST
-    endpoint: /servers
-  - action: modify_service
-    method: PATCH
-    endpoint: /servers/{server_id}
-  - action: delete_service
-    method: DELETE
-    endpoint: /servers/{server_id}
-  - action: toggle_service
-    method: POST
-    endpoint: /servers/{server_id}/toggle
 
 federations-read:
   # Federation read scopes only allow access to federation read endpoints.

--- a/registry-pkgs/src/registry_pkgs/scopes.yml
+++ b/registry-pkgs/src/registry_pkgs/scopes.yml
@@ -133,6 +133,9 @@ agents-write:
   - action: toggle_agent
     method: POST
     endpoint: /agents/{agent_id}/toggle
+  - action: refresh_agent_capabilities
+    method: POST
+    endpoint: /agents/{agent_id}/refresh
   - action: sync_wellknown
     method: POST
     endpoint: /agents/{agent_id}/wellknown

--- a/registry/src/registry/api/v1/a2a/agent_routes.py
+++ b/registry/src/registry/api/v1/a2a/agent_routes.py
@@ -639,8 +639,11 @@ async def refresh_agent_capabilities(
         # Other errors
         raise HTTPException(
             status_code=http_status.HTTP_400_BAD_REQUEST,
-            detail=create_error_detail(ErrorCode.EXTERNAL_SERVICE_ERROR, error_msg),
+            detail=create_error_detail(ErrorCode.INVALID_REQUEST, error_msg),
         )
+    except HTTPException:
+        # Re-raise HTTPException as-is (e.g., from ACL permission checks)
+        raise
     except Exception as e:
         logger.error(f"Error refreshing capabilities for agent {agent_id}: {e}", exc_info=True)
         raise HTTPException(

--- a/registry/src/registry/api/v1/a2a/agent_routes.py
+++ b/registry/src/registry/api/v1/a2a/agent_routes.py
@@ -564,6 +564,94 @@ async def get_agent_skills(
 
 
 @router.post(
+    "/agents/{agent_id}/refresh",
+    response_model=AgentDetailResponse,
+    response_model_by_alias=True,
+    summary="Refresh Agent Capabilities",
+    description="Refresh agent capabilities (skills) from .well-known/agent-card.json endpoint and sync to vector database",
+)
+@track_registry_operation("refresh", resource_type="agent")
+async def refresh_agent_capabilities(
+    agent_id: str,
+    user_context: CurrentUser,
+    acl_service: ACLService = Depends(get_acl_service),
+    a2a_agent_service: A2AAgentService = Depends(get_a2a_agent_service),
+):
+    """
+    Refresh agent capabilities by fetching latest agent card from well-known endpoint.
+
+    This endpoint provides a consistent API experience with MCP server refresh:
+    - Fetches latest agent card (including skills) from the agent's well-known endpoint
+    - Updates MongoDB with new capabilities
+    - Automatically syncs to Weaviate vector database
+    - Returns the full agent detail response (not just sync status)
+    """
+    try:
+        user_id = user_context.get("user_id")
+
+        # Check EDIT permission and get permissions for response
+        permissions = await acl_service.check_user_permission(
+            user_id=PydanticObjectId(user_id),
+            resource_type=ResourceType.REMOTE_AGENT.value,
+            resource_id=PydanticObjectId(agent_id),
+            required_permission="EDIT",
+        )
+
+        # Refresh agent capabilities using the service method
+        agent = await a2a_agent_service.refresh_agent_capabilities(agent_id=agent_id)
+
+        return convert_to_detail(agent, acl_permission=permissions)
+
+    except A2AAgentCardNotFoundException as e:
+        error_msg = str(e)
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=create_error_detail(ErrorCode.RESOURCE_NOT_FOUND, error_msg),
+        )
+    except A2AAgentCardTransportException as e:
+        error_msg = str(e)
+        raise HTTPException(
+            status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=create_error_detail(ErrorCode.SERVICE_UNAVAILABLE, error_msg),
+        )
+    except (A2AAgentCardUpstreamException, A2AAgentCardParseException) as e:
+        error_msg = str(e)
+        raise HTTPException(
+            status_code=http_status.HTTP_502_BAD_GATEWAY,
+            detail=create_error_detail(ErrorCode.EXTERNAL_SERVICE_ERROR, error_msg),
+        )
+    except ValueError as e:
+        error_msg = str(e)
+
+        # Check error types
+        if "not found" in error_msg.lower():
+            raise HTTPException(
+                status_code=http_status.HTTP_404_NOT_FOUND,
+                detail=create_error_detail(ErrorCode.RESOURCE_NOT_FOUND, error_msg),
+            )
+
+        if "not enabled" in error_msg.lower() or "not configured" in error_msg.lower():
+            raise HTTPException(
+                status_code=http_status.HTTP_400_BAD_REQUEST,
+                detail=create_error_detail(ErrorCode.INVALID_REQUEST, error_msg),
+            )
+
+        # Other errors
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail=create_error_detail(ErrorCode.EXTERNAL_SERVICE_ERROR, error_msg),
+        )
+    except Exception as e:
+        logger.error(f"Error refreshing capabilities for agent {agent_id}: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=create_error_detail(
+                ErrorCode.INTERNAL_ERROR, "Internal server error while refreshing agent capabilities"
+            ),
+        )
+
+
+@router.post(
     "/agents/{agent_id}/wellknown",
     response_model=WellKnownSyncResponse,
     summary="Sync Well-Known",

--- a/registry/src/registry/api/v1/server/server_routes.py
+++ b/registry/src/registry/api/v1/server/server_routes.py
@@ -709,7 +709,7 @@ async def refresh_server_capabilities(
             user_id=PydanticObjectId(user_id),
             resource_type=ResourceType.MCPSERVER.value,
             resource_id=PydanticObjectId(server_id),
-            required_permission="VIEW",
+            required_permission="EDIT",
         )
 
         capabilities_info = await server_service.refresh_server_capabilities(

--- a/registry/src/registry/api/v1/server/server_routes.py
+++ b/registry/src/registry/api/v1/server/server_routes.py
@@ -691,17 +691,17 @@ async def get_server_tools(
     "/servers/{server_id}/refresh",
     response_model=ServerDetailResponse,
     response_model_by_alias=True,  # Use camelCase in API responses
-    summary="Refresh Server Health",
-    description="Refresh server health status and check connectivity",
+    summary="Refresh Server Capabilities",
+    description="Refresh server capabilities (prompts, resources, tools) and sync to vector database",
 )
-@track_registry_operation("refresh", resource_type="health")
-async def refresh_server_health(
+@track_registry_operation("refresh", resource_type="capabilities")
+async def refresh_server_capabilities(
     server_id: str,
     user_context: dict = Depends(get_user_context),
     acl_service: ACLService = Depends(get_acl_service),
     server_service: ServerServiceV1 = Depends(get_server_service),
 ):
-    """Refresh server health status. Updates tools if server becomes active."""
+    """Refresh server capabilities by fetching latest prompts, resources, and tools from the MCP server."""
     try:
         user_id = user_context.get("user_id")
 
@@ -712,22 +712,22 @@ async def refresh_server_health(
             required_permission="VIEW",
         )
 
-        health_info = await server_service.refresh_server_health(
+        capabilities_info = await server_service.refresh_server_capabilities(
             server_id=server_id,
             user_id=user_id,
         )
 
-        # Check if health check failed
-        if health_info["status"] == "unhealthy":
+        # Check if capabilities refresh failed
+        if capabilities_info["status"] == "failed":
             raise HTTPException(
                 status_code=http_status.HTTP_400_BAD_REQUEST,
                 detail={
-                    "error": "health_check_failed",
-                    "message": health_info.get("status_message", "Failed to retrieve tools from server"),
+                    "error": "capabilities_refresh_failed",
+                    "message": capabilities_info.get("status_message", "Failed to retrieve capabilities from server"),
                 },
             )
 
-        server = health_info["server"]
+        server = capabilities_info["server"]
 
         return convert_to_detail(server, acl_permission=permissions)
 
@@ -748,8 +748,8 @@ async def refresh_server_health(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error refreshing health for server {server_id}: {e}", exc_info=True)
+        logger.error(f"Error refreshing capabilities for server {server_id}: {e}", exc_info=True)
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Internal server error while refreshing server health",
+            detail="Internal server error while refreshing server capabilities",
         )

--- a/registry/src/registry/schemas/server_api_schemas.py
+++ b/registry/src/registry/schemas/server_api_schemas.py
@@ -246,7 +246,7 @@ class ServerDetailResponse(APIBaseModel):
     prompts: list[dict[str, Any]] | None = Field(None, description="List of available prompts")
     initDuration: int | None = Field(None, description="Initialization duration in ms")
     author: str | None = Field(None, description="Author user ID")
-    status: str
+    status: str = Field(default="active", description="Operational state: active, inactive, error")
     path: str | None = Field(None, description="API path for this server")
     tags: list[str] = Field(default_factory=list)
     numTools: int = Field(0, description="Number of tools")

--- a/registry/src/registry/services/a2a_agent_service.py
+++ b/registry/src/registry/services/a2a_agent_service.py
@@ -637,15 +637,11 @@ class A2AAgentService:
             A2AAgentCardUpstreamException: If upstream returns non-404 errors
             A2AAgentCardParseException: If agent card cannot be parsed/validated
         """
-        # Reuse the sync_wellknown implementation
-        await self.sync_wellknown(agent_id)
+        # Reuse the sync_wellknown implementation - it now returns the updated agent
+        result = await self.sync_wellknown(agent_id)
 
-        # Return the updated agent document
-        agent = await A2AAgent.get(PydanticObjectId(agent_id))
-        if not agent:
-            raise ValueError(f"Agent not found: {agent_id}")
-
-        return agent
+        # Return the updated agent document from sync result (avoids redundant DB query)
+        return result["agent"]
 
     async def sync_wellknown(self, agent_id: str) -> dict[str, Any]:
         """
@@ -732,6 +728,7 @@ class A2AAgentService:
                 "synced_at": agent.wellKnown.lastSyncAt,
                 "version": updated_card.version,
                 "changes": changes if changes else ["No changes detected"],
+                "agent": agent,  # Include updated agent to avoid redundant DB query
             }
 
         except A2AAgentCardTransportException as e:

--- a/registry/src/registry/services/a2a_agent_service.py
+++ b/registry/src/registry/services/a2a_agent_service.py
@@ -617,6 +617,36 @@ class A2AAgentService:
             logger.error(f"Error toggling agent {agent_id}: {e}", exc_info=True)
             raise ValueError(f"Failed to toggle agent: {str(e)}")
 
+    async def refresh_agent_capabilities(self, agent_id: str) -> A2AAgent:
+        """
+        Refresh agent capabilities by fetching latest agent card from well-known endpoint.
+
+        This method provides the same functionality as sync_wellknown but returns
+        the updated agent document directly (for consistent API with MCP server refresh).
+
+        Args:
+            agent_id: Agent ID
+
+        Returns:
+            Updated agent document with refreshed capabilities
+
+        Raises:
+            ValueError: If agent not found, well-known not enabled, or sync fails
+            A2AAgentCardNotFoundException: If agent card not found at well-known endpoint
+            A2AAgentCardTransportException: If network/transport errors occur
+            A2AAgentCardUpstreamException: If upstream returns non-404 errors
+            A2AAgentCardParseException: If agent card cannot be parsed/validated
+        """
+        # Reuse the sync_wellknown implementation
+        await self.sync_wellknown(agent_id)
+
+        # Return the updated agent document
+        agent = await A2AAgent.get(PydanticObjectId(agent_id))
+        if not agent:
+            raise ValueError(f"Agent not found: {agent_id}")
+
+        return agent
+
     async def sync_wellknown(self, agent_id: str) -> dict[str, Any]:
         """
         Sync agent configuration from .well-known/agent-card.json endpoint using SDK.

--- a/registry/src/registry/services/server_service.py
+++ b/registry/src/registry/services/server_service.py
@@ -1350,25 +1350,28 @@ class ServerServiceV1:
             user_id=user_id,
         )
 
-    async def refresh_server_health(
+    async def refresh_server_capabilities(
         self,
         server_id: str,
         user_id: str | None = None,
     ) -> dict[str, Any]:
         """
-        Refresh server health status.
+        Refresh server capabilities (prompts, resources, tools).
 
-        Uses the same strict validation as registration:
-        - Retrieves tools and capabilities from the server
-        - If capabilities cannot be retrieved, server is considered unhealthy
-        - This serves as a comprehensive sanity check
+        Fetches the latest capabilities from the MCP server and updates MongoDB.
+        Automatically triggers sync to Weaviate vector database.
 
         Args:
             server_id: Server document ID
-            user_id: Current user's ID (kept for compatibility but not used)
+            user_id: Current user's ID (required for OAuth servers)
 
         Returns:
-            Health information dictionary
+            Capabilities refresh result dictionary with keys:
+            - server: Updated server document
+            - status: "success" or "failed"
+            - status_message: Human-readable status message
+            - last_checked: Timestamp of the refresh attempt
+            - response_time_ms: Response time (always None for MCP connections)
 
         Raises:
             ValueError: If server not found
@@ -1391,13 +1394,13 @@ class ServerServiceV1:
         ) = await self.retrieve_tools_and_capabilities_from_server(server, user_id)
 
         if tool_list is None or capabilities is None:
-            # Health check failed - cannot retrieve capabilities
-            logger.error(f"Health check failed for {server.serverName}: {tool_error}")
+            # Capabilities refresh failed
+            logger.error(f"Capabilities refresh failed for {server.serverName}: {tool_error}")
 
-            server.status = "error"
+            # Do NOT update server.status (status is no longer used for enabled/disabled logic)
             server.lastError = now
             server.errorMessage = tool_error or "Failed to retrieve capabilities"
-            server.lastConnected = now
+            # Do NOT update lastConnected on failure - only update on success
             server.updatedAt = now
 
             old_hash = server.vectorContentHash
@@ -1406,20 +1409,21 @@ class ServerServiceV1:
 
             return {
                 "server": server,
-                "status": "unhealthy",
+                "status": "failed",
                 "status_message": tool_error or "Failed to retrieve capabilities",
                 "last_checked": now,
                 "response_time_ms": None,
             }
 
-        # Health check passed - capabilities retrieved successfully
+        # Capabilities refresh succeeded
         logger.info(
-            f"Health check passed for {server.serverName}: retrieved {len(tool_list)} tools, {len(resource_list or [])} resources, {len(prompt_list or [])} prompts, and capabilities"
+            f"Capabilities refresh succeeded for {server.serverName}: retrieved {len(tool_list)} tools, {len(resource_list or [])} resources, {len(prompt_list or [])} prompts, and capabilities"
         )
 
-        server.status = "active"
+        # Do NOT update server.status (status is no longer used for enabled/disabled logic)
         server.lastError = None
         server.errorMessage = None
+        # ONLY update lastConnected on success
         server.lastConnected = now
         server.updatedAt = now
 
@@ -1454,11 +1458,11 @@ class ServerServiceV1:
         await server.save()
         self._schedule_vector_sync(server, old_hash)
 
-        # Return health info
+        # Return capabilities refresh result
         return {
             "server": server,
-            "status": "healthy",
-            "status_message": f"healthy (retrieved {len(tool_list)} tools, {len(resource_list or [])} resources, {len(prompt_list or [])} prompts)",
+            "status": "success",
+            "status_message": f"Successfully refreshed capabilities (retrieved {len(tool_list)} tools, {len(resource_list or [])} resources, {len(prompt_list or [])} prompts)",
             "last_checked": now,
             "response_time_ms": None,  # We don't track response time for MCP connections
         }

--- a/registry/src/registry/services/server_service.py
+++ b/registry/src/registry/services/server_service.py
@@ -1403,9 +1403,7 @@ class ServerServiceV1:
             # Do NOT update lastConnected on failure - only update on success
             server.updatedAt = now
 
-            old_hash = server.vectorContentHash
             await server.save()
-            self._schedule_vector_sync(server, old_hash)
 
             return {
                 "server": server,
@@ -1444,13 +1442,13 @@ class ServerServiceV1:
 
             # Update numTools at root level
             server.numTools = len(tool_functions)
-            logger.info(f"Updated {len(tool_functions)} tools for {server.serverName} during health refresh")
+            logger.info(f"Updated {len(tool_functions)} tools for {server.serverName} during capabilities refresh")
 
         # Store resources and prompts
         config["resources"] = resource_list or []
         config["prompts"] = prompt_list or []
         logger.info(
-            f"Updated {len(resource_list or [])} resources and {len(prompt_list or [])} prompts for {server.serverName} during health refresh"
+            f"Updated {len(resource_list or [])} resources and {len(prompt_list or [])} prompts for {server.serverName} during capabilities refresh"
         )
 
         server.config = config

--- a/registry/tests/unit/api/v1/test_agent_routes.py
+++ b/registry/tests/unit/api/v1/test_agent_routes.py
@@ -165,7 +165,7 @@ async def test_create_agent_uses_injected_services(sample_user_context):
 
 @pytest.mark.asyncio
 async def test_refresh_agent_capabilities_success(sample_user_context):
-    """测试成功刷新 agent 能力"""
+    """Test successful agent capabilities refresh."""
 
     from registry.api.v1.a2a.agent_routes import refresh_agent_capabilities
     from registry.schemas.acl_schema import ResourcePermissions
@@ -188,21 +188,21 @@ async def test_refresh_agent_capabilities_success(sample_user_context):
         a2a_agent_service=mock_a2a_agent_service,
     )
 
-    # 验证 ACL 检查使用了 EDIT 权限
+    # Verify ACL check used EDIT permission
     mock_acl_service.check_user_permission.assert_awaited_once()
     call_args = mock_acl_service.check_user_permission.call_args
     assert call_args.kwargs["required_permission"] == "EDIT"
 
-    # 验证服务被调用
+    # Verify service was called
     mock_a2a_agent_service.refresh_agent_capabilities.assert_awaited_once_with(agent_id=agent_id)
 
-    # 验证响应
+    # Verify response
     assert result.name == "Test Agent"
 
 
 @pytest.mark.asyncio
 async def test_refresh_agent_capabilities_not_found():
-    """测试 agent 不存在时返回 404"""
+    """Test 404 response when agent is not found."""
     from fastapi import HTTPException
 
     from registry.api.v1.a2a.agent_routes import refresh_agent_capabilities
@@ -224,14 +224,14 @@ async def test_refresh_agent_capabilities_not_found():
             a2a_agent_service=mock_a2a_agent_service,
         )
 
-    # 验证 404 错误
+    # Verify 404 error
     assert exc_info.value.status_code == 404
     assert "resource_not_found" in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio
 async def test_refresh_agent_capabilities_transport_error():
-    """测试网络/传输错误时返回 503"""
+    """Test 503 response on network/transport error."""
     from fastapi import HTTPException
 
     from registry.api.v1.a2a.agent_routes import refresh_agent_capabilities
@@ -256,14 +256,14 @@ async def test_refresh_agent_capabilities_transport_error():
             a2a_agent_service=mock_a2a_agent_service,
         )
 
-    # 验证 503 错误
+    # Verify 503 error
     assert exc_info.value.status_code == 503
     assert "service_unavailable" in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio
 async def test_refresh_agent_capabilities_upstream_error():
-    """测试上游服务错误时返回 502"""
+    """Test 502 response on upstream service error."""
     from fastapi import HTTPException
 
     from registry.api.v1.a2a.agent_routes import refresh_agent_capabilities
@@ -288,14 +288,14 @@ async def test_refresh_agent_capabilities_upstream_error():
             a2a_agent_service=mock_a2a_agent_service,
         )
 
-    # 验证 502 错误
+    # Verify 502 error
     assert exc_info.value.status_code == 502
     assert "external_service_error" in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio
 async def test_refresh_agent_capabilities_invalid_request():
-    """测试无效请求（agent 未启用）时返回 400"""
+    """Test 400 response on invalid request (agent well-known not enabled)."""
     from fastapi import HTTPException
 
     from registry.api.v1.a2a.agent_routes import refresh_agent_capabilities
@@ -319,14 +319,14 @@ async def test_refresh_agent_capabilities_invalid_request():
             a2a_agent_service=mock_a2a_agent_service,
         )
 
-    # 验证 400 错误，使用正确的错误码
+    # Verify 400 error with correct error code
     assert exc_info.value.status_code == 400
     assert "invalid_request" in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio
 async def test_refresh_agent_capabilities_permission_denied():
-    """测试刷新端点需要 EDIT 权限"""
+    """Test that the refresh endpoint requires EDIT permission."""
     from fastapi import HTTPException
 
     from registry.api.v1.a2a.agent_routes import refresh_agent_capabilities
@@ -336,7 +336,7 @@ async def test_refresh_agent_capabilities_permission_denied():
     user_context = {"user_id": str(PydanticObjectId())}
 
     mock_acl_service = MagicMock()
-    # 模拟权限拒绝 - 使用标准错误格式
+    # Simulate permission denied using standard error format
     mock_acl_service.check_user_permission = AsyncMock(
         side_effect=HTTPException(
             status_code=403, detail=create_error_detail(ErrorCode.INSUFFICIENT_PERMISSIONS, "Forbidden")
@@ -353,10 +353,8 @@ async def test_refresh_agent_capabilities_permission_denied():
             a2a_agent_service=mock_a2a_agent_service,
         )
 
-    # 验证权限检查抛出 403
-    # 注意：由于路由的通用异常处理器，HTTPException 会被重新抛出
-    # 如果是 403，应该能正确传递
+    # Verify 403 is propagated (HTTPException is re-raised as-is by the route handler)
     assert exc_info.value.status_code == 403
 
-    # 验证服务从未被调用（权限检查先失败）
+    # Verify service was never called (permission check failed first)
     mock_a2a_agent_service.refresh_agent_capabilities.assert_not_called()

--- a/registry/tests/unit/api/v1/test_agent_routes.py
+++ b/registry/tests/unit/api/v1/test_agent_routes.py
@@ -158,3 +158,205 @@ async def test_create_agent_uses_injected_services(sample_user_context):
     assert result.config.title == "Test Agent"
     assert result.config.description == "Agent description"
     assert result.config.type == "jsonrpc"
+
+
+# ==================== refresh_agent_capabilities endpoint tests ====================
+
+
+@pytest.mark.asyncio
+async def test_refresh_agent_capabilities_success(sample_user_context):
+    """测试成功刷新 agent 能力"""
+
+    from registry.api.v1.a2a.agent_routes import refresh_agent_capabilities
+    from registry.schemas.acl_schema import ResourcePermissions
+
+    agent_id = str(PydanticObjectId())
+    mock_agent = _build_agent(PydanticObjectId(agent_id))
+
+    mock_acl_service = MagicMock()
+    mock_acl_service.check_user_permission = AsyncMock(
+        return_value=ResourcePermissions(VIEW=True, EDIT=True, DELETE=True, SHARE=True)
+    )
+
+    mock_a2a_agent_service = MagicMock()
+    mock_a2a_agent_service.refresh_agent_capabilities = AsyncMock(return_value=mock_agent)
+
+    result = await refresh_agent_capabilities(
+        agent_id=agent_id,
+        user_context=sample_user_context,
+        acl_service=mock_acl_service,
+        a2a_agent_service=mock_a2a_agent_service,
+    )
+
+    # 验证 ACL 检查使用了 EDIT 权限
+    mock_acl_service.check_user_permission.assert_awaited_once()
+    call_args = mock_acl_service.check_user_permission.call_args
+    assert call_args.kwargs["required_permission"] == "EDIT"
+
+    # 验证服务被调用
+    mock_a2a_agent_service.refresh_agent_capabilities.assert_awaited_once_with(agent_id=agent_id)
+
+    # 验证响应
+    assert result.name == "Test Agent"
+
+
+@pytest.mark.asyncio
+async def test_refresh_agent_capabilities_not_found():
+    """测试 agent 不存在时返回 404"""
+    from fastapi import HTTPException
+
+    from registry.api.v1.a2a.agent_routes import refresh_agent_capabilities
+
+    agent_id = str(PydanticObjectId())
+    user_context = {"user_id": str(PydanticObjectId())}
+
+    mock_acl_service = MagicMock()
+    mock_acl_service.check_user_permission = AsyncMock(return_value=MagicMock())
+
+    mock_a2a_agent_service = MagicMock()
+    mock_a2a_agent_service.refresh_agent_capabilities = AsyncMock(side_effect=ValueError("Agent not found"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await refresh_agent_capabilities(
+            agent_id=agent_id,
+            user_context=user_context,
+            acl_service=mock_acl_service,
+            a2a_agent_service=mock_a2a_agent_service,
+        )
+
+    # 验证 404 错误
+    assert exc_info.value.status_code == 404
+    assert "resource_not_found" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_refresh_agent_capabilities_transport_error():
+    """测试网络/传输错误时返回 503"""
+    from fastapi import HTTPException
+
+    from registry.api.v1.a2a.agent_routes import refresh_agent_capabilities
+    from registry.core.exceptions import A2AAgentCardTransportException
+
+    agent_id = str(PydanticObjectId())
+    user_context = {"user_id": str(PydanticObjectId())}
+
+    mock_acl_service = MagicMock()
+    mock_acl_service.check_user_permission = AsyncMock(return_value=MagicMock())
+
+    mock_a2a_agent_service = MagicMock()
+    mock_a2a_agent_service.refresh_agent_capabilities = AsyncMock(
+        side_effect=A2AAgentCardTransportException("Connection timeout")
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await refresh_agent_capabilities(
+            agent_id=agent_id,
+            user_context=user_context,
+            acl_service=mock_acl_service,
+            a2a_agent_service=mock_a2a_agent_service,
+        )
+
+    # 验证 503 错误
+    assert exc_info.value.status_code == 503
+    assert "service_unavailable" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_refresh_agent_capabilities_upstream_error():
+    """测试上游服务错误时返回 502"""
+    from fastapi import HTTPException
+
+    from registry.api.v1.a2a.agent_routes import refresh_agent_capabilities
+    from registry.core.exceptions import A2AAgentCardUpstreamException
+
+    agent_id = str(PydanticObjectId())
+    user_context = {"user_id": str(PydanticObjectId())}
+
+    mock_acl_service = MagicMock()
+    mock_acl_service.check_user_permission = AsyncMock(return_value=MagicMock())
+
+    mock_a2a_agent_service = MagicMock()
+    mock_a2a_agent_service.refresh_agent_capabilities = AsyncMock(
+        side_effect=A2AAgentCardUpstreamException("Upstream returned 500")
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await refresh_agent_capabilities(
+            agent_id=agent_id,
+            user_context=user_context,
+            acl_service=mock_acl_service,
+            a2a_agent_service=mock_a2a_agent_service,
+        )
+
+    # 验证 502 错误
+    assert exc_info.value.status_code == 502
+    assert "external_service_error" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_refresh_agent_capabilities_invalid_request():
+    """测试无效请求（agent 未启用）时返回 400"""
+    from fastapi import HTTPException
+
+    from registry.api.v1.a2a.agent_routes import refresh_agent_capabilities
+
+    agent_id = str(PydanticObjectId())
+    user_context = {"user_id": str(PydanticObjectId())}
+
+    mock_acl_service = MagicMock()
+    mock_acl_service.check_user_permission = AsyncMock(return_value=MagicMock())
+
+    mock_a2a_agent_service = MagicMock()
+    mock_a2a_agent_service.refresh_agent_capabilities = AsyncMock(
+        side_effect=ValueError("Well-known sync is not enabled for this agent")
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await refresh_agent_capabilities(
+            agent_id=agent_id,
+            user_context=user_context,
+            acl_service=mock_acl_service,
+            a2a_agent_service=mock_a2a_agent_service,
+        )
+
+    # 验证 400 错误，使用正确的错误码
+    assert exc_info.value.status_code == 400
+    assert "invalid_request" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_refresh_agent_capabilities_permission_denied():
+    """测试刷新端点需要 EDIT 权限"""
+    from fastapi import HTTPException
+
+    from registry.api.v1.a2a.agent_routes import refresh_agent_capabilities
+    from registry.schemas.errors import ErrorCode, create_error_detail
+
+    agent_id = str(PydanticObjectId())
+    user_context = {"user_id": str(PydanticObjectId())}
+
+    mock_acl_service = MagicMock()
+    # 模拟权限拒绝 - 使用标准错误格式
+    mock_acl_service.check_user_permission = AsyncMock(
+        side_effect=HTTPException(
+            status_code=403, detail=create_error_detail(ErrorCode.INSUFFICIENT_PERMISSIONS, "Forbidden")
+        )
+    )
+
+    mock_a2a_agent_service = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await refresh_agent_capabilities(
+            agent_id=agent_id,
+            user_context=user_context,
+            acl_service=mock_acl_service,
+            a2a_agent_service=mock_a2a_agent_service,
+        )
+
+    # 验证权限检查抛出 403
+    # 注意：由于路由的通用异常处理器，HTTPException 会被重新抛出
+    # 如果是 403，应该能正确传递
+    assert exc_info.value.status_code == 403
+
+    # 验证服务从未被调用（权限检查先失败）
+    mock_a2a_agent_service.refresh_agent_capabilities.assert_not_called()

--- a/registry/tests/unit/api/v1/test_server_routes.py
+++ b/registry/tests/unit/api/v1/test_server_routes.py
@@ -96,3 +96,154 @@ async def test_create_server_route_creates_acl_entry(
         assert call_args.kwargs["resource_type"] == ResourceType.MCPSERVER
         assert call_args.kwargs["resource_id"] == mock_created_server.id
         assert call_args.kwargs["perm_bits"] == RoleBits.OWNER
+
+
+# ==================== refresh_server_capabilities endpoint tests ====================
+
+
+@pytest.mark.asyncio
+async def test_refresh_server_capabilities_success(sample_user_context):
+    """Test successful server capabilities refresh"""
+
+    from registry.api.v1.server.server_routes import refresh_server_capabilities
+    from registry.schemas.acl_schema import ResourcePermissions
+
+    server_id = str(PydanticObjectId())
+    mock_server = MagicMock()
+    mock_server.id = PydanticObjectId(server_id)
+    mock_server.serverName = "test-server"
+
+    mock_acl_service = MagicMock()
+    mock_acl_service.check_user_permission = AsyncMock(
+        return_value=ResourcePermissions(VIEW=True, EDIT=True, DELETE=True, SHARE=True)
+    )
+
+    mock_server_service = MagicMock()
+    mock_server_service.refresh_server_capabilities = AsyncMock(
+        return_value={
+            "server": mock_server,
+            "status": "success",
+            "status_message": "Capabilities refreshed successfully",
+            "last_checked": "2026-01-01T00:00:00Z",
+            "response_time_ms": None,
+        }
+    )
+
+    with patch(
+        "registry.api.v1.server.server_routes.convert_to_detail",
+        return_value={"id": server_id, "serverName": "test-server"},
+    ):
+        result = await refresh_server_capabilities(
+            server_id=server_id,
+            user_context=sample_user_context,
+            acl_service=mock_acl_service,
+            server_service=mock_server_service,
+        )
+
+        # Verify ACL check was called with EDIT permission
+        mock_acl_service.check_user_permission.assert_awaited_once()
+        call_args = mock_acl_service.check_user_permission.call_args
+        assert call_args.kwargs["required_permission"] == "EDIT"
+
+        # Verify service was called
+        mock_server_service.refresh_server_capabilities.assert_awaited_once_with(
+            server_id=server_id,
+            user_id=sample_user_context["user_id"],
+        )
+
+        # Verify response
+        assert result["id"] == server_id
+
+
+@pytest.mark.asyncio
+async def test_refresh_server_capabilities_failed():
+    """Test failed server capabilities refresh returns HTTP 400"""
+    from fastapi import HTTPException
+
+    from registry.api.v1.server.server_routes import refresh_server_capabilities
+
+    server_id = str(PydanticObjectId())
+    user_context = {"user_id": str(PydanticObjectId())}
+
+    mock_acl_service = MagicMock()
+    mock_acl_service.check_user_permission = AsyncMock(return_value=MagicMock())
+
+    mock_server_service = MagicMock()
+    mock_server_service.refresh_server_capabilities = AsyncMock(
+        return_value={
+            "status": "failed",
+            "status_message": "Failed to connect to server",
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await refresh_server_capabilities(
+            server_id=server_id,
+            user_context=user_context,
+            acl_service=mock_acl_service,
+            server_service=mock_server_service,
+        )
+
+    # Verify HTTP 400 error
+    assert exc_info.value.status_code == 400
+    assert "capabilities_refresh_failed" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_refresh_server_capabilities_permission_denied():
+    """Test refresh endpoint requires EDIT permission"""
+    from fastapi import HTTPException
+
+    from registry.api.v1.server.server_routes import refresh_server_capabilities
+
+    server_id = str(PydanticObjectId())
+    user_context = {"user_id": str(PydanticObjectId())}
+
+    mock_acl_service = MagicMock()
+    # Simulate permission denied
+    mock_acl_service.check_user_permission = AsyncMock(side_effect=HTTPException(status_code=403, detail="Forbidden"))
+
+    mock_server_service = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await refresh_server_capabilities(
+            server_id=server_id,
+            user_context=user_context,
+            acl_service=mock_acl_service,
+            server_service=mock_server_service,
+        )
+
+    # Verify permission check raised 403
+    assert exc_info.value.status_code == 403
+
+    # Verify service was never called (permission check failed first)
+    mock_server_service.refresh_server_capabilities.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_server_capabilities_server_not_found():
+    """Test refresh endpoint returns 404 when server not found"""
+    from fastapi import HTTPException
+
+    from registry.api.v1.server.server_routes import refresh_server_capabilities
+
+    server_id = str(PydanticObjectId())
+    user_context = {"user_id": str(PydanticObjectId())}
+
+    mock_acl_service = MagicMock()
+    mock_acl_service.check_user_permission = AsyncMock(return_value=MagicMock())
+
+    mock_server_service = MagicMock()
+    mock_server_service.refresh_server_capabilities = AsyncMock(side_effect=ValueError("Server not found"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await refresh_server_capabilities(
+            server_id=server_id,
+            user_context=user_context,
+            acl_service=mock_acl_service,
+            server_service=mock_server_service,
+        )
+
+    # Verify 404 error
+    assert exc_info.value.status_code == 404
+    assert "not_found" in str(exc_info.value.detail)

--- a/registry/tests/unit/servers/test_server_service.py
+++ b/registry/tests/unit/servers/test_server_service.py
@@ -5,7 +5,7 @@ Unit tests for server service.
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import AsyncMock, Mock, mock_open, patch
 
 import pytest
 
@@ -847,6 +847,186 @@ class TestBuildCompleteHeaders:
 
             assert headers["X-Trace-Id"] == "trace-123"
             assert headers["Accept"] == "application/json, application/xml"
+
+
+@pytest.mark.unit
+@pytest.mark.servers
+@pytest.mark.asyncio
+class TestRefreshServerCapabilities:
+    """Test suite for refresh_server_capabilities service method."""
+
+    @pytest.fixture
+    def mock_server(self):
+        """Create a mock MCP server document."""
+        from datetime import UTC, datetime
+
+        from registry_pkgs.models.extended_mcp_server import ExtendedMCPServer
+
+        server = Mock(spec=ExtendedMCPServer)
+        server.id = Mock()
+        server.serverName = "test-server"
+        server.config = {"title": "Test Server"}
+        server.lastError = None
+        server.errorMessage = None
+        server.lastConnected = None
+        server.updatedAt = datetime.now(UTC)
+        server.vectorContentHash = "old-hash"
+        server.numTools = 0
+        server.save = AsyncMock()
+        return server
+
+    @pytest.fixture
+    def server_service(self):
+        """Create a ServerServiceV1 instance with mocked dependencies."""
+        from unittest.mock import Mock
+
+        from registry.services.server_service import ServerServiceV1
+
+        # Mock 所有必需的依赖
+        mock_user_service = Mock()
+        mock_token_service = Mock()
+        mock_oauth_service = Mock()
+        mock_mcp_server_repo = Mock()
+
+        service = ServerServiceV1(
+            user_service=mock_user_service,
+            token_service=mock_token_service,
+            oauth_service=mock_oauth_service,
+            mcp_server_repo=mock_mcp_server_repo,
+        )
+        return service
+
+    async def test_refresh_server_capabilities_success(self, server_service, mock_server):
+        """测试成功获取服务器能力"""
+        from unittest.mock import patch
+
+        # Mock get_server_by_id
+        with patch.object(server_service, "get_server_by_id", return_value=mock_server):
+            # Mock retrieve_tools_and_capabilities_from_server - 成功返回
+            mock_tools = [{"name": "tool1"}, {"name": "tool2"}]
+            mock_resources = [{"uri": "file://test.txt"}]
+            mock_prompts = [{"name": "prompt1"}]
+            mock_capabilities = {"sampling": {}}
+
+            with patch.object(
+                server_service,
+                "retrieve_tools_and_capabilities_from_server",
+                return_value=(mock_tools, mock_resources, mock_prompts, mock_capabilities, None),
+            ):
+                # Mock _schedule_vector_sync
+                with patch.object(server_service, "_schedule_vector_sync"):
+                    result = await server_service.refresh_server_capabilities(server_id="test-id", user_id="user-123")
+
+                    # 验证返回结果
+                    assert result["status"] == "success"
+                    assert result["server"] == mock_server
+                    assert "Successfully refreshed capabilities" in result["status_message"]
+                    assert result["last_checked"] is not None
+                    assert result["response_time_ms"] is None
+
+                    # 验证 lastConnected 被设置
+                    assert mock_server.lastConnected is not None
+
+                    # 验证 lastError 和 errorMessage 被清除
+                    assert mock_server.lastError is None
+                    assert mock_server.errorMessage is None
+
+                    # 验证 save 被调用
+                    mock_server.save.assert_called_once()
+
+    async def test_refresh_server_capabilities_mcp_unreachable(self, server_service, mock_server):
+        """测试 MCP 服务器不可达时的失败路径"""
+        from unittest.mock import patch
+
+        # 保存初始的 lastConnected 值
+        initial_last_connected = mock_server.lastConnected
+
+        # Mock get_server_by_id
+        with patch.object(server_service, "get_server_by_id", return_value=mock_server):
+            # Mock retrieve_tools_and_capabilities_from_server - 失败返回
+            error_message = "Connection timeout: Failed to connect to MCP server"
+
+            with patch.object(
+                server_service,
+                "retrieve_tools_and_capabilities_from_server",
+                return_value=(None, None, None, None, error_message),
+            ):
+                # Mock _schedule_vector_sync
+                with patch.object(server_service, "_schedule_vector_sync"):
+                    result = await server_service.refresh_server_capabilities(server_id="test-id", user_id="user-123")
+
+                    # 验证返回结果
+                    assert result["status"] == "failed"
+                    assert result["server"] == mock_server
+                    assert error_message in result["status_message"]
+                    assert result["last_checked"] is not None
+
+                    # 验证 lastConnected 不被更新（保持初始值）
+                    assert mock_server.lastConnected == initial_last_connected
+
+                    # 验证 lastError 被设置
+                    assert mock_server.lastError is not None
+
+                    # 验证 errorMessage 被设置
+                    assert mock_server.errorMessage == error_message
+
+                    # 验证 save 被调用
+                    mock_server.save.assert_called_once()
+
+    async def test_refresh_server_capabilities_invalid_server_id(self, server_service):
+        """测试无效的 server_id 抛出 ValueError"""
+        from unittest.mock import patch
+
+        # Mock get_server_by_id 返回 None
+        with patch.object(server_service, "get_server_by_id", return_value=None):
+            with pytest.raises(ValueError, match="Server not found"):
+                await server_service.refresh_server_capabilities(server_id="invalid-id", user_id="user-123")
+
+    async def test_refresh_server_capabilities_triggers_weaviate_sync(self, server_service, mock_server):
+        """测试成功刷新时触发 Weaviate 同步"""
+        from unittest.mock import patch
+
+        # Mock get_server_by_id
+        with patch.object(server_service, "get_server_by_id", return_value=mock_server):
+            # Mock retrieve_tools_and_capabilities_from_server - 成功返回
+            mock_tools = [{"name": "tool1"}]
+
+            with patch.object(
+                server_service,
+                "retrieve_tools_and_capabilities_from_server",
+                return_value=(mock_tools, [], [], {}, None),
+            ):
+                # Mock _schedule_vector_sync 并验证调用
+                with patch.object(server_service, "_schedule_vector_sync") as mock_sync:
+                    await server_service.refresh_server_capabilities(server_id="test-id", user_id="user-123")
+
+                    # 验证 Weaviate 同步被触发
+                    mock_sync.assert_called_once_with(mock_server, "old-hash")
+
+    async def test_refresh_server_capabilities_updates_tool_count(self, server_service, mock_server):
+        """测试刷新时更新工具数量"""
+        from unittest.mock import patch
+
+        # Mock get_server_by_id
+        with patch.object(server_service, "get_server_by_id", return_value=mock_server):
+            # Mock retrieve_tools_and_capabilities_from_server - 返回3个工具
+            mock_tools = [{"name": "tool1"}, {"name": "tool2"}, {"name": "tool3"}]
+
+            with patch.object(
+                server_service,
+                "retrieve_tools_and_capabilities_from_server",
+                return_value=(mock_tools, [], [], {}, None),
+            ):
+                # Mock _schedule_vector_sync
+                with patch.object(server_service, "_schedule_vector_sync"):
+                    await server_service.refresh_server_capabilities(server_id="test-id", user_id="user-123")
+
+                    # 验证 numTools 被更新
+                    assert mock_server.numTools == 3
+
+                    # 验证工具信息在 config 中
+                    assert "toolFunctions" in mock_server.config
+                    assert len(mock_server.config["toolFunctions"]) == 3
 
     @pytest.mark.asyncio
     async def test_custom_header_with_list_values(self):


### PR DESCRIPTION
- Rename MCP server refresh from "health" to "capabilities"
- Stop updating status field in refresh operations
- Add new POST /agents/{id}/refresh endpoint for A2A agents
- Update scopes.yml and API documentation