### PR TITLE
Hotfix: Remove the `A2AAgent.federationMetadata.sourceType` field completely.

### DIFF
--- a/registry-pkgs/tests/unit/test_models.py
+++ b/registry-pkgs/tests/unit/test_models.py
@@ -8,6 +8,7 @@ from beanie import PydanticObjectId
 from pydantic import ValidationError
 
 from registry_pkgs.models.a2a_agent import A2AAgent
+from registry_pkgs.models.enums import FederationProviderType
 from registry_pkgs.models.extended_mcp_server import ExtendedMCPServer
 
 
@@ -264,7 +265,7 @@ class TestExtendedMCPServerStructure:
             path="/agentcore/mcp/versioned-server",
             status="active",
             federationId="arn:aws:bedrock-agentcore:us-east-1:1:runtime/versioned",
-            federationMetadata={"sourceType": "runtime", "runtimeVersion": "7"},
+            federationMetadata={"providerType": FederationProviderType.AWS_AGENTCORE, "runtimeVersion": "7"},
         )
 
         docs = server.to_documents()
@@ -440,7 +441,7 @@ class TestExtendedMCPServerStructure:
             status="active",
             isEnabled=True,
             author=PydanticObjectId(),
-            federationMetadata={"sourceType": "runtime", "runtimeVersion": "11"},
+            federationMetadata={"providerType": FederationProviderType.AWS_AGENTCORE, "runtimeVersion": "11"},
         )
 
         docs = agent.to_documents()

--- a/registry/src/registry/services/agentcore_import_service.py
+++ b/registry/src/registry/services/agentcore_import_service.py
@@ -10,7 +10,7 @@ from registry.services.federation.agentcore_discovery import AgentCoreFederation
 from registry.services.federation.agentcore_runtime import AgentCoreRuntimeInvoker
 from registry_pkgs.database.decorators import get_current_session, use_transaction
 from registry_pkgs.models import A2AAgent, ExtendedMCPServer, PrincipalType, ResourceType
-from registry_pkgs.models.enums import PermissionBits, RoleBits
+from registry_pkgs.models.enums import FederationProviderType, PermissionBits, RoleBits
 from registry_pkgs.vector.repositories.a2a_agent_repository import A2AAgentRepository
 from registry_pkgs.vector.repositories.mcp_server_repository import MCPServerRepository
 
@@ -642,7 +642,7 @@ class AgentCoreImportService:
             runtime_arn = self.extract_runtime_arn(server.federationMetadata)
             if not runtime_arn:
                 continue
-            if (server.federationMetadata or {}).get("sourceType") != "runtime":
+            if (server.federationMetadata or {}).get("providerType") != FederationProviderType.AWS_AGENTCORE:
                 continue
             if runtime_arn not in all_discovered_runtime_arns:
                 stale_mcp.append(server)
@@ -654,7 +654,7 @@ class AgentCoreImportService:
             runtime_arn = self.extract_runtime_arn(agent.federationMetadata)
             if not runtime_arn:
                 continue
-            if (agent.federationMetadata or {}).get("sourceType") != "runtime":
+            if (agent.federationMetadata or {}).get("providerType") != FederationProviderType.AWS_AGENTCORE:
                 continue
             if runtime_arn not in all_discovered_runtime_arns:
                 stale_a2a.append(agent)

--- a/registry/src/registry/services/federation/agentcore_discovery.py
+++ b/registry/src/registry/services/federation/agentcore_discovery.py
@@ -8,6 +8,7 @@ from beanie import PydanticObjectId
 
 from registry_pkgs.models import A2AAgent, ExtendedMCPServer
 from registry_pkgs.models.a2a_agent import TRANSPORT_JSONRPC, AgentConfig
+from registry_pkgs.models.enums import FederationProviderType
 
 from .agentcore_clients import AgentCoreClientProvider
 from .agentcore_runtime_auth import AgentCoreRuntimeAuthService
@@ -319,7 +320,7 @@ class AgentCoreFederationClient:
             registeredBy="agentcore-federation",
             registeredAt=datetime.now(UTC),
             federationMetadata={
-                "sourceType": "runtime",
+                "providerType": FederationProviderType.AWS_AGENTCORE,
                 "runtimeArn": runtime_arn,
                 "runtimeId": runtime_id,
                 "runtimeVersion": runtime_version,
@@ -385,7 +386,7 @@ class AgentCoreFederationClient:
             },
             "author": author_id or PydanticObjectId(),
             "federationMetadata": {
-                "sourceType": "runtime",
+                "providerType": FederationProviderType.AWS_AGENTCORE,
                 "runtimeArn": runtime_arn,
                 "runtimeId": runtime_id,
                 "runtimeName": runtime_name,

--- a/registry/tests/unit/services/test_agentcore_import_service.py
+++ b/registry/tests/unit/services/test_agentcore_import_service.py
@@ -7,6 +7,7 @@ from beanie import PydanticObjectId
 
 from registry.services.agentcore_import_service import AgentCoreImportService
 from registry_pkgs.models import ExtendedMCPServer, ResourceType
+from registry_pkgs.models.enums import FederationProviderType
 
 
 class _FakeRepo:
@@ -69,9 +70,9 @@ class _FakeServer:
         self.numTools = 0
         self.author = PydanticObjectId()
         self.federationMetadata = {
-            "sourceType": "gateway_target",
             "runtimeArn": federation_id,
             "runtimeVersion": "1",
+            "providerType": FederationProviderType.AWS_AGENTCORE,
         }
         self.createdAt = datetime.now(UTC)
         self.updatedAt = datetime.now(UTC)
@@ -291,7 +292,7 @@ class TestAgentCoreImportService:
             status="active",
             isEnabled=True,
             wellKnown=None,
-            federationMetadata={"sourceType": "runtime", "runtimeArn": "fed-a2a-new"},
+            federationMetadata={"providerType": FederationProviderType.AWS_AGENTCORE, "runtimeArn": "fed-a2a-new"},
             createdAt=datetime.now(UTC),
             updatedAt=datetime.now(UTC),
             author=None,
@@ -319,7 +320,11 @@ class TestAgentCoreImportService:
             status="inactive",
             isEnabled=False,
             wellKnown=None,
-            federationMetadata={"sourceType": "runtime", "runtimeArn": "fed-a2a-upd", "runtimeVersion": "1"},
+            federationMetadata={
+                "providerType": FederationProviderType.AWS_AGENTCORE,
+                "runtimeArn": "fed-a2a-upd",
+                "runtimeVersion": "1",
+            },
             save=AsyncMock(),
         )
         new_data = SimpleNamespace(
@@ -329,7 +334,11 @@ class TestAgentCoreImportService:
             status="active",
             isEnabled=True,
             wellKnown=None,
-            federationMetadata={"sourceType": "runtime", "runtimeArn": "fed-a2a-upd", "runtimeVersion": "2"},
+            federationMetadata={
+                "providerType": FederationProviderType.AWS_AGENTCORE,
+                "runtimeArn": "fed-a2a-upd",
+                "runtimeVersion": "2",
+            },
         )
 
         changes = await service._update_a2a_agent(existing=existing, new_data=new_data)
@@ -343,11 +352,17 @@ class TestAgentCoreImportService:
     async def test_collects_stale_entities(self, service, monkeypatch):
         stale_server = _FakeServer(name="stale-mcp", federation_id="arn:runtime:stale")
         stale_server.id = PydanticObjectId()
-        stale_server.federationMetadata = {"sourceType": "runtime", "runtimeArn": "arn:runtime:stale"}
+        stale_server.federationMetadata = {
+            "providerType": FederationProviderType.AWS_AGENTCORE,
+            "runtimeArn": "arn:runtime:stale",
+        }
         stale_agent = SimpleNamespace(
             id=PydanticObjectId(),
             card=SimpleNamespace(name="stale-a2a"),
-            federationMetadata={"sourceType": "runtime", "runtimeArn": "arn:runtime:stale2"},
+            federationMetadata={
+                "providerType": FederationProviderType.AWS_AGENTCORE,
+                "runtimeArn": "arn:runtime:stale2",
+            },
         )
 
         find_mock_mcp = SimpleNamespace(to_list=self._async_return([stale_server]))
@@ -391,9 +406,15 @@ class TestAgentCoreImportService:
         assert service._detect_changes(existing, discovered_new) == ["runtimeVersion: 1 -> 2"]
 
     async def test_detect_a2a_changes_only_uses_runtime_version(self, service):
-        existing = SimpleNamespace(federationMetadata={"sourceType": "runtime", "runtimeVersion": "3"})
-        discovered_same = SimpleNamespace(federationMetadata={"sourceType": "runtime", "runtimeVersion": "3"})
-        discovered_new = SimpleNamespace(federationMetadata={"sourceType": "runtime", "runtimeVersion": "4"})
+        existing = SimpleNamespace(
+            federationMetadata={"providerType": FederationProviderType.AWS_AGENTCORE, "runtimeVersion": "3"}
+        )
+        discovered_same = SimpleNamespace(
+            federationMetadata={"providerType": FederationProviderType.AWS_AGENTCORE, "runtimeVersion": "3"}
+        )
+        discovered_new = SimpleNamespace(
+            federationMetadata={"providerType": FederationProviderType.AWS_AGENTCORE, "runtimeVersion": "4"}
+        )
 
         assert service._detect_a2a_changes(existing, discovered_same) == []
         assert service._detect_a2a_changes(existing, discovered_new) == ["runtimeVersion: 3 -> 4"]
@@ -414,10 +435,23 @@ class TestAgentCoreImportService:
         assert service.detect_runtime_version_change(existing, new_data) == ["runtimeVersion: 2 -> 3"]
 
     async def test_detect_runtime_version_change_handles_missing_version(self, service):
-        assert service.detect_runtime_version_change({"sourceType": "runtime"}, {"sourceType": "runtime"}) == []
-        assert service.detect_runtime_version_change({"sourceType": "runtime"}, {"runtimeVersion": "1"}) == [
-            "runtimeVersion: None -> 1"
-        ]
+        assert (
+            service.detect_runtime_version_change(
+                {
+                    "providerType": FederationProviderType.AWS_AGENTCORE,
+                },
+                {
+                    "providerType": FederationProviderType.AWS_AGENTCORE,
+                },
+            )
+            == []
+        )
+        assert service.detect_runtime_version_change(
+            {
+                "providerType": FederationProviderType.AWS_AGENTCORE,
+            },
+            {"runtimeVersion": "1"},
+        ) == ["runtimeVersion: None -> 1"]
 
     @staticmethod
     def _async_return(value):


### PR DESCRIPTION
  - This field is set on federation import but not consistently used to determine if an agent is on AgentCore Runtime.
  - `A2AAgent.federationMetadata.providerType` has an Enum type, is used to tell if an agent in on AgentCore, but is not set on import at all.
  - We are paying prices for not explicitly typing federationMetadata.
  - `sourceType` is removed completely. Use `providerType` in the future.
  - Data migration has been done.