### PR TITLE
fix: input_schema invalid characters

### DIFF
--- a/registry-pkgs/src/registry_pkgs/models/extended_mcp_server.py
+++ b/registry-pkgs/src/registry_pkgs/models/extended_mcp_server.py
@@ -46,6 +46,7 @@ Key Principle:
 """
 
 import hashlib
+import json
 import logging
 from datetime import datetime
 from typing import Any, ClassVar
@@ -61,6 +62,23 @@ from ..models.enums import MCPEntityType
 from ._generated import MCPServer
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_input_schema(raw: Any) -> dict | None:
+    """
+    Decode the JSON-stringified input_schema stored in Weaviate metadata.
+    """
+    if raw is None or raw == "":
+        return None
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("input_schema is not valid JSON, returning None")
+            return None
+    return None
 
 
 class ExtendedMCPServer(MCPServer):
@@ -248,10 +266,14 @@ class ExtendedMCPServer(MCPServer):
         metadata = self._get_base_metadata(MCPEntityType.TOOL)
         metadata["tool_name"] = downstream_tool_name
         # Store the full parameter schema so LLMs can execute without a separate lookup.
+        # Serialize as JSON string: Weaviate rejects nested property names that collide with
+        # reserved keys (`id`, `vector`) or that aren't valid GraphQL identifiers (e.g. `$ref`),
+        # which JSON-Schema bodies frequently contain. A string column has no such restriction
+        # and preserves the schema verbatim for the LLM (parsed back to dict on read).
         func = tool_data.get("function", {}) if isinstance(tool_data, dict) else {}
         input_schema = func.get("parameters")
         if input_schema:
-            metadata["input_schema"] = input_schema
+            metadata["input_schema"] = json.dumps(input_schema, default=str)
 
         return self._split_if_needed(content, metadata, chunking_config)
 
@@ -512,7 +534,7 @@ class ExtendedMCPServer(MCPServer):
         entity_type = metadata.get("entity_type")
         if entity_type == MCPEntityType.TOOL:
             result["tool_name"] = metadata.get("tool_name")
-            result["input_schema"] = metadata.get("input_schema")
+            result["input_schema"] = _parse_input_schema(metadata.get("input_schema"))
         elif entity_type == MCPEntityType.RESOURCE:
             result["resource_name"] = metadata.get("resource_name")
             result["resource_uri"] = metadata.get("resource_uri")

--- a/registry-pkgs/src/registry_pkgs/vector/repositories/a2a_agent_repository.py
+++ b/registry-pkgs/src/registry_pkgs/vector/repositories/a2a_agent_repository.py
@@ -70,20 +70,21 @@ class A2AAgentRepository(BaseVectorSyncRepository[A2AAgent]):
                 result.error = "asave returned no doc_ids"
                 logger.error("asave returned no doc_ids for agent '%s' (agent_id=%s).", agent.card.name, agent_id)
                 return result.to_dict()
+            verified = False
             try:
-                landed_docs = await self.afilter(filters={"agent_id": agent_id}, limit=expected + 1)
-                actual = len(landed_docs)
+                landed_docs = await self.afilter(filters={"agent_id": agent_id}, limit=expected)
+                verified = len(landed_docs) >= expected
             except Exception as e:
                 logger.warning(
-                    "Post-insert verification failed for agent '%s' (agent_id=%s): %s — falling back to doc_ids count",
+                    "Post-insert verification failed for agent '%s' (agent_id=%s): %s — trusting asave return value",
                     agent.card.name,
                     agent_id,
                     e,
                 )
-                actual = len(doc_ids)
+                verified = True
 
-            if actual >= expected:
-                result.indexed = actual
+            if verified:
+                result.indexed = len(doc_ids)
                 result.version = self._extract_runtime_version(agent)
                 logger.info(
                     "Indexed %d docs for agent '%s' (agent_id=%s).",
@@ -92,17 +93,16 @@ class A2AAgentRepository(BaseVectorSyncRepository[A2AAgent]):
                     agent_id,
                 )
             else:
-                result.indexed = actual
-                result.failed = expected - actual
+                result.indexed = 0
+                result.failed = expected
                 result.error = (
-                    f"only {actual}/{expected} docs landed in Weaviate "
-                    "(check langchain-weaviate ERROR logs for batch insert failures)"
+                    f"asave returned {len(doc_ids)} UUIDs but fewer than {expected} docs are queryable "
+                    "in Weaviate (check langchain-weaviate ERROR logs for batch insert failures)"
                 )
                 logger.error(
-                    "Vector sync partial failure for agent '%s' (agent_id=%s): %d/%d docs inserted",
+                    "Vector sync verification failed for agent '%s' (agent_id=%s): expected %d docs",
                     agent.card.name,
                     agent_id,
-                    actual,
                     expected,
                 )
         except Exception as e:

--- a/registry-pkgs/src/registry_pkgs/vector/repositories/a2a_agent_repository.py
+++ b/registry-pkgs/src/registry_pkgs/vector/repositories/a2a_agent_repository.py
@@ -62,9 +62,28 @@ class A2AAgentRepository(BaseVectorSyncRepository[A2AAgent]):
                         agent_id,
                     )
 
+            docs = agent.to_documents()
+            expected = len(docs) if docs else 0
             doc_ids = await self.asave(agent)
-            if doc_ids:
-                result.indexed = len(doc_ids)
+            if not doc_ids:
+                result.failed = max(expected, 1)
+                result.error = "asave returned no doc_ids"
+                logger.error("asave returned no doc_ids for agent '%s' (agent_id=%s).", agent.card.name, agent_id)
+                return result.to_dict()
+            try:
+                landed_docs = await self.afilter(filters={"agent_id": agent_id}, limit=expected + 1)
+                actual = len(landed_docs)
+            except Exception as e:
+                logger.warning(
+                    "Post-insert verification failed for agent '%s' (agent_id=%s): %s — falling back to doc_ids count",
+                    agent.card.name,
+                    agent_id,
+                    e,
+                )
+                actual = len(doc_ids)
+
+            if actual >= expected:
+                result.indexed = actual
                 result.version = self._extract_runtime_version(agent)
                 logger.info(
                     "Indexed %d docs for agent '%s' (agent_id=%s).",
@@ -73,8 +92,19 @@ class A2AAgentRepository(BaseVectorSyncRepository[A2AAgent]):
                     agent_id,
                 )
             else:
-                result.failed = 1
-                logger.error("asave returned no doc_ids for agent '%s' (agent_id=%s).", agent.card.name, agent_id)
+                result.indexed = actual
+                result.failed = expected - actual
+                result.error = (
+                    f"only {actual}/{expected} docs landed in Weaviate "
+                    "(check langchain-weaviate ERROR logs for batch insert failures)"
+                )
+                logger.error(
+                    "Vector sync partial failure for agent '%s' (agent_id=%s): %d/%d docs inserted",
+                    agent.card.name,
+                    agent_id,
+                    actual,
+                    expected,
+                )
         except Exception as e:
             logger.error("A2A vector sync failed for agent %s: %s", getattr(agent, "id", "?"), e, exc_info=True)
             result.failed = 1

--- a/registry-pkgs/src/registry_pkgs/vector/repositories/mcp_server_repository.py
+++ b/registry-pkgs/src/registry_pkgs/vector/repositories/mcp_server_repository.py
@@ -72,9 +72,27 @@ class MCPServerRepository(BaseVectorSyncRepository[ExtendedMCPServer]):
                 )
                 return result.to_dict_mcp()
 
+            expected = len(docs)
             doc_ids = await self.asave(server)
-            if doc_ids:
-                result.indexed = len(doc_ids)
+            if not doc_ids:
+                result.failed = expected
+                result.error = "asave returned no doc_ids"
+                logger.error("asave returned no doc_ids for server '%s' (server_id=%s).", server.serverName, server_id)
+                return result.to_dict_mcp()
+            try:
+                landed_docs = await self.afilter(filters={"server_id": server_id}, limit=expected + 1)
+                actual = len(landed_docs)
+            except Exception as e:
+                logger.warning(
+                    "Post-insert verification failed for server '%s' (server_id=%s): %s — falling back to doc_ids count",
+                    server.serverName,
+                    server_id,
+                    e,
+                )
+                actual = len(doc_ids)
+
+            if actual >= expected:
+                result.indexed = actual
                 result.version = self._extract_runtime_version(server)
                 logger.info(
                     "Indexed %d docs for server '%s' (server_id=%s).",
@@ -83,8 +101,19 @@ class MCPServerRepository(BaseVectorSyncRepository[ExtendedMCPServer]):
                     server_id,
                 )
             else:
-                result.failed = 1
-                logger.error("asave returned no doc_ids for server '%s' (server_id=%s).", server.serverName, server_id)
+                result.indexed = actual
+                result.failed = expected - actual
+                result.error = (
+                    f"only {actual}/{expected} docs landed in Weaviate "
+                    "(check langchain-weaviate ERROR logs for batch insert failures)"
+                )
+                logger.error(
+                    "Vector sync partial failure for server '%s' (server_id=%s): %d/%d docs inserted",
+                    server.serverName,
+                    server_id,
+                    actual,
+                    expected,
+                )
 
         except Exception as e:
             logger.error("MCP vector sync failed for server %s: %s", getattr(server, "id", "?"), e, exc_info=True)

--- a/registry-pkgs/src/registry_pkgs/vector/repositories/mcp_server_repository.py
+++ b/registry-pkgs/src/registry_pkgs/vector/repositories/mcp_server_repository.py
@@ -20,6 +20,13 @@ class MCPServerRepository(BaseVectorSyncRepository[ExtendedMCPServer]):
         "runtimeArn": "text",
         "path": "text",
         "enabled": "bool",
+        # Declared as TEXT explicitly: input_schema holds a JSON-encoded tool parameter
+        # schema. Storing it as text bypasses Weaviate's nested-property validation
+        # (which rejects reserved keys like `id`/`vector` and non-GraphQL names like
+        # `$ref` that JSON Schema bodies routinely contain). Old collections where this
+        # property was auto-inferred as `object` must be dropped + recreated
+        # (`vector_sync.py --target mcp --clean`) for new inserts to succeed.
+        "input_schema": "text",
     }
 
     def __init__(self, db_client: DatabaseClient):
@@ -79,20 +86,21 @@ class MCPServerRepository(BaseVectorSyncRepository[ExtendedMCPServer]):
                 result.error = "asave returned no doc_ids"
                 logger.error("asave returned no doc_ids for server '%s' (server_id=%s).", server.serverName, server_id)
                 return result.to_dict_mcp()
+            verified = False
             try:
-                landed_docs = await self.afilter(filters={"server_id": server_id}, limit=expected + 1)
-                actual = len(landed_docs)
+                landed_docs = await self.afilter(filters={"server_id": server_id}, limit=expected)
+                verified = len(landed_docs) >= expected
             except Exception as e:
                 logger.warning(
-                    "Post-insert verification failed for server '%s' (server_id=%s): %s — falling back to doc_ids count",
+                    "Post-insert verification failed for server '%s' (server_id=%s): %s — trusting asave return value",
                     server.serverName,
                     server_id,
                     e,
                 )
-                actual = len(doc_ids)
+                verified = True
 
-            if actual >= expected:
-                result.indexed = actual
+            if verified:
+                result.indexed = len(doc_ids)
                 result.version = self._extract_runtime_version(server)
                 logger.info(
                     "Indexed %d docs for server '%s' (server_id=%s).",
@@ -101,17 +109,16 @@ class MCPServerRepository(BaseVectorSyncRepository[ExtendedMCPServer]):
                     server_id,
                 )
             else:
-                result.indexed = actual
-                result.failed = expected - actual
+                result.indexed = 0
+                result.failed = expected
                 result.error = (
-                    f"only {actual}/{expected} docs landed in Weaviate "
-                    "(check langchain-weaviate ERROR logs for batch insert failures)"
+                    f"asave returned {len(doc_ids)} UUIDs but fewer than {expected} docs are queryable "
+                    "in Weaviate (check langchain-weaviate ERROR logs for batch insert failures)"
                 )
                 logger.error(
-                    "Vector sync partial failure for server '%s' (server_id=%s): %d/%d docs inserted",
+                    "Vector sync verification failed for server '%s' (server_id=%s): expected %d docs",
                     server.serverName,
                     server_id,
-                    actual,
                     expected,
                 )
 

--- a/scripts/vector_sync.py
+++ b/scripts/vector_sync.py
@@ -307,11 +307,11 @@ async def run() -> int:
     target, clean_mode, batch_size = parse_args()
 
     env_path = Path(".env")
-    if not env_path.exists():
-        print(f"Error: .env not found at {env_path.resolve()}")
-        return 1
-
-    settings = Settings(_env_file=str(env_path))
+    if env_path.exists():
+        settings = Settings(_env_file=str(env_path))
+    else:
+        print(f"No .env at {env_path.resolve()} — loading config from environment variables.")
+        settings = Settings()
 
     db_client = None
     redis_client = None


### PR DESCRIPTION
Store tool input_schema as JSON string so Weaviate doesn't reject batches containing reserved keys (id/vector) or invalid GraphQL names ($ref) in tool parameter schemas. 

vector_sync.py ignored this exception during synchronization, causing some data to sync successfully and leading me to believe that everything had synced successfully. This prevents GitHub and other related tools from being found in the demo environment. @kxue43 xu This ticket is intended to fix that bug.

I've rebuilt the data in the demo environment, and everything worked.