### PR TITLE
Feature/as 1543

### DIFF
--- a/docs/design/workflow-api-design.md
+++ b/docs/design/workflow-api-design.md
@@ -961,13 +961,12 @@ All endpoints return errors in the following format:
 }
 ```
 
-> **Backward compatibility (HITL v2 migration)**: legacy `require_approval: bool`
-> and `approval_timeout_seconds: int` fields are accepted for inbound requests
-> and auto-migrated to `humanReview: { requiresConfirmation, timeoutSeconds }`
-> by the backend model layer. Existing MongoDB documents with the legacy fields
-> are upgraded on read (no migration script required). **New clients must use
-> `humanReview` exclusively** — the legacy fields are not echoed back in responses
-> and will be dropped after a deprecation window.
+> **No legacy `require_approval` shim**: the path-A `require_approval` /
+> `approval_timeout_seconds` fields have been removed. They are **not** accepted,
+> auto-migrated, or upgraded on read — with the current `APIBaseModel` config
+> (`extra` at Pydantic's default `ignore`), unknown legacy fields are silently
+> ignored. New clients must use `humanReview` exclusively. See
+> [Backward Compatibility](#backward-compatibility--legacy-require_approval-fields).
 
 ### HumanReview
 
@@ -1040,7 +1039,7 @@ frontend chooses which decision UI to render based on the `requires*` flags.
   // User-facing prompts
   confirmationMessage?: string;
   userInputMessage?: string;
-  userInputSchema?: UserInputField[];
+  userInputSchema?: PendingUserInputField[];   // runtime payload — NOT the authoring UserInputField
   outputReviewMessage?: string;
   availableChoices?: string[];          // for router selection
   allowMultipleSelections: boolean;
@@ -1062,6 +1061,29 @@ frontend chooses which decision UI to render based on the `requires*` flags.
   timeoutAt?: string;                   // ISO8601
   onTimeout: 'approve' | 'skip' | 'cancel';
   onReject: 'skip' | 'cancel' | 'retry' | 'else_branch';
+}
+```
+
+### PendingUserInputField
+
+The `userInputSchema` inside a `StepRequirementSummary` is **not** the authoring
+[`UserInputField`](#userinputfield). It is the live agno runtime payload
+(`StepRequirement.to_dict()`), so its shape differs deliberately:
+
+- `fieldType` is passed through verbatim as agno's Python type name
+  (`"str" | "int" | "float" | "bool" | "list" | "dict"`), **not** coerced into
+  the authoring `'string' | 'number' | 'boolean' | 'array'` set.
+- Carries agno's `value` / `allowedValues` instead of the authoring `defaultValue`.
+- `required` defaults to `true` (agno's default).
+
+```typescript
+{
+  name: string;
+  fieldType?: string;            // agno type name: "str" | "int" | "float" | "bool" | "list" | "dict"
+  description?: string;
+  required: boolean;             // defaults to true
+  value?: unknown;               // value collected so far (null until the user submits)
+  allowedValues?: unknown[];     // optional allow-list for validation
 }
 ```
 
@@ -1216,24 +1238,25 @@ partners.
 ### Backward Compatibility — Legacy `require_approval` Fields
 
 The path-A `require_approval: bool` and `approval_timeout_seconds: int` fields on
-WorkflowNode have been **removed** from the v2 API/model. To avoid breaking
-existing clients and silently dropping data from pre-v2 MongoDB documents, the
-backend provides a transparent migration:
+WorkflowNode have been **removed** from the v2 API/model.
 
-- **Inbound requests** containing legacy `requireApproval=true` (camelCase) are
-  rejected with a Pydantic 400 — frontend must switch to `humanReview`.
-- **Snake-case `require_approval=true` / `approval_timeout_seconds=N` keys
-  (from raw MongoDB documents or internal API callers)** are automatically
-  upgraded to `humanReview: { requiresConfirmation: true, timeoutSeconds: N }`
-  via a Pydantic `model_validator(mode='before')`. An INFO log entry is emitted
-  per migrated node so operators can audit usage.
-- `require_approval=false` was a no-op in path-A and remains a no-op (no
-  `humanReview` is synthesized).
-- If both legacy and `humanReview` are present, **`humanReview` wins** (explicit
-  beats legacy).
+Current behavior is:
 
-These shims will be removed in a future cleanup release once telemetry confirms
-no callers send the legacy fields.
+- There is **no request/model compatibility shim** for legacy `requireApproval`,
+  `require_approval`, or `approval_timeout_seconds` fields — no auto-migration
+  and no validator rejects them.
+- Clients must send the v2 `humanReview` structure instead of the removed legacy
+  fields.
+- With the current `APIBaseModel` configuration (`extra` left at the Pydantic
+  default of `ignore`), unknown legacy fields are **silently ignored** rather
+  than rejected or auto-migrated.
+- Pre-v2 MongoDB documents containing these legacy fields are **not**
+  transparently upgraded by the API/model layer; operators reading older data
+  should not expect `humanReview` to be synthesized automatically.
+
+If compatibility handling is added in the future, this section must be updated to
+document the exact request-validation and document-migration behavior actually
+implemented.
 
 ### Internal WorkflowRun Fields (Not API-Exposed)
 
@@ -1243,19 +1266,23 @@ MongoDB directly or building admin tooling.
 
 | Field                                  | Type   | Purpose |
 |----------------------------------------|--------|---------|
-| `triggering_user_id`                   | string | User ID captured at trigger time; used to re-authenticate downstream MCP/A2A executor calls during HITL resume |
-| `triggering_registry_token_encrypted`  | string | AES-CBC ciphertext of the user's bearer token; decrypted just-in-time by `WorkflowControlService.resolve_requirement` before invoking `runner.continue_run` |
+| `triggering_user_id`                   | string | User ID captured at trigger time. Used (with `triggering_username` / `triggering_scopes`) to re-mint a short-lived service JWT for downstream MCP/A2A executor calls during HITL resume. The raw bearer token is **never** persisted — storing it would be useless since it expires during the pause. |
+| `triggering_username`                  | string | Username captured at trigger time; carried into the re-minted resume JWT identity |
+| `triggering_scopes`                    | array  | Scopes captured at trigger time; copied into the re-minted resume JWT |
 | `pending_requirements`                 | array  | Serialized agno `StepRequirement` objects awaiting user decision; populated when `arun()` returns `is_paused=True`. **Surfaced to clients as `pendingRequirements`** in run-detail responses. |
 | `pending_directive`                    | enum   | Runtime intervention signal for pause/resume/cancel/retry (separate from HITL decisions, which go via `/approve`) |
 | `paused_at`                            | datetime | Set when run enters `paused` via user `/pause` directive (separate from HITL `awaiting_approval`) |
 
 ### Known Limitations
 
-- **JWT expiration during long HITL pauses**: the captured triggering token is
-  not refreshed. If a user resolves an HITL pause after the token's `exp`,
-  `resolve_requirement` detects expiration, clears the token, logs a warning,
-  and proceeds — downstream MCP/A2A calls will return 401 (visible in
-  `nodeRuns[].error`).
+- **Authorization can drift during long HITL pauses**: resume does not reuse the
+  original bearer token (which would have expired anyway). Instead it re-mints a
+  short-lived service JWT from the captured trigger identity (`triggering_user_id`
+  / `triggering_username` / `triggering_scopes`). If the user's account state,
+  roles, or scopes change before they resolve the pause, downstream MCP/A2A calls
+  may be authorized differently than at trigger time. Runs with no captured
+  `triggering_user_id` (e.g. script-driven) get an empty token, so auth-required
+  steps return 401 (visible in `nodeRuns[].error`).
 - **agno cancel edge case ([#7929](https://github.com/agno-agi/agno/issues/7929) OPEN)**:
   cancel signals may not propagate through certain `acontinue_run +
   external_execution` code paths inside agno. Our wait-loop wrapper's CANCEL

--- a/docs/design/workflow-api-design.md
+++ b/docs/design/workflow-api-design.md
@@ -695,18 +695,16 @@ node type does not use them. This lets clients access any field without null che
 {
   "id": "run-demo-id",
   "workflowDefinitionId": "wf-demo-id",
-  "status": "completed",
+  "workflowVersion": 2,
+  "status": "awaiting_approval",
   "triggerSource": "manual",
   "startedAt": "2024-01-25T10:00:00Z",
-  "finishedAt": "2024-01-25T10:05:30Z",
+  "finishedAt": null,
   "initialInput": {
     "customerId": "cust-123",
     "email": "customer@example.com"
   },
-  "finalOutput": {
-    "status": "success",
-    "accountId": "acc-456"
-  },
+  "finalOutput": null,
   "errorSummary": null,
   "definitionSnapshot": {
     "name": "Customer Onboarding Workflow",
@@ -722,26 +720,198 @@ node type does not use them. This lets clients access any field without null che
       "nodeId": "node-1",
       "nodeName": "Validate Customer Data",
       "status": "completed",
-      "attempt": 0,
-      "inputSnapshot": {
-        "customerId": "cust-123",
-        "email": "customer@example.com"
-      },
-      "outputSnapshot": {
-        "valid": true
-      },
+      "attempt": 1,
+      "inputSnapshot": {"customerId": "cust-123"},
+      "outputSnapshot": {"valid": true},
       "error": null,
       "startedAt": "2024-01-25T10:00:05Z",
       "finishedAt": "2024-01-25T10:00:10Z"
+    }
+  ],
+  "pendingRequirements": [
+    {
+      "schemaVersion": 1,
+      "stepId": "node-2",
+      "stepName": "Send Welcome Email",
+      "stepType": "step",
+      "requiresConfirmation": true,
+      "requiresUserInput": false,
+      "requiresOutputReview": false,
+      "requiresRouteSelection": false,
+      "confirmationMessage": "Send welcome email to cust-123?",
+      "isPostExecution": false,
+      "confirmed": null,
+      "timeoutAt": "2024-01-25T11:00:00Z",
+      "onTimeout": "cancel",
+      "onReject": "skip",
+      "retryCount": 0
     }
   ]
 }
 ```
 
+**Notes**:
+- `workflowVersion`: the WorkflowDefinition version snapshot this run is replaying against (HITL v2)
+- `pendingRequirements`: non-empty iff `status == "awaiting_approval"`. Each element is one
+  HITL gate awaiting decision; the frontend renders a decision UI per element (see
+  [StepRequirementSummary](#steprequirementsummary)).
+
 **Error**:
 - `400` Invalid workflow ID or run ID
 - `404` Workflow or run not found
 - `500` Internal server error
+
+---
+
+### 9. Resolve HITL Requirement (Approve / Reject / Edit / etc.)
+
+**Endpoint**: `POST /api/v1/workflows/{workflow_id}/runs/{run_id}/approve`
+
+HITL v2: resolve one pending requirement on a run holding at an HITL gate. The
+endpoint accepts a 5-way decision aligned 1:1 with agno's `StepRequirement`
+methods (`confirm` / `reject` / `edit` / `set_user_input` / `set_selected_choices`).
+
+**Request Body**:
+```json
+{
+  "stepId": "node-2",
+  "resolution": "confirm",
+  "feedback": null,
+  "editedOutput": null,
+  "userInput": null,
+  "selectedChoices": null
+}
+```
+
+**Fields**:
+- `stepId` (required): the `pendingRequirements[].stepId` from GET /runs/{id}
+- `resolution` (required): one of:
+  - `confirm` — approve the gate; run resumes from the held step
+  - `reject` — reject; node fails per `onReject` policy (skip / cancel / retry / else_branch)
+  - `edit` — accept with modifications (output_review only); replaces `step_output` with `editedOutput`
+  - `user_input` — provide collected form values (matching `userInputSchema`); requires `userInput`
+  - `route_select` — choose router branch(es); requires `selectedChoices`
+- `feedback` (optional): explanatory text on rejection (passed to agno when `onReject=retry`)
+- `editedOutput` (required iff resolution=`edit`): replacement output to use downstream
+- `userInput` (required iff resolution=`user_input`): form values matching schema
+- `selectedChoices` (required iff resolution=`route_select`): chosen router choice name(s)
+
+**Response**: `200 OK`
+```json
+{
+  "runId": "run-demo-id",
+  "status": "running",
+  "resolvedStepId": "node-2",
+  "message": "Requirement resolved as confirm; run resuming"
+}
+```
+
+**Resolution × Requirement Type Compatibility**:
+
+The backend validates that the chosen `resolution` matches the requirement's
+capability flags (returns 400 on mismatch):
+
+| Resolution      | Requires (on the pending requirement)              |
+|-----------------|----------------------------------------------------|
+| `confirm`       | always valid                                       |
+| `reject`        | always valid                                       |
+| `edit`          | `requiresOutputReview=true` AND `isPostExecution=true` |
+| `user_input`    | `requiresUserInput=true`                           |
+| `route_select`  | `requiresRouteSelection=true`                      |
+
+**Status Codes**:
+
+| Code | Meaning |
+|------|---------|
+| 200  | Decision accepted; `continue_run` triggered in the background |
+| 400  | Resolution/requirement mismatch, or missing required field (editedOutput/userInput/selectedChoices) |
+| 403  | Caller lacks `workflows-control` scope or VIEW permission on the workflow |
+| 404  | Workflow, run, or step_id not found (incl. already-resolved requirement) |
+| 409  | Run not in `awaiting_approval` (already resolved by someone else, timed out, completed) |
+| 500  | Internal server error |
+
+**Concurrency**: Decisions on different `stepId` values within the same run are
+independent (a single run may have multiple pending requirements, e.g. parallel
+branches). Concurrent decisions on the *same* `stepId` are resolved atomically via
+MongoDB `array_filters` — the loser receives 409. The frontend should disable the
+decision button after click and refetch on 409 to display the winning decision.
+
+**Resume Flow**:
+The HTTP response returns immediately after the decision is persisted. The actual
+workflow resumption (`acontinue_run`) happens in a background task on whichever
+pod handles it (CAS-protected so only one wins). Frontend should poll
+`GET /runs/{run_id}` to observe state transitions.
+
+---
+
+## Internal Data Flow — Control Endpoints
+
+The five control endpoints (`/pause`, `/resume`, `/cancel`, `/retry`, `/approve`)
+look similar from the outside but take different internal paths and therefore
+have different latency / persistence characteristics.  The frontend should not
+treat them as interchangeable.
+
+### `/pause`, `/resume`, `/cancel`
+
+**Path**: route → `WorkflowControlService.send_*` → MongoDB write + in-process
+`DirectiveQueue.put(...)` → HTTP 200 returned.
+
+- The wait-loop wrapper inside the runner picks the directive up at the next
+  step boundary (≤ 2 s under normal load), or on the next Mongo poll (≤ 60 s)
+  if the queue is missed.
+- Persistent: even if the pod owning the queue dies, the directive survives in
+  `WorkflowRun.pending_directive` and is honored when the run is next observed.
+- `cancel` additionally calls `agno.run.cancel.acancel_run(run_id)` via the
+  `MongoBackedCancellationManager`, so any agno-internal code path that checks
+  `raise_if_cancelled` also stops.
+
+### `/retry`
+
+**Path**: route → `WorkflowControlService.send_retry` → builds a *child*
+`WorkflowRun` with `resolved_dependencies` describing which nodes replay from
+cached outputs vs. re-execute → `asyncio.create_task(runner.run(child_run_id))`
+→ HTTP 200 returned immediately with the **child run's** ID.
+
+- The original run is unchanged.
+- The child run starts at `PENDING` and proceeds normally.
+- Background task runs on the pod that handled the HTTP request.
+
+### `/approve` (HITL resolution)
+
+**Path**: route → `WorkflowControlService.resolve_requirement`:
+
+1. Validates the run is in `AWAITING_APPROVAL` and the `stepId` matches an
+   unresolved entry in `pending_requirements`.
+2. Atomically writes the decision into `pending_requirements[stepId]` using
+   MongoDB `array_filters` (three-layer concurrency protection: top-level
+   `status` filter, per-element `confirmed is None` filter, and
+   `modified_count == 0 → 409`).
+3. Fires `asyncio.create_task(runner.continue_run(...))` to resume on the
+   same pod.
+
+`continue_run` then CAS-transitions the run from `AWAITING_APPROVAL` to
+`RUNNING`, rebuilds the agno Workflow from `definition_snapshot`, hydrates the
+decided requirements, and calls `workflow.acontinue_run(...)`.  agno restores
+the persisted `WorkflowRunOutput` from `agno_workflow_sessions` and continues
+execution.
+
+**Frontend implications**:
+
+- HTTP 200 returns *before* the resume completes — the status returned in the
+  response body may still be `awaiting_approval` for a brief moment.  Poll
+  `GET /workflows/{id}/runs/{run_id}` to observe the actual transition.
+- Resume latency depends on the agno workflow's next step (LLM call, tool
+  call, etc.); the `/approve` HTTP itself is fast (~20 ms).
+- If multiple requirements are pending on the same run, decide them one at a
+  time; agno only proceeds when *all* outstanding requirements on the current
+  step are resolved.
+
+### Failure modes shared across endpoints
+
+If the pod that started a background `continue_run` / `runner.run` task dies
+mid-execution, the run stays at `RUNNING` past its expected duration.  An
+operator currently has to mark such runs `FAILED` manually (e.g. via mongosh)
+— automated orphan-run recovery is tracked as a follow-up.
 
 ---
 
@@ -787,6 +957,111 @@ All endpoints return errors in the following format:
   choices: RouterChoice[];       // Named choices for router nodes (≥ 2 required)
   conditionCel?: string;         // CEL expression for condition/router nodes
   loopConfig?: LoopConfig;       // Loop configuration for loop nodes
+  humanReview?: HumanReview;     // HITL v2: per-node Human-In-The-Loop configuration; see HumanReview type
+}
+```
+
+> **Backward compatibility (HITL v2 migration)**: legacy `require_approval: bool`
+> and `approval_timeout_seconds: int` fields are accepted for inbound requests
+> and auto-migrated to `humanReview: { requiresConfirmation, timeoutSeconds }`
+> by the backend model layer. Existing MongoDB documents with the legacy fields
+> are upgraded on read (no migration script required). **New clients must use
+> `humanReview` exclusively** — the legacy fields are not echoed back in responses
+> and will be dropped after a deprecation window.
+
+### HumanReview
+
+Per-node HITL configuration (translated 1:1 to agno's `HumanReview`).
+Field × node-type compatibility is enforced server-side; sending an unsupported
+combination returns 400.
+
+```typescript
+{
+  requiresConfirmation: boolean;        // step / steps / loop / router / condition — pause before/after exec for approval
+  confirmationMessage?: string;
+  requiresUserInput: boolean;           // step / router only — collect form values before exec
+  userInputMessage?: string;
+  userInputSchema?: UserInputField[];
+  requiresOutputReview: boolean;        // step / router only — review/edit/reject output after exec
+  outputReviewMessage?: string;
+  requiresIterationReview: boolean;     // loop only — review after each iteration
+  iterationReviewMessage?: string;
+  onReject: 'skip' | 'cancel' | 'retry' | 'else_branch';   // else_branch is condition-only
+  timeoutSeconds?: number;              // pause timeout; null = use run-level default
+  onTimeout: 'approve' | 'skip' | 'cancel';
+}
+```
+
+**Node-type × field compatibility matrix**:
+
+| Field                     | step | steps | condition | loop | router | parallel |
+|---------------------------|:----:|:-----:|:---------:|:----:|:------:|:--------:|
+| requiresConfirmation      | ✅   | ✅    | ✅        | ✅   | ✅     | ❌       |
+| requiresUserInput         | ✅   | —     | —         | —    | ✅     | ❌       |
+| requiresOutputReview      | ✅   | —     | —         | —    | ✅     | ❌       |
+| requiresIterationReview   | —    | —     | —         | ✅   | —      | ❌       |
+| onReject = else_branch    | —    | —     | ✅ only   | —    | —      | ❌       |
+
+PARALLEL nodes reject any HITL field (agno itself forbids it because parallel
+branches execute concurrently and cannot be individually paused).
+
+### UserInputField
+
+```typescript
+{
+  name: string;
+  fieldType: 'string' | 'number' | 'boolean' | 'array';
+  description?: string;
+  required: boolean;
+  defaultValue?: unknown;
+}
+```
+
+### StepRequirementSummary
+
+Returned inside `WorkflowRun.pendingRequirements` (see Get Workflow Run Detail
+response). Each element represents one HITL gate awaiting user decision. The
+frontend chooses which decision UI to render based on the `requires*` flags.
+
+```typescript
+{
+  schemaVersion: number;                // 1 for current HITL v2 layout
+  stepId: string;
+  stepName?: string;
+  stepIndex?: number;
+  stepType?: 'step' | 'loop' | 'router' | 'condition' | 'steps';
+
+  // Capability flags — drive which UI variant to render
+  requiresConfirmation: boolean;
+  requiresUserInput: boolean;
+  requiresOutputReview: boolean;
+  requiresRouteSelection: boolean;
+
+  // User-facing prompts
+  confirmationMessage?: string;
+  userInputMessage?: string;
+  userInputSchema?: UserInputField[];
+  outputReviewMessage?: string;
+  availableChoices?: string[];          // for router selection
+  allowMultipleSelections: boolean;
+
+  // Post-execution review (output_review only)
+  stepOutput?: object;
+  isPostExecution: boolean;
+
+  // Decision state (null until user resolves)
+  confirmed?: boolean;
+  rejectionFeedback?: string;
+  editedOutput?: unknown;
+  userInput?: object;
+  selectedChoices?: string[];
+
+  // Retry + timeout
+  retryCount: number;
+  maxRetries?: number;
+  timeoutAt?: string;                   // ISO8601
+  onTimeout: 'approve' | 'skip' | 'cancel';
+  onReject: 'skip' | 'cancel' | 'retry' | 'else_branch';
 }
 ```
 
@@ -900,7 +1175,8 @@ Notes on the selector semantics:
 
 - `pending`: Run is queued
 - `running`: Run is in progress
-- `paused`: Run is paused and waiting to resume
+- `paused`: Run is paused by user directive (POST /pause); awaiting RESUME
+- `awaiting_approval`: Run is holding at one or more HITL gates; awaiting decision via POST /approve
 - `completed`: Run completed successfully
 - `failed`: Run failed
 - `cancelled`: Run was cancelled
@@ -909,6 +1185,7 @@ Notes on the selector semantics:
 
 - `pending`: Node execution is queued
 - `running`: Node is executing
+- `awaiting_approval`: Node is at an HITL gate (mirrored from WorkflowRun.status for UI highlighting)
 - `completed`: Node completed successfully
 - `failed`: Node execution failed
 - `skipped`: Node was skipped
@@ -926,5 +1203,66 @@ Notes on the selector semantics:
 - All field names use **camelCase** in API requests and responses
 - MongoDB document field names use **snake_case** internally
 - Response models use `response_model_by_alias=True` for automatic conversion
+
+---
+
+## HITL v2 Notes (Backward Compatibility & Internal Fields)
+
+This section documents implementation-level details introduced by the HITL v2
+migration (agno-native HumanReview). Frontend clients generally do not need
+these details, but they're documented here for operators and integration
+partners.
+
+### Backward Compatibility — Legacy `require_approval` Fields
+
+The path-A `require_approval: bool` and `approval_timeout_seconds: int` fields on
+WorkflowNode have been **removed** from the v2 API/model. To avoid breaking
+existing clients and silently dropping data from pre-v2 MongoDB documents, the
+backend provides a transparent migration:
+
+- **Inbound requests** containing legacy `requireApproval=true` (camelCase) are
+  rejected with a Pydantic 400 — frontend must switch to `humanReview`.
+- **Snake-case `require_approval=true` / `approval_timeout_seconds=N` keys
+  (from raw MongoDB documents or internal API callers)** are automatically
+  upgraded to `humanReview: { requiresConfirmation: true, timeoutSeconds: N }`
+  via a Pydantic `model_validator(mode='before')`. An INFO log entry is emitted
+  per migrated node so operators can audit usage.
+- `require_approval=false` was a no-op in path-A and remains a no-op (no
+  `humanReview` is synthesized).
+- If both legacy and `humanReview` are present, **`humanReview` wins** (explicit
+  beats legacy).
+
+These shims will be removed in a future cleanup release once telemetry confirms
+no callers send the legacy fields.
+
+### Internal WorkflowRun Fields (Not API-Exposed)
+
+The following fields exist on the persisted `WorkflowRun` document but are not
+returned in API responses. They are documented here for operators reading
+MongoDB directly or building admin tooling.
+
+| Field                                  | Type   | Purpose |
+|----------------------------------------|--------|---------|
+| `triggering_user_id`                   | string | User ID captured at trigger time; used to re-authenticate downstream MCP/A2A executor calls during HITL resume |
+| `triggering_registry_token_encrypted`  | string | AES-CBC ciphertext of the user's bearer token; decrypted just-in-time by `WorkflowControlService.resolve_requirement` before invoking `runner.continue_run` |
+| `pending_requirements`                 | array  | Serialized agno `StepRequirement` objects awaiting user decision; populated when `arun()` returns `is_paused=True`. **Surfaced to clients as `pendingRequirements`** in run-detail responses. |
+| `pending_directive`                    | enum   | Runtime intervention signal for pause/resume/cancel/retry (separate from HITL decisions, which go via `/approve`) |
+| `paused_at`                            | datetime | Set when run enters `paused` via user `/pause` directive (separate from HITL `awaiting_approval`) |
+
+### Known Limitations
+
+- **JWT expiration during long HITL pauses**: the captured triggering token is
+  not refreshed. If a user resolves an HITL pause after the token's `exp`,
+  `resolve_requirement` detects expiration, clears the token, logs a warning,
+  and proceeds — downstream MCP/A2A calls will return 401 (visible in
+  `nodeRuns[].error`).
+- **agno cancel edge case ([#7929](https://github.com/agno-agi/agno/issues/7929) OPEN)**:
+  cancel signals may not propagate through certain `acontinue_run +
+  external_execution` code paths inside agno. Our wait-loop wrapper's CANCEL
+  branch is the safety net (checks `pending_directive` before each step
+  attempt); dual-signal sync mitigates but does not 100% eliminate the race.
+- **HITL `on_reject=retry` attempt count**: agno's internal HITL retry does not
+  flow into our `NodeRun.attempt` field. The UI's attempt counter reflects
+  wait-loop retries only.
 
 ---

--- a/registry-pkgs/src/registry_pkgs/database/mongodb.py
+++ b/registry-pkgs/src/registry_pkgs/database/mongodb.py
@@ -25,6 +25,7 @@ from ..models import (
     User,
     WorkflowDefinition,
     WorkflowRun,
+    WorkflowVersion,
 )
 
 
@@ -133,6 +134,7 @@ class MongoDB:
                     WorkflowDefinition,
                     WorkflowRun,
                     NodeRun,
+                    WorkflowVersion,
                 ],
             )
         except Exception:

--- a/registry-pkgs/src/registry_pkgs/models/__init__.py
+++ b/registry-pkgs/src/registry_pkgs/models/__init__.py
@@ -21,7 +21,7 @@ from .extended_acl_entry import ExtendedAclEntry
 from .extended_mcp_server import ExtendedMCPServer
 from .federation import Federation
 from .federation_sync_job import FederationSyncJob
-from .workflow import NodeRun, WorkflowDefinition, WorkflowRun
+from .workflow import NodeRun, WorkflowDefinition, WorkflowRun, WorkflowVersion
 
 __all__ = [
     "A2AAgent",
@@ -33,6 +33,7 @@ __all__ = [
     "NodeRun",
     "WorkflowDefinition",
     "WorkflowRun",
+    "WorkflowVersion",
     "Group",
     "User",
     "Key",

--- a/registry-pkgs/src/registry_pkgs/models/enums.py
+++ b/registry-pkgs/src/registry_pkgs/models/enums.py
@@ -288,14 +288,59 @@ class ResolvedDependencyResolution(StrEnum):
 
 
 class WorkflowDirective(StrEnum):
-    """User-issued directives that can be sent to a live or finished workflow run."""
+    """User-issued runtime directives for a live workflow run.
+
+    Covers ad-hoc runtime intervention (pause / resume / cancel / retry) that
+    agno does not natively support and we implement via the wait-loop wrapper.
+    Node-level HITL decisions (confirm / reject / edit / user_input /
+    route_select) flow through ``WorkflowRun.pending_requirements`` +
+    ``POST /approve``, not through the directive queue.
+    """
 
     PAUSE = "pause"
     RESUME = "resume"
     CANCEL = "cancel"
     RETRY = "retry"
+
+
+# Enums below mirror agno's HumanReview / OnReject / OnTimeout /
+# StepRequirement methods so the API/UI layer talks in agno-aligned vocabulary.
+class OnRejectPolicy(StrEnum):
+    """What should happen when a user rejects an HITL gate.
+
+    Mirrors ``agno.workflow.types.OnReject``.  ``ELSE_BRANCH`` is only valid on
+    ``CONDITION`` nodes (sends execution down ``false_steps``).
+    """
+
+    SKIP = "skip"
+    CANCEL = "cancel"
+    RETRY = "retry"
+    ELSE_BRANCH = "else_branch"
+
+
+class OnTimeoutPolicy(StrEnum):
+    """What should happen when an HITL gate's timeout expires without a decision.
+
+    Mirrors ``agno.workflow.types.OnTimeout``.
+    """
+
     APPROVE = "approve"
+    SKIP = "skip"
+    CANCEL = "cancel"
+
+
+class RequirementResolution(StrEnum):
+    """The kind of user decision sent to a pending HITL requirement.
+
+    Maps 1:1 to agno ``StepRequirement.confirm() / .reject() / .edit() /
+    .set_user_input() / .set_selected_choices()``.  See API ``POST /approve``.
+    """
+
+    CONFIRM = "confirm"
     REJECT = "reject"
+    EDIT = "edit"
+    USER_INPUT = "user_input"
+    ROUTE_SELECT = "route_select"
 
 
 class WorkflowRunStateMachine:
@@ -358,14 +403,6 @@ class WorkflowRunStateMachine:
             if current in {WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED}:
                 return current
             raise ValueError(f"Cannot retry a run in status '{current}'")
-
-        if directive in {WorkflowDirective.APPROVE, WorkflowDirective.REJECT}:
-            # Approval directives are only valid while a node is holding for approval.
-            # On APPROVE the run resumes; on REJECT it also returns to RUNNING and the
-            # executor applies the node's on_error policy (fail/skip).
-            if current == WorkflowRunStatus.AWAITING_APPROVAL:
-                return WorkflowRunStatus.RUNNING
-            raise ValueError(f"Cannot {directive} a run in status '{current}'")
 
         raise ValueError(f"Unknown directive: '{directive}'")
 

--- a/registry-pkgs/src/registry_pkgs/models/enums.py
+++ b/registry-pkgs/src/registry_pkgs/models/enums.py
@@ -266,6 +266,7 @@ class WorkflowRunStatus(StrEnum):
     PENDING = "pending"
     RUNNING = "running"
     PAUSED = "paused"
+    AWAITING_APPROVAL = "awaiting_approval"
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
@@ -274,6 +275,7 @@ class WorkflowRunStatus(StrEnum):
 class NodeRunStatus(StrEnum):
     PENDING = "pending"
     RUNNING = "running"
+    AWAITING_APPROVAL = "awaiting_approval"
     COMPLETED = "completed"
     FAILED = "failed"
     SKIPPED = "skipped"
@@ -292,6 +294,8 @@ class WorkflowDirective(StrEnum):
     RESUME = "resume"
     CANCEL = "cancel"
     RETRY = "retry"
+    APPROVE = "approve"
+    REJECT = "reject"
 
 
 class WorkflowRunStateMachine:
@@ -308,7 +312,9 @@ class WorkflowRunStateMachine:
     )
 
     # Statuses that represent an in-flight execution (can receive pause/cancel).
-    ACTIVE_STATUSES: frozenset[WorkflowRunStatus] = frozenset({WorkflowRunStatus.RUNNING, WorkflowRunStatus.PAUSED})
+    ACTIVE_STATUSES: frozenset[WorkflowRunStatus] = frozenset(
+        {WorkflowRunStatus.RUNNING, WorkflowRunStatus.PAUSED, WorkflowRunStatus.AWAITING_APPROVAL}
+    )
 
     @staticmethod
     def apply_directive(current: WorkflowRunStatus, directive: WorkflowDirective) -> WorkflowRunStatus:
@@ -352,6 +358,14 @@ class WorkflowRunStateMachine:
             if current in {WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED}:
                 return current
             raise ValueError(f"Cannot retry a run in status '{current}'")
+
+        if directive in {WorkflowDirective.APPROVE, WorkflowDirective.REJECT}:
+            # Approval directives are only valid while a node is holding for approval.
+            # On APPROVE the run resumes; on REJECT it also returns to RUNNING and the
+            # executor applies the node's on_error policy (fail/skip).
+            if current == WorkflowRunStatus.AWAITING_APPROVAL:
+                return WorkflowRunStatus.RUNNING
+            raise ValueError(f"Cannot {directive} a run in status '{current}'")
 
         raise ValueError(f"Unknown directive: '{directive}'")
 

--- a/registry-pkgs/src/registry_pkgs/models/extended_acl_entry.py
+++ b/registry-pkgs/src/registry_pkgs/models/extended_acl_entry.py
@@ -18,6 +18,7 @@ class ExtendedResourceType(StrEnum):
     MCPSERVER = "mcpServer"
     REMOTE_AGENT = "remoteAgent"
     FEDERATION = "federation"
+    WORKFLOW = "workflow"
 
 
 class ExtendedAclEntry(AclEntry):

--- a/registry-pkgs/src/registry_pkgs/models/workflow.py
+++ b/registry-pkgs/src/registry_pkgs/models/workflow.py
@@ -458,6 +458,9 @@ class WorkflowRun(Document):
     # is the fast path.  On service restart the Queue is lost but this field survives,
     # allowing startup cleanup to mark orphan runs correctly.
     pending_directive: WorkflowDirective | None = None
+
+    # agno generates its own internal run_id (UUID) inside ``workflow.arun``;
+    agno_run_id: str | None = None
     # Set when the run transitions to PAUSED; used to enforce pause_timeout_seconds.
     paused_at: datetime | None = None
     # How long (seconds) a paused run may wait before being automatically cancelled.

--- a/registry-pkgs/src/registry_pkgs/models/workflow.py
+++ b/registry-pkgs/src/registry_pkgs/models/workflow.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import logging
 from collections import Counter
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from beanie import Document, PydanticObjectId
@@ -11,11 +12,15 @@ from pymongo import ASCENDING
 
 from registry_pkgs.models.enums import (
     NodeRunStatus,
+    OnRejectPolicy,
+    OnTimeoutPolicy,
     ResolvedDependencyResolution,
     WorkflowDirective,
     WorkflowNodeType,
     WorkflowRunStatus,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class StepConfig(BaseModel):
@@ -84,6 +89,63 @@ class LoopConfig(BaseModel):
         return value
 
 
+class UserInputField(BaseModel):
+    """Schema element used by ``HumanReviewSpec.user_input_schema``"""
+
+    name: str
+    field_type: Literal["string", "number", "boolean", "array"]
+    description: str | None = None
+    required: bool = False
+    default_value: Any | None = None
+
+
+class HumanReviewSpec(BaseModel):
+    """Per-node HITL configuration translated to agno ``HumanReview`` at compile time.
+
+    Field compatibility (validated in :meth:`WorkflowNode._validate_shape`):
+
+    ============================  =============  =============  =============  =============  =============
+    Field                         Step           Steps          Condition      Loop           Router
+    ============================  =============  =============  =============  =============  =============
+    requires_confirmation          ✓             ✓              ✓              ✓               ✓
+    requires_user_input            ✓             —              —              —               ✓
+    requires_output_review         ✓             —              —              —               ✓
+    requires_iteration_review      —             —              —              ✓               —
+    on_reject (else_branch)        —             —              ✓ only         —               —
+    ============================  =============  =============  =============  =============  =============
+
+    Parallel nodes do not support any HITL field (agno itself rejects them).
+    """
+
+    requires_confirmation: bool = False
+    confirmation_message: str | None = None
+    # Step / Router only — collect parameters at runtime via dynamic form
+    requires_user_input: bool = False
+    user_input_message: str | None = None
+    user_input_schema: list[UserInputField] | None = None
+    # Step / Router only — post-execution review (user can accept/edit/reject the step output)
+    requires_output_review: bool = False
+    output_review_message: str | None = None
+    # Loop only — pause after each iteration
+    requires_iteration_review: bool = False
+    iteration_review_message: str | None = None
+    # Shared behaviour
+    on_reject: OnRejectPolicy = OnRejectPolicy.SKIP
+    # timeout_seconds → agno stamps a per-requirement ``timeout_at`` deadline.
+    # agno applies on_timeout only at continue-time (not via a background timer),
+    # so WorkflowControlService.get_run_status nudges continue_run once a polled
+    # AWAITING_APPROVAL run is past the deadline.
+    timeout_seconds: int | None = None
+    on_timeout: OnTimeoutPolicy = OnTimeoutPolicy.CANCEL
+
+    @field_validator("timeout_seconds")
+    @classmethod
+    def _validate_timeout(cls, value: int | None) -> int | None:
+        if value is not None and value <= 0:
+            raise ValueError("timeout_seconds must be > 0")
+        return value
+
+
 class RouterChoice(BaseModel):
     """A single named choice in a ROUTER node, containing one or more steps.
 
@@ -118,10 +180,9 @@ class WorkflowNode(BaseModel):
     step_config: StepConfig | None = None
     config: dict[str, Any] = Field(default_factory=dict)
 
-    # Approval gate (STEP nodes only): when True the run holds at this node until a
-    # user APPROVE/REJECT directive is received (or the timeout elapses → treated as reject).
-    require_approval: bool = False
-    approval_timeout_seconds: int | None = None
+    # When set, agno's execution loop pauses at this node and emits a
+    # StepRequirement which we surface via WorkflowRun.pending_requirements.
+    human_review: HumanReviewSpec | None = None
 
     # Child nodes used by PARALLEL and LOOP container nodes.
     children: list[WorkflowNode] = Field(default_factory=list)
@@ -148,21 +209,11 @@ class WorkflowNode(BaseModel):
             raise ValueError("a2a_pool must contain at most 5 agents")
         return value
 
-    @field_validator("approval_timeout_seconds")
-    @classmethod
-    def _validate_approval_timeout(cls, value: int | None) -> int | None:
-        if value is not None and value <= 0:
-            raise ValueError("approval_timeout_seconds must be > 0")
-        return value
-
     @model_validator(mode="after")
     def _validate_shape(self) -> WorkflowNode:
-        # Approval gates are only supported on step nodes.
-        if self.node_type != WorkflowNodeType.STEP:
-            if self.require_approval:
-                raise ValueError("require_approval is only supported on step nodes")
-            if self.approval_timeout_seconds is not None:
-                raise ValueError("approval_timeout_seconds is only supported on step nodes")
+        # HITL: enforce per-node-type field compatibility for ``human_review``.
+        # Mirrors agno's validate_human_review_for_step / loop / router / condition / steps
+        _validate_human_review_for_node(self.node_type, self.human_review)
 
         if self.node_type == WorkflowNodeType.STEP:
             has_key = bool(self.executor_key)
@@ -250,6 +301,64 @@ class WorkflowNode(BaseModel):
 
 RouterChoice.model_rebuild()
 WorkflowNode.model_rebuild()
+
+
+def _validate_human_review_for_node(node_type: WorkflowNodeType, spec: HumanReviewSpec | None) -> None:
+    """
+        HITL: enforce agno's per-primitive HumanReview compatibility rules.
+
+    Mirrors ``agno.workflow.types.validate_human_review_for_*`` so we fail fast
+    at definition time instead of letting agno raise at compile time.
+    """
+    if spec is None:
+        return
+
+    if node_type == WorkflowNodeType.PARALLEL:
+        # agno itself raises ``requires_confirmation is not supported on Parallel``.
+        if (
+            spec.requires_confirmation
+            or spec.requires_user_input
+            or spec.requires_output_review
+            or spec.requires_iteration_review
+        ):
+            raise ValueError("parallel node does not support any HITL fields (agno restriction)")
+        return
+
+    if node_type == WorkflowNodeType.STEP:
+        if spec.requires_iteration_review:
+            raise ValueError("requires_iteration_review is not supported on step nodes")
+        return
+
+    if node_type == WorkflowNodeType.ROUTER:
+        if spec.requires_iteration_review:
+            raise ValueError("requires_iteration_review is not supported on router nodes")
+        return
+
+    if node_type == WorkflowNodeType.LOOP:
+        if spec.requires_user_input:
+            raise ValueError("requires_user_input is not supported on loop nodes")
+        if spec.requires_output_review:
+            raise ValueError("requires_output_review is not supported on loop nodes")
+        return
+
+    if node_type == WorkflowNodeType.CONDITION:
+        if spec.requires_user_input:
+            raise ValueError("requires_user_input is not supported on condition nodes")
+        if spec.requires_output_review:
+            raise ValueError("requires_output_review is not supported on condition nodes")
+        if spec.requires_iteration_review:
+            raise ValueError("requires_iteration_review is not supported on condition nodes")
+        # else_branch is only valid here (condition has true/false branches)
+        return
+
+    # Any future node type defaults to "no HITL until explicitly supported".
+    if (
+        spec.requires_confirmation
+        or spec.requires_user_input
+        or spec.requires_output_review
+        or spec.requires_iteration_review
+    ):
+        raise ValueError(f"HITL not supported on node_type={node_type!r}")
 
 
 class ResolvedDependency(BaseModel):
@@ -352,7 +461,24 @@ class WorkflowRun(Document):
     # Set when the run transitions to PAUSED; used to enforce pause_timeout_seconds.
     paused_at: datetime | None = None
     # How long (seconds) a paused run may wait before being automatically cancelled.
+    # NOTE: not yet enforced — ad-hoc PAUSE auto-cancel needs the periodic run
+    # reaper (tracked separately). HITL *gate* timeouts (HumanReviewSpec.on_timeout)
+    # ARE enforced lazily at continue-time; see WorkflowControlService.get_run_status.
     pause_timeout_seconds: int = 3600
+
+    # HITL: serialized agno ``StepRequirement`` objects awaiting user decision.
+    # Populated by ``WorkflowRunner._handle_run_output`` when ``arun()`` returns
+    # ``is_paused=True``; cleared (rehydrated into agno) by ``continue_run``.
+    # Atomically updated by ``WorkflowControlService.resolve_requirement`` using
+    # MongoDB ``array_filters`` so concurrent decisions on different stepIds are safe.
+    pending_requirements: list[dict[str, Any]] = Field(default_factory=list)
+
+    # Non-sensitive identity of the triggering user, captured so an HITL resume
+    # can re-mint a short-lived service JWT on their behalf. We deliberately do
+    # NOT persist the raw bearer token — see _prepare_resume_credentials.
+    triggering_user_id: str | None = None
+    triggering_username: str | None = None
+    triggering_scopes: list[str] | None = None
 
     class Settings:
         name = "workflow_runs"

--- a/registry-pkgs/src/registry_pkgs/models/workflow.py
+++ b/registry-pkgs/src/registry_pkgs/models/workflow.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 
 from beanie import Document, PydanticObjectId
 from pydantic import BaseModel, Field, field_validator, model_validator
-from pymongo import ASCENDING
+from pymongo import ASCENDING, IndexModel
 
 from registry_pkgs.models.enums import (
     NodeRunStatus,
@@ -262,6 +262,14 @@ class WorkflowNode(BaseModel):
                 raise ValueError("condition node must not define loop_config")
             if self.step_config is not None:
                 raise ValueError("condition node must not define step_config")
+            # on_reject=else_branch routes a rejected gate
+            # into the false branch at runtime;
+            if (
+                self.human_review is not None
+                and self.human_review.on_reject == OnRejectPolicy.ELSE_BRANCH
+                and not self.false_steps
+            ):
+                raise ValueError("condition node with on_reject=else_branch requires at least one false_steps entry")
             return self
 
         if self.node_type == WorkflowNodeType.LOOP:
@@ -412,7 +420,7 @@ class WorkflowVersion(Document):
     class Settings:
         name = "workflow_versions"
         indexes = [
-            [("workflow_id", ASCENDING), ("version", ASCENDING)],
+            IndexModel([("workflow_id", ASCENDING), ("version", ASCENDING)], unique=True),
         ]
 
 

--- a/registry-pkgs/src/registry_pkgs/models/workflow.py
+++ b/registry-pkgs/src/registry_pkgs/models/workflow.py
@@ -313,6 +313,11 @@ def _validate_human_review_for_node(node_type: WorkflowNodeType, spec: HumanRevi
     if spec is None:
         return
 
+    # else_branch needs a false branch, which only CONDITION nodes have; agno only
+    # fails on this at runtime (its validators ignore on_reject), so reject it here.
+    if spec.on_reject == OnRejectPolicy.ELSE_BRANCH and node_type != WorkflowNodeType.CONDITION:
+        raise ValueError("on_reject=else_branch is only supported on condition nodes")
+
     if node_type == WorkflowNodeType.PARALLEL:
         # agno itself raises ``requires_confirmation is not supported on Parallel``.
         if (

--- a/registry-pkgs/src/registry_pkgs/models/workflow.py
+++ b/registry-pkgs/src/registry_pkgs/models/workflow.py
@@ -118,6 +118,11 @@ class WorkflowNode(BaseModel):
     step_config: StepConfig | None = None
     config: dict[str, Any] = Field(default_factory=dict)
 
+    # Approval gate (STEP nodes only): when True the run holds at this node until a
+    # user APPROVE/REJECT directive is received (or the timeout elapses → treated as reject).
+    require_approval: bool = False
+    approval_timeout_seconds: int | None = None
+
     # Child nodes used by PARALLEL and LOOP container nodes.
     children: list[WorkflowNode] = Field(default_factory=list)
 
@@ -143,8 +148,22 @@ class WorkflowNode(BaseModel):
             raise ValueError("a2a_pool must contain at most 5 agents")
         return value
 
+    @field_validator("approval_timeout_seconds")
+    @classmethod
+    def _validate_approval_timeout(cls, value: int | None) -> int | None:
+        if value is not None and value <= 0:
+            raise ValueError("approval_timeout_seconds must be > 0")
+        return value
+
     @model_validator(mode="after")
     def _validate_shape(self) -> WorkflowNode:
+        # Approval gates are only supported on step nodes.
+        if self.node_type != WorkflowNodeType.STEP:
+            if self.require_approval:
+                raise ValueError("require_approval is only supported on step nodes")
+            if self.approval_timeout_seconds is not None:
+                raise ValueError("approval_timeout_seconds is only supported on step nodes")
+
         if self.node_type == WorkflowNodeType.STEP:
             has_key = bool(self.executor_key)
             has_pool = bool(self.a2a_pool)
@@ -245,6 +264,7 @@ class WorkflowDefinition(Document):
     name: str
     description: str | None = None
     nodes: list[WorkflowNode] = Field(default_factory=list)
+    version: int = 1
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
@@ -259,6 +279,26 @@ class WorkflowDefinition(Document):
         name = "workflow_definitions"
         indexes = [
             [("name", ASCENDING)],
+        ]
+
+
+class WorkflowVersion(Document):
+    """Historical snapshot of a WorkflowDefinition at a specific version.
+
+    Written on each PUT before the definition is overwritten, so prior versions
+    remain available for deterministic replay and audit.
+    """
+
+    workflow_id: PydanticObjectId
+    version: int
+    definition: dict[str, Any]
+    checksum: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "workflow_versions"
+        indexes = [
+            [("workflow_id", ASCENDING), ("version", ASCENDING)],
         ]
 
 
@@ -290,6 +330,8 @@ class WorkflowRun(Document):
     """Top-level record for a single execution of a WorkflowDefinition."""
 
     workflow_definition_id: PydanticObjectId
+    # Version of the definition this run executed against (snapshot in definition_snapshot).
+    workflow_version: int | None = None
     status: WorkflowRunStatus = WorkflowRunStatus.PENDING
     trigger_source: str | None = None
     started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/registry-pkgs/src/registry_pkgs/scopes.yml
+++ b/registry-pkgs/src/registry_pkgs/scopes.yml
@@ -34,6 +34,7 @@ group_mappings:
     - a2a-proxy-ops
     - workflows-read
     - workflows-control
+    - workflows-share
   jarvis-registry-power-user:
     - servers-read
     - agents-read
@@ -53,6 +54,7 @@ group_mappings:
     - a2a-proxy-ops
     - workflows-read
     - workflows-control
+    - workflows-share
   jarvis-registry-user:
     - servers-read
     - agents-read
@@ -315,6 +317,9 @@ workflows-read:
   - action: get_workflow_run
     method: GET
     endpoint: /workflows/{workflow_id}/runs/{run_id}
+  - action: list_workflow_versions
+    method: GET
+    endpoint: /workflows/{workflow_id}/versions
 
 workflows-control:
   # Write directives to live or finished workflow runs. Requires workflows-read.
@@ -333,6 +338,9 @@ workflows-control:
   - action: retry_workflow
     method: POST
     endpoint: /workflows/{workflow_id}/runs/{run_id}/retry
+  - action: approve_workflow_run
+    method: POST
+    endpoint: /workflows/{workflow_id}/runs/{run_id}/approve
 
 
 workflows-write:
@@ -345,6 +353,8 @@ workflows-write:
   - action: delete_workflow
     method: DELETE
     endpoint: /workflows/{workflow_id}
-  - action: trigger_workflow_run
-    method: POST
-    endpoint: /workflows/{workflow_id}/runs
+
+workflows-share:
+  - action: share_workflow
+    method: PUT
+    endpoint: /permissions/workflow/{resource_id}

--- a/registry-pkgs/src/registry_pkgs/scopes.yml
+++ b/registry-pkgs/src/registry_pkgs/scopes.yml
@@ -32,7 +32,6 @@ group_mappings:
     - acl-write
     - mcp-proxy-ops
     - a2a-proxy-ops
-    - workflows-read
     - workflows-control
     - workflows-share
   jarvis-registry-power-user:
@@ -52,7 +51,6 @@ group_mappings:
     - acl-write
     - mcp-proxy-ops
     - a2a-proxy-ops
-    - workflows-read
     - workflows-control
     - workflows-share
   jarvis-registry-user:
@@ -68,7 +66,6 @@ group_mappings:
     - acl-read
     - mcp-proxy-ops
     - a2a-proxy-ops
-    - workflows-read
     - workflows-control
   jarvis-registry-read-only:
     - servers-read
@@ -77,7 +74,6 @@ group_mappings:
     - workflows-read
     - user-read
     - acl-read
-    - workflows-read
 
 servers-read:
   - action: list_servers
@@ -305,9 +301,6 @@ workflows-read:
   - action: get_run_status
     method: GET
     endpoint: /workflows/{workflow_id}/runs/{run_id}/status
-  - action: list_runs_status
-    method: GET
-    endpoint: /workflows/{workflow_id}/runs/status
   - action: list_workflows
     method: GET
     endpoint: /workflows

--- a/registry-pkgs/src/registry_pkgs/scopes.yml
+++ b/registry-pkgs/src/registry_pkgs/scopes.yml
@@ -34,6 +34,7 @@ group_mappings:
     - a2a-proxy-ops
     - workflows-read
     - workflows-control
+    - workflows-share
   jarvis-registry-power-user:
     - servers-read
     - servers-write
@@ -53,6 +54,7 @@ group_mappings:
     - a2a-proxy-ops
     - workflows-read
     - workflows-control
+    - workflows-share
   jarvis-registry-user:
     - servers-read
     - servers-write
@@ -318,6 +320,9 @@ workflows-read:
   - action: get_workflow_run
     method: GET
     endpoint: /workflows/{workflow_id}/runs/{run_id}
+  - action: list_workflow_versions
+    method: GET
+    endpoint: /workflows/{workflow_id}/versions
 
 workflows-control:
   # Write directives to live or finished workflow runs. Requires workflows-read.
@@ -336,6 +341,9 @@ workflows-control:
   - action: retry_workflow
     method: POST
     endpoint: /workflows/{workflow_id}/runs/{run_id}/retry
+  - action: approve_workflow_run
+    method: POST
+    endpoint: /workflows/{workflow_id}/runs/{run_id}/approve
 
 
 workflows-write:
@@ -348,6 +356,8 @@ workflows-write:
   - action: delete_workflow
     method: DELETE
     endpoint: /workflows/{workflow_id}
-  - action: trigger_workflow_run
-    method: POST
-    endpoint: /workflows/{workflow_id}/runs
+
+workflows-share:
+  - action: share_workflow
+    method: PUT
+    endpoint: /permissions/workflow/{resource_id}

--- a/registry-pkgs/src/registry_pkgs/workflows/compiler.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/compiler.py
@@ -110,6 +110,8 @@ def compile_workflow(
                     node_name=node.name,
                     step_config=node.step_config,
                     directive_queue=directive_queue,
+                    require_approval=node.require_approval,
+                    approval_timeout_seconds=node.approval_timeout_seconds,
                 )
             return Step(
                 name=node.name,

--- a/registry-pkgs/src/registry_pkgs/workflows/compiler.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/compiler.py
@@ -15,9 +15,31 @@ from agno.workflow import (
     Workflow,
 )
 from agno.workflow.step import OnError, StepExecutor
+from agno.workflow.types import HumanReview
 
-from registry_pkgs.models.enums import WorkflowNodeType
-from registry_pkgs.models.workflow import StepConfig, WorkflowDefinition, WorkflowNode, WorkflowRun
+from registry_pkgs.models.enums import OnRejectPolicy, OnTimeoutPolicy, WorkflowNodeType
+from registry_pkgs.models.workflow import (
+    HumanReviewSpec,
+    StepConfig,
+    WorkflowDefinition,
+    WorkflowNode,
+    WorkflowRun,
+)
+
+# Anti-corruption layer: our enum values are the stable API/DB contract; agno's
+# internal string values are an implementation detail we translate at the boundary.
+# In particular agno spells ELSE_BRANCH as "else", not "else_branch".
+_ON_REJECT_TO_AGNO: dict[OnRejectPolicy, str] = {
+    OnRejectPolicy.SKIP: "skip",
+    OnRejectPolicy.CANCEL: "cancel",
+    OnRejectPolicy.RETRY: "retry",
+    OnRejectPolicy.ELSE_BRANCH: "else",
+}
+_ON_TIMEOUT_TO_AGNO: dict[OnTimeoutPolicy, str] = {
+    OnTimeoutPolicy.APPROVE: "approve",
+    OnTimeoutPolicy.SKIP: "skip",
+    OnTimeoutPolicy.CANCEL: "cancel",
+}
 from registry_pkgs.workflows.persistence import WorkflowRunSyncer
 from registry_pkgs.workflows.types import POOL_KEY_PREFIX
 
@@ -25,6 +47,32 @@ if TYPE_CHECKING:
     from registry_pkgs.workflows.control import DirectiveQueue
 
 logger = logging.getLogger(__name__)
+
+
+def _to_agno_human_review(spec: HumanReviewSpec | None) -> HumanReview | None:
+    """Translate our ``HumanReviewSpec`` into agno ``HumanReview``.
+
+    Returns ``None`` when no HITL is configured so we don't pass an empty
+    HumanReview into agno (which would still be a no-op but produces noisier
+    serialized state).
+    """
+    if not spec:
+        return None
+    schema = [f.model_dump() for f in spec.user_input_schema] if spec.user_input_schema else None
+    return HumanReview(
+        requires_confirmation=spec.requires_confirmation,
+        confirmation_message=spec.confirmation_message,
+        requires_user_input=spec.requires_user_input,
+        user_input_message=spec.user_input_message,
+        user_input_schema=schema,
+        requires_output_review=spec.requires_output_review,
+        output_review_message=spec.output_review_message,
+        requires_iteration_review=spec.requires_iteration_review,
+        iteration_review_message=spec.iteration_review_message,
+        on_reject=_ON_REJECT_TO_AGNO[spec.on_reject],
+        timeout=spec.timeout_seconds,
+        on_timeout=_ON_TIMEOUT_TO_AGNO[spec.on_timeout],
+    )
 
 
 def compile_workflow(
@@ -83,6 +131,8 @@ def compile_workflow(
         return _injected
 
     def _build(node: WorkflowNode) -> Any:
+
+        human_review = _to_agno_human_review(node.human_review)
         if node.node_type == WorkflowNodeType.STEP:
             lookup_key = f"{POOL_KEY_PREFIX}{node.id}" if node.a2a_pool else node.executor_key
 
@@ -110,16 +160,16 @@ def compile_workflow(
                     node_name=node.name,
                     step_config=node.step_config,
                     directive_queue=directive_queue,
-                    require_approval=node.require_approval,
-                    approval_timeout_seconds=node.approval_timeout_seconds,
                 )
             return Step(
                 name=node.name,
                 executor=executor,
+                human_review=human_review,
                 **step_kwargs(node.step_config),
             )
 
         if node.node_type == WorkflowNodeType.PARALLEL:
+            # agno's Parallel does not accept human_review (model layer enforces this too).
             return Parallel(*[_build(c) for c in node.children], name=node.name)
 
         if node.node_type == WorkflowNodeType.CONDITION:
@@ -130,6 +180,7 @@ def compile_workflow(
                 evaluator=node.condition_cel,
                 else_steps=false_branch,
                 name=node.name,
+                human_review=human_review,
             )
 
         if node.node_type == WorkflowNodeType.LOOP:
@@ -139,6 +190,7 @@ def compile_workflow(
                 name=node.name,
                 max_iterations=node.loop_config.max_iterations,  # type: ignore[union-attr]
                 end_condition=end_cond,
+                human_review=human_review,
             )
 
         if node.node_type == WorkflowNodeType.ROUTER:
@@ -149,6 +201,7 @@ def compile_workflow(
                 choices=compiled_choices,
                 selector=node.condition_cel,
                 name=node.name,
+                human_review=human_review,
             )
 
         raise ValueError(f"Unknown node_type: {node.node_type!r}")

--- a/registry-pkgs/src/registry_pkgs/workflows/compiler.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/compiler.py
@@ -40,6 +40,7 @@ _ON_TIMEOUT_TO_AGNO: dict[OnTimeoutPolicy, str] = {
     OnTimeoutPolicy.SKIP: "skip",
     OnTimeoutPolicy.CANCEL: "cancel",
 }
+from registry_pkgs.workflows.hitl.field_types import field_type_to_agno
 from registry_pkgs.workflows.persistence import WorkflowRunSyncer
 from registry_pkgs.workflows.types import POOL_KEY_PREFIX
 
@@ -58,7 +59,11 @@ def _to_agno_human_review(spec: HumanReviewSpec | None) -> HumanReview | None:
     """
     if not spec:
         return None
-    schema = [f.model_dump() for f in spec.user_input_schema] if spec.user_input_schema else None
+    schema = (
+        [{**f.model_dump(), "field_type": field_type_to_agno(f.field_type)} for f in spec.user_input_schema]
+        if spec.user_input_schema
+        else None
+    )
     return HumanReview(
         requires_confirmation=spec.requires_confirmation,
         confirmation_message=spec.confirmation_message,

--- a/registry-pkgs/src/registry_pkgs/workflows/compiler.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/compiler.py
@@ -25,6 +25,14 @@ from registry_pkgs.models.workflow import (
     WorkflowNode,
     WorkflowRun,
 )
+from registry_pkgs.workflows.hitl.field_types import field_type_to_agno
+from registry_pkgs.workflows.persistence import WorkflowRunSyncer
+from registry_pkgs.workflows.types import POOL_KEY_PREFIX
+
+if TYPE_CHECKING:
+    from registry_pkgs.workflows.control import DirectiveQueue
+
+logger = logging.getLogger(__name__)
 
 # Anti-corruption layer: our enum values are the stable API/DB contract; agno's
 # internal string values are an implementation detail we translate at the boundary.
@@ -40,14 +48,6 @@ _ON_TIMEOUT_TO_AGNO: dict[OnTimeoutPolicy, str] = {
     OnTimeoutPolicy.SKIP: "skip",
     OnTimeoutPolicy.CANCEL: "cancel",
 }
-from registry_pkgs.workflows.hitl.field_types import field_type_to_agno
-from registry_pkgs.workflows.persistence import WorkflowRunSyncer
-from registry_pkgs.workflows.types import POOL_KEY_PREFIX
-
-if TYPE_CHECKING:
-    from registry_pkgs.workflows.control import DirectiveQueue
-
-logger = logging.getLogger(__name__)
 
 
 def _to_agno_human_review(spec: HumanReviewSpec | None) -> HumanReview | None:

--- a/registry-pkgs/src/registry_pkgs/workflows/control/wrapper.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/control/wrapper.py
@@ -1,5 +1,4 @@
-"""
-Executor wrapper that injects directive checking and retry backoff into every step.
+"""Executor wrapper that injects directive checking and retry backoff into every step.
 
 ``with_control`` wraps any StepExecutor and adds:
 
@@ -19,6 +18,13 @@ Executor wrapper that injects directive checking and retry backoff into every st
 
 4. **Attempt persistence** — ``NodeRun.attempt`` is incremented and written to
    MongoDB at the start of each attempt so the UI always reflects the latest try.
+
+Node-level HITL (confirmation / user_input / output_review / iteration review)
+is handled by agno's native ``HumanReview`` configuration — agno's execution
+loop detects and pauses on its own, and we surface the pause via
+``WorkflowRunner._handle_run_output`` writing ``WorkflowRun.pending_requirements``.
+This wrapper covers what agno does not: ad-hoc pause/resume, exponential-backoff
+retry, and per-attempt persistence.
 """
 
 from __future__ import annotations
@@ -31,11 +37,11 @@ from datetime import UTC, datetime
 from agno.workflow import StepInput, StepOutput
 from agno.workflow.step import StepExecutor
 from beanie import PydanticObjectId
-from pydantic import BaseModel
 
 from registry_pkgs.models.enums import NodeRunStatus, WorkflowDirective, WorkflowRunStatus
 from registry_pkgs.models.workflow import NodeRun, StepConfig, WorkflowRun
 from registry_pkgs.workflows.control.queue import DirectiveQueue
+from registry_pkgs.workflows.hitl import PendingDirectiveProjection
 
 logger = logging.getLogger(__name__)
 
@@ -60,8 +66,6 @@ def with_control(
     node_name: str,
     step_config: StepConfig | None,
     directive_queue: DirectiveQueue,
-    require_approval: bool = False,
-    approval_timeout_seconds: int | None = None,
 ) -> StepExecutor:
     """Wrap *executor* with directive checking and retry-backoff logic.
 
@@ -73,10 +77,6 @@ def with_control(
         step_config:     Per-step retry / error-handling policy, or ``None`` for
                          the safe production default (no retry, fail-fast).
         directive_queue: The shared in-process DirectiveQueue.
-        require_approval: When True, hold the run at this node until a user
-                         APPROVE/REJECT directive arrives (or the timeout elapses).
-        approval_timeout_seconds: Seconds to wait for approval before treating it
-                         as a rejection; falls back to ``WorkflowRun.pause_timeout_seconds``.
 
     Returns:
         A new async callable with the same signature as *executor*.
@@ -91,21 +91,6 @@ def with_control(
         backoff_cap = 60.0
 
     async def wrapped(step_input: StepInput, session_state: dict | None = None) -> StepOutput:
-        # Approval gate — evaluated once before any execution attempt.
-        if require_approval:
-            decision = await _wait_for_approval(
-                run_id=run_id,
-                node_id=node_id,
-                node_name=node_name,
-                directive_queue=directive_queue,
-                approval_timeout_seconds=approval_timeout_seconds,
-            )
-            if decision == "cancelled":
-                raise WorkflowCancelledError("Workflow cancelled by user")
-            if decision == "rejected":
-                await _mark_node_failed(run_id, node_id, node_name, "Rejected at approval gate")
-                return StepOutput(content="", success=False, error="Rejected at approval gate")
-
         for attempt in range(max_attempts):
             # 1. Check for a pending directive before starting the attempt
             cancel_reason = await _check_and_handle_directive(
@@ -192,10 +177,6 @@ async def _check_and_handle_directive(
     return None
 
 
-class _PendingDirectiveProjection(BaseModel):
-    pending_directive: WorkflowDirective | None = None
-
-
 async def _read_mongodb_directive(run_id: str) -> WorkflowDirective | None:
     """Read ``WorkflowRun.pending_directive`` from MongoDB.
 
@@ -203,10 +184,13 @@ async def _read_mongodb_directive(run_id: str) -> WorkflowDirective | None:
     recover a lost directive after a pod restart.  Only ``pending_directive`` is
     projected so the full document (with definition_snapshot, outputs, etc.) is
     never transferred over the wire.
+
+    The projection model is shared with ``MongoBackedCancellationManager`` via
+    ``registry_pkgs.workflows.hitl.projections`` so both consumers stay in sync.
     """
     run = await WorkflowRun.find_one(
         WorkflowRun.id == PydanticObjectId(run_id),
-        projection_model=_PendingDirectiveProjection,
+        projection_model=PendingDirectiveProjection,
     )
     return run.pending_directive if run is not None else None
 
@@ -269,126 +253,6 @@ async def _wait_while_paused(
                 timeout_secs,
             )
             return f"Workflow cancelled after pause timeout ({int(timeout_secs)}s)"
-
-
-async def _wait_for_approval(
-    *,
-    run_id: str,
-    node_id: str,
-    node_name: str,
-    directive_queue: DirectiveQueue,
-    approval_timeout_seconds: int | None,
-) -> str:
-    """Hold the run at an approval gate until APPROVE/REJECT/CANCEL or timeout.
-
-    Returns one of ``"approved"``, ``"rejected"`` (also on timeout), or
-    ``"cancelled"``.  Mirrors the pause-wait loop but with approval semantics.
-    """
-    logger.info("Node %r: require_approval — holding for user APPROVE/REJECT", node_name)
-
-    run = await WorkflowRun.get(PydanticObjectId(run_id))
-    if run is None:
-        raise RuntimeError(f"WorkflowRun {run_id!r} not found while entering approval — data integrity error")
-
-    await _update_run_control_state(
-        run_id,
-        status=WorkflowRunStatus.AWAITING_APPROVAL,
-        pending_directive=None,
-        paused_at=datetime.now(UTC),
-    )
-    await _mark_node_status(run_id, node_id, node_name, NodeRunStatus.AWAITING_APPROVAL)
-
-    timeout_secs = float(
-        approval_timeout_seconds if approval_timeout_seconds is not None else run.pause_timeout_seconds
-    )
-    waiting_since = datetime.now(UTC)
-
-    poll_count = 0
-    while True:
-        next_directive = await directive_queue.wait_for_directive(run_id, timeout=PAUSE_POLL_INTERVAL)
-
-        poll_count += 1
-        if next_directive is None and poll_count % MONGO_POLL_EVERY_N == 0:
-            next_directive = await _read_mongodb_directive(run_id)
-
-        if next_directive == WorkflowDirective.APPROVE:
-            await _update_run_control_state(
-                run_id, status=WorkflowRunStatus.RUNNING, pending_directive=None, paused_at=None
-            )
-            logger.info("Node %r: APPROVE received, continuing execution", node_name)
-            return "approved"
-
-        if next_directive == WorkflowDirective.REJECT:
-            await _update_run_control_state(
-                run_id, status=WorkflowRunStatus.RUNNING, pending_directive=None, paused_at=None
-            )
-            logger.info("Node %r: REJECT received, failing node via on_error policy", node_name)
-            return "rejected"
-
-        if next_directive == WorkflowDirective.CANCEL:
-            await _update_run_control_state(run_id, pending_directive=None)
-            logger.info("Node %r: CANCEL received while awaiting approval, aborting", node_name)
-            return "cancelled"
-
-        elapsed = (datetime.now(UTC) - waiting_since).total_seconds()
-        if elapsed >= timeout_secs:
-            await _update_run_control_state(
-                run_id, status=WorkflowRunStatus.RUNNING, pending_directive=None, paused_at=None
-            )
-            logger.warning(
-                "Node %r: approval timeout (%.0fs) exceeded, treating as rejection",
-                node_name,
-                timeout_secs,
-            )
-            return "rejected"
-
-
-async def _mark_node_status(
-    run_id: str,
-    node_id: str,
-    node_name: str,
-    status: NodeRunStatus,
-) -> None:
-    """Upsert a NodeRun and set its status (used to surface awaiting_approval)."""
-    run_oid = PydanticObjectId(run_id)
-    node_run = await NodeRun.find_one(
-        NodeRun.workflow_run_id == run_oid,
-        NodeRun.node_id == node_id,
-    )
-    if node_run is None:
-        node_run = NodeRun(
-            workflow_run_id=run_oid,
-            node_id=node_id,
-            node_name=node_name,
-            started_at=datetime.now(UTC),
-        )
-    node_run.status = status
-    await node_run.save()
-
-
-async def _mark_node_failed(
-    run_id: str,
-    node_id: str,
-    node_name: str,
-    error: str,
-) -> None:
-    """Upsert a NodeRun as FAILED with an error message (used on approval rejection)."""
-    run_oid = PydanticObjectId(run_id)
-    node_run = await NodeRun.find_one(
-        NodeRun.workflow_run_id == run_oid,
-        NodeRun.node_id == node_id,
-    )
-    if node_run is None:
-        node_run = NodeRun(
-            workflow_run_id=run_oid,
-            node_id=node_id,
-            node_name=node_name,
-            started_at=datetime.now(UTC),
-        )
-    node_run.status = NodeRunStatus.FAILED
-    node_run.error = error
-    node_run.finished_at = datetime.now(UTC)
-    await node_run.save()
 
 
 async def _record_attempt_start(

--- a/registry-pkgs/src/registry_pkgs/workflows/control/wrapper.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/control/wrapper.py
@@ -60,6 +60,8 @@ def with_control(
     node_name: str,
     step_config: StepConfig | None,
     directive_queue: DirectiveQueue,
+    require_approval: bool = False,
+    approval_timeout_seconds: int | None = None,
 ) -> StepExecutor:
     """Wrap *executor* with directive checking and retry-backoff logic.
 
@@ -71,6 +73,10 @@ def with_control(
         step_config:     Per-step retry / error-handling policy, or ``None`` for
                          the safe production default (no retry, fail-fast).
         directive_queue: The shared in-process DirectiveQueue.
+        require_approval: When True, hold the run at this node until a user
+                         APPROVE/REJECT directive arrives (or the timeout elapses).
+        approval_timeout_seconds: Seconds to wait for approval before treating it
+                         as a rejection; falls back to ``WorkflowRun.pause_timeout_seconds``.
 
     Returns:
         A new async callable with the same signature as *executor*.
@@ -85,6 +91,21 @@ def with_control(
         backoff_cap = 60.0
 
     async def wrapped(step_input: StepInput, session_state: dict | None = None) -> StepOutput:
+        # Approval gate — evaluated once before any execution attempt.
+        if require_approval:
+            decision = await _wait_for_approval(
+                run_id=run_id,
+                node_id=node_id,
+                node_name=node_name,
+                directive_queue=directive_queue,
+                approval_timeout_seconds=approval_timeout_seconds,
+            )
+            if decision == "cancelled":
+                raise WorkflowCancelledError("Workflow cancelled by user")
+            if decision == "rejected":
+                await _mark_node_failed(run_id, node_id, node_name, "Rejected at approval gate")
+                return StepOutput(content="", success=False, error="Rejected at approval gate")
+
         for attempt in range(max_attempts):
             # 1. Check for a pending directive before starting the attempt
             cancel_reason = await _check_and_handle_directive(
@@ -248,6 +269,126 @@ async def _wait_while_paused(
                 timeout_secs,
             )
             return f"Workflow cancelled after pause timeout ({int(timeout_secs)}s)"
+
+
+async def _wait_for_approval(
+    *,
+    run_id: str,
+    node_id: str,
+    node_name: str,
+    directive_queue: DirectiveQueue,
+    approval_timeout_seconds: int | None,
+) -> str:
+    """Hold the run at an approval gate until APPROVE/REJECT/CANCEL or timeout.
+
+    Returns one of ``"approved"``, ``"rejected"`` (also on timeout), or
+    ``"cancelled"``.  Mirrors the pause-wait loop but with approval semantics.
+    """
+    logger.info("Node %r: require_approval — holding for user APPROVE/REJECT", node_name)
+
+    run = await WorkflowRun.get(PydanticObjectId(run_id))
+    if run is None:
+        raise RuntimeError(f"WorkflowRun {run_id!r} not found while entering approval — data integrity error")
+
+    await _update_run_control_state(
+        run_id,
+        status=WorkflowRunStatus.AWAITING_APPROVAL,
+        pending_directive=None,
+        paused_at=datetime.now(UTC),
+    )
+    await _mark_node_status(run_id, node_id, node_name, NodeRunStatus.AWAITING_APPROVAL)
+
+    timeout_secs = float(
+        approval_timeout_seconds if approval_timeout_seconds is not None else run.pause_timeout_seconds
+    )
+    waiting_since = datetime.now(UTC)
+
+    poll_count = 0
+    while True:
+        next_directive = await directive_queue.wait_for_directive(run_id, timeout=PAUSE_POLL_INTERVAL)
+
+        poll_count += 1
+        if next_directive is None and poll_count % MONGO_POLL_EVERY_N == 0:
+            next_directive = await _read_mongodb_directive(run_id)
+
+        if next_directive == WorkflowDirective.APPROVE:
+            await _update_run_control_state(
+                run_id, status=WorkflowRunStatus.RUNNING, pending_directive=None, paused_at=None
+            )
+            logger.info("Node %r: APPROVE received, continuing execution", node_name)
+            return "approved"
+
+        if next_directive == WorkflowDirective.REJECT:
+            await _update_run_control_state(
+                run_id, status=WorkflowRunStatus.RUNNING, pending_directive=None, paused_at=None
+            )
+            logger.info("Node %r: REJECT received, failing node via on_error policy", node_name)
+            return "rejected"
+
+        if next_directive == WorkflowDirective.CANCEL:
+            await _update_run_control_state(run_id, pending_directive=None)
+            logger.info("Node %r: CANCEL received while awaiting approval, aborting", node_name)
+            return "cancelled"
+
+        elapsed = (datetime.now(UTC) - waiting_since).total_seconds()
+        if elapsed >= timeout_secs:
+            await _update_run_control_state(
+                run_id, status=WorkflowRunStatus.RUNNING, pending_directive=None, paused_at=None
+            )
+            logger.warning(
+                "Node %r: approval timeout (%.0fs) exceeded, treating as rejection",
+                node_name,
+                timeout_secs,
+            )
+            return "rejected"
+
+
+async def _mark_node_status(
+    run_id: str,
+    node_id: str,
+    node_name: str,
+    status: NodeRunStatus,
+) -> None:
+    """Upsert a NodeRun and set its status (used to surface awaiting_approval)."""
+    run_oid = PydanticObjectId(run_id)
+    node_run = await NodeRun.find_one(
+        NodeRun.workflow_run_id == run_oid,
+        NodeRun.node_id == node_id,
+    )
+    if node_run is None:
+        node_run = NodeRun(
+            workflow_run_id=run_oid,
+            node_id=node_id,
+            node_name=node_name,
+            started_at=datetime.now(UTC),
+        )
+    node_run.status = status
+    await node_run.save()
+
+
+async def _mark_node_failed(
+    run_id: str,
+    node_id: str,
+    node_name: str,
+    error: str,
+) -> None:
+    """Upsert a NodeRun as FAILED with an error message (used on approval rejection)."""
+    run_oid = PydanticObjectId(run_id)
+    node_run = await NodeRun.find_one(
+        NodeRun.workflow_run_id == run_oid,
+        NodeRun.node_id == node_id,
+    )
+    if node_run is None:
+        node_run = NodeRun(
+            workflow_run_id=run_oid,
+            node_id=node_id,
+            node_name=node_name,
+            started_at=datetime.now(UTC),
+        )
+    node_run.status = NodeRunStatus.FAILED
+    node_run.error = error
+    node_run.finished_at = datetime.now(UTC)
+    await node_run.save()
 
 
 async def _record_attempt_start(

--- a/registry-pkgs/src/registry_pkgs/workflows/hitl/__init__.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/hitl/__init__.py
@@ -1,0 +1,10 @@
+from registry_pkgs.workflows.hitl.cancellation import MongoBackedCancellationManager
+from registry_pkgs.workflows.hitl.projections import PendingDirectiveProjection
+from registry_pkgs.workflows.hitl.serde import hydrate_requirement, serialize_requirement
+
+__all__ = [
+    "MongoBackedCancellationManager",
+    "PendingDirectiveProjection",
+    "hydrate_requirement",
+    "serialize_requirement",
+]

--- a/registry-pkgs/src/registry_pkgs/workflows/hitl/cancellation.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/hitl/cancellation.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from agno.exceptions import RunCancelledException
+from agno.run.cancellation_management.base import BaseRunCancellationManager
+from beanie import PydanticObjectId
+
+from registry_pkgs.models.enums import WorkflowDirective
+from registry_pkgs.models.workflow import WorkflowRun
+from registry_pkgs.workflows.hitl.projections import PendingDirectiveProjection
+
+if TYPE_CHECKING:
+    from registry_pkgs.workflows.control.queue import DirectiveQueue
+
+logger = logging.getLogger(__name__)
+
+
+class MongoBackedCancellationManager(BaseRunCancellationManager):
+    """Bridge agno cancel signals ⇄ ``WorkflowRun.pending_directive``.
+
+    ``directive_queue`` is optional; when wired, ``acancel_run`` pushes CANCEL
+    onto it so the wait-loop wrapper wakes up immediately instead of waiting
+    up to 60s for its next Mongo poll.
+    """
+
+    def __init__(self, directive_queue: DirectiveQueue | None = None) -> None:
+        super().__init__()
+        self._directive_queue = directive_queue
+
+    async def aregister_run(self, run_id: str) -> None:
+        return None
+
+    async def acancel_run(self, run_id: str) -> bool:
+        try:
+            oid = PydanticObjectId(run_id)
+        except Exception as exc:
+            logger.warning(f"Could not find run_id {run_id}: {exc}")
+            return False
+        result = await WorkflowRun.find_one(WorkflowRun.id == oid).update(
+            {"$set": {"pending_directive": WorkflowDirective.CANCEL.value}}
+        )
+        modified = bool(getattr(result, "modified_count", 0))
+        if modified and self._directive_queue is not None:
+            try:
+                self._directive_queue.put(run_id, WorkflowDirective.CANCEL)
+            except Exception as exc:
+                # Queue push failure is non-fatal — Mongo write is the truth source.
+                logger.warning("acancel_run: directive_queue.put failed for %s: %s", run_id, exc)
+        logger.info("acancel_run: run_id=%s modified=%s", run_id, modified)
+        return modified
+
+    async def ais_cancelled(self, run_id: str) -> bool:
+        try:
+            oid = PydanticObjectId(run_id)
+        except Exception as exc:
+            logger.error(f"acancel_run: invalid run_id={run_id}: {exc}")
+            return False
+        run = await WorkflowRun.find_one(
+            WorkflowRun.id == oid,
+            projection_model=PendingDirectiveProjection,
+        )
+        return run is not None and run.pending_directive == WorkflowDirective.CANCEL
+
+    async def araise_if_cancelled(self, run_id: str) -> None:
+        if await self.ais_cancelled(run_id):
+            raise RunCancelledException(f"Run {run_id} was cancelled")
+
+    async def acleanup_run(self, run_id: str) -> None:
+        return None
+
+    async def aget_active_runs(self) -> dict[str, bool]:
+        return {}
+
+    def register_run(self, run_id: str) -> None:
+        return None
+
+    def cancel_run(self, run_id: str) -> bool:
+        raise NotImplementedError("use acancel_run")
+
+    def is_cancelled(self, run_id: str) -> bool:
+        raise NotImplementedError("use ais_cancelled")
+
+    def raise_if_cancelled(self, run_id: str) -> None:
+        raise NotImplementedError("use araise_if_cancelled")
+
+    def cleanup_run(self, run_id: str) -> None:
+        return None
+
+    def get_active_runs(self) -> dict[str, bool]:
+        return {}

--- a/registry-pkgs/src/registry_pkgs/workflows/hitl/field_types.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/hitl/field_types.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+_AUTHORING_TO_AGNO: dict[str, str] = {
+    "string": "str",
+    "number": "float",
+    "boolean": "bool",
+    "array": "list",
+}
+
+_AGNO_TO_AUTHORING: dict[str, str] = {
+    "str": "string",
+    "int": "number",
+    "float": "number",
+    "bool": "boolean",
+    "list": "array",
+    "string": "string",
+    "number": "number",
+    "boolean": "boolean",
+    "array": "array",
+}
+
+
+def field_type_to_agno(field_type: str) -> str:
+    """Map an authoring field-type name to the agno Python type name.
+
+    Unknown values pass through unchanged.
+    """
+    return _AUTHORING_TO_AGNO.get(field_type, field_type)
+
+
+def field_type_to_authoring(field_type: str | None) -> str | None:
+    """Map an agno (or already-authoring) field-type name to the authoring vocab.
+
+    ``None`` passes through as ``None``; unknown values pass through unchanged.
+    """
+    if field_type is None:
+        return None
+    return _AGNO_TO_AUTHORING.get(field_type, field_type)

--- a/registry-pkgs/src/registry_pkgs/workflows/hitl/projections.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/hitl/projections.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from registry_pkgs.models.enums import WorkflowDirective
+
+
+class PendingDirectiveProjection(BaseModel):
+    """Minimal projection — read pending_directive without loading the full WorkflowRun."""
+
+    pending_directive: WorkflowDirective | None = None

--- a/registry-pkgs/src/registry_pkgs/workflows/hitl/serde.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/hitl/serde.py
@@ -1,0 +1,59 @@
+"""Serde for agno ``StepRequirement`` ↔ MongoDB-friendly dict.
+
+Why
+---
+agno's ``StepRequirement`` is a Python dataclass with nested ``StepInput`` /
+``StepOutput`` objects.  We persist these inside ``WorkflowRun.pending_requirements``
+(a list of plain dicts) so the API layer can expose them to the frontend and so
+``WorkflowRunner.continue_run`` can re-hydrate them before calling
+``workflow.acontinue_run(step_requirements=...)``.
+
+Schema versioning
+-----------------
+Every serialized requirement carries ``schema_version`` so we can detect / migrate
+across agno upgrades that change the underlying dataclass shape.  When agno bumps
+its types, increment ``CURRENT_SCHEMA_VERSION`` and add a branch in
+``hydrate_requirement`` if the new layout is not back-compatible.
+
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from agno.workflow.types import StepRequirement
+
+logger = logging.getLogger(__name__)
+
+CURRENT_SCHEMA_VERSION: int = 1
+
+
+def serialize_requirement(requirement: StepRequirement) -> dict[str, Any]:
+    """Convert an agno ``StepRequirement`` into a JSON/Mongo-friendly dict.
+
+    Delegates to agno's own ``StepRequirement.to_dict()`` (which handles nested
+    ``StepInput`` / ``StepOutput``) and adds our ``schema_version`` envelope.
+    """
+    data = requirement.to_dict()
+    data["schema_version"] = CURRENT_SCHEMA_VERSION
+    return data
+
+
+def hydrate_requirement(data: dict[str, Any]) -> StepRequirement:
+    """Reconstruct an agno ``StepRequirement`` from a previously serialized dict.
+
+    Strips the ``schema_version`` envelope before delegating to
+    ``StepRequirement.from_dict()``.
+    """
+    version = data.get("schema_version", CURRENT_SCHEMA_VERSION)
+    if version != CURRENT_SCHEMA_VERSION:
+        # Future hook for forward migrations.  For now we attempt best-effort
+        # passthrough and log a warning so operators can spot incompatibilities.
+        logger.warning(
+            "requirement_serde: hydrating schema_version=%s with current=%s — verify compatibility",
+            version,
+            CURRENT_SCHEMA_VERSION,
+        )
+    payload = {k: v for k, v in data.items() if k != "schema_version"}
+    return StepRequirement.from_dict(payload)

--- a/registry-pkgs/src/registry_pkgs/workflows/persistence.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/persistence.py
@@ -221,6 +221,8 @@ def _flatten_step_results(results: list[Any]) -> list[StepOutput]:
             flat.extend(_flatten_step_results(item))
         elif isinstance(item, StepOutput):
             flat.append(item)
+            if item.steps:
+                flat.extend(_flatten_step_results(item.steps))
     return flat
 
 

--- a/registry-pkgs/src/registry_pkgs/workflows/persistence.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/persistence.py
@@ -88,7 +88,7 @@ class WorkflowRunSyncer(AsyncMongoDb):
     ) -> None:
         """Write WorkflowRun status and per-step NodeRuns from WorkflowRunOutput."""
         step_outputs = _flatten_step_results(run_output.step_results)
-        final_status = _resolve_workflow_run_status(run_output, step_outputs)
+        final_status = _resolve_workflow_run_status(run_output, step_outputs, self._node_by_name)
         active_session = get_current_session()
 
         if final_status in _TERMINAL_STATUSES:
@@ -143,7 +143,7 @@ class WorkflowRunSyncer(AsyncMongoDb):
         session: AsyncClientSession | None = None,
     ) -> WorkflowRunStatus:
         run = self._workflow_run
-        mapped_status = _resolve_workflow_run_status(run_output, step_outputs or [])
+        mapped_status = _resolve_workflow_run_status(run_output, step_outputs or [], self._node_by_name)
         run.status = mapped_status
         if mapped_status in _TERMINAL_STATUSES:
             if run.finished_at is None:
@@ -184,7 +184,14 @@ class WorkflowRunSyncer(AsyncMongoDb):
                 node_name=step_name,
             )
 
-        node_run.status = NodeRunStatus.COMPLETED if step_output.success else NodeRunStatus.FAILED
+        if step_output.success:
+            node_run.status = NodeRunStatus.COMPLETED
+        elif _is_skip_tolerated_failure(step_output, self._node_by_name):
+            # on_error=skip: a tolerated failure is recorded as SKIPPED (not FAILED)
+            # so the UI distinguishes "skipped over" from a hard failure.
+            node_run.status = NodeRunStatus.SKIPPED
+        else:
+            node_run.status = NodeRunStatus.FAILED
         node_run.attempt = max(node_run.attempt, 1)
         node_run.finished_at = datetime.now(UTC)
         node_run.error = step_output.error
@@ -226,9 +233,26 @@ def _flatten_step_results(results: list[Any]) -> list[StepOutput]:
     return flat
 
 
+def _is_skip_tolerated_failure(
+    step_output: StepOutput,
+    node_by_name: dict[str, WorkflowNode] | None,
+) -> bool:
+    """True if a failed step belongs to a node configured with ``on_error="skip"``.
+
+    Such a failure is non-fatal by the author's explicit choice: agno skips the
+    step and continues, and the run should remain eligible to COMPLETE.  The
+    failure is still surfaced via the node's SKIPPED status (and retained error).
+    """
+    if step_output.success:
+        return False
+    node = (node_by_name or {}).get(step_output.step_name or "")
+    return bool(node and node.step_config and node.step_config.on_error == "skip")
+
+
 def _resolve_workflow_run_status(
     run_output: WorkflowRunOutput,
     step_outputs: list[StepOutput],
+    node_by_name: dict[str, WorkflowNode] | None = None,
 ) -> WorkflowRunStatus:
     mapped_status = _STATUS_MAP.get(run_output.status, WorkflowRunStatus.FAILED)
 
@@ -237,7 +261,12 @@ def _resolve_workflow_run_status(
     if mapped_status == WorkflowRunStatus.CANCELLED:
         return WorkflowRunStatus.CANCELLED
 
-    if any(not step_output.success for step_output in step_outputs):
+    # A failed step forces FAILED only when it is *not* tolerated by on_error=skip;
+    # skip-tolerated failures keep the run eligible to COMPLETE.
+    if any(
+        not step_output.success and not _is_skip_tolerated_failure(step_output, node_by_name)
+        for step_output in step_outputs
+    ):
         return WorkflowRunStatus.FAILED
 
     return mapped_status

--- a/registry-pkgs/src/registry_pkgs/workflows/runner.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/runner.py
@@ -294,8 +294,6 @@ class WorkflowRunner:
 
         try:
             requirements = [hydrate_requirement(item) for item in pending]
-            run.pending_requirements = []
-            await run.save()
             executor_registry = await self._build_registry(snapshot_def, registry_token, user_id)
             workflow = compile_workflow(
                 snapshot_def,
@@ -313,6 +311,12 @@ class WorkflowRunner:
                 session_id=existing_run_id,
                 step_requirements=requirements,
             )
+            # Only clear pending_requirements after agno has successfully
+            # consumed them.  If acontinue_run (or the build/compile steps
+            # before it) raise, the requirements survive in MongoDB so a
+            # subsequent continue_run — e.g. after a pod restart — can retry.
+            run.pending_requirements = []
+            await run.save()
             await self._handle_run_output(run, result)
         except (WorkflowCancelledError, RunCancelledException) as exc:
             await self._finalize_cancel(run, exc)

--- a/registry-pkgs/src/registry_pkgs/workflows/runner.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/runner.py
@@ -305,9 +305,12 @@ class WorkflowRunner:
                 db_name=self._db_name,
                 directive_queue=self._directive_queue,
             )
+            # agno needs its own internal run_id (the UUID it generated inside
+            # ``arun``), not our WorkflowRun ObjectId.
+            agno_run_id = run.agno_run_id or existing_run_id
             try:
                 result = await workflow.acontinue_run(
-                    run_id=existing_run_id,
+                    run_id=agno_run_id,
                     session_id=existing_run_id,
                     step_requirements=requirements,
                 )
@@ -390,6 +393,12 @@ class WorkflowRunner:
                     )
             run.status = WorkflowRunStatus.AWAITING_APPROVAL
             run.pending_requirements = serialized
+            # Capture agno's internal run_id so ``continue_run`` can locate the
+            # persisted RunOutput in agno_workflow_sessions on resume.  We use
+            # str() because agno generates UUID strings.
+            agno_id = getattr(result, "run_id", None)
+            if agno_id:
+                run.agno_run_id = str(agno_id)
             await run.save()
             logger.info(
                 "[run=%s] ⏸ HITL pause — %d requirement(s) awaiting decision",

--- a/registry-pkgs/src/registry_pkgs/workflows/runner.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/runner.py
@@ -286,16 +286,16 @@ class WorkflowRunner:
         # Reconstruct definition from the snapshot to guarantee version determinism
         snapshot_def = WorkflowDefinition(**run.definition_snapshot)
 
-        # Pull the pending requirements out and hydrate back to agno objects.
+        # Pull the pending requirements out; hydration happens inside the try below.
         pending = list(run.pending_requirements)
-        run.pending_requirements = []
-        await run.save()
-        requirements = [hydrate_requirement(item) for item in pending]
 
         if self._directive_queue is not None:
             self._directive_queue.register(existing_run_id)
 
         try:
+            requirements = [hydrate_requirement(item) for item in pending]
+            run.pending_requirements = []
+            await run.save()
             executor_registry = await self._build_registry(snapshot_def, registry_token, user_id)
             workflow = compile_workflow(
                 snapshot_def,
@@ -308,18 +308,17 @@ class WorkflowRunner:
             # agno needs its own internal run_id (the UUID it generated inside
             # ``arun``), not our WorkflowRun ObjectId.
             agno_run_id = run.agno_run_id or existing_run_id
-            try:
-                result = await workflow.acontinue_run(
-                    run_id=agno_run_id,
-                    session_id=existing_run_id,
-                    step_requirements=requirements,
-                )
-                await self._handle_run_output(run, result)
-            except (WorkflowCancelledError, RunCancelledException) as exc:
-                await self._finalize_cancel(run, exc)
-            except Exception as exc:
-                await self._finalize_failure(run, exc)
-                raise
+            result = await workflow.acontinue_run(
+                run_id=agno_run_id,
+                session_id=existing_run_id,
+                step_requirements=requirements,
+            )
+            await self._handle_run_output(run, result)
+        except (WorkflowCancelledError, RunCancelledException) as exc:
+            await self._finalize_cancel(run, exc)
+        except Exception as exc:
+            await self._finalize_failure(run, exc)
+            raise
         finally:
             if self._directive_queue is not None:
                 self._directive_queue.unregister(existing_run_id)

--- a/registry-pkgs/src/registry_pkgs/workflows/runner.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/runner.py
@@ -49,7 +49,10 @@ from datetime import UTC, datetime
 from typing import Any
 
 import httpx
+from agno.exceptions import RunCancelledException
 from agno.models.base import Model
+from agno.run.cancel import acancel_run as agno_acancel_run
+from beanie import PydanticObjectId
 
 from registry_pkgs.core.config import JwtSigningConfig
 from registry_pkgs.models.enums import WorkflowRunStatus
@@ -57,6 +60,7 @@ from registry_pkgs.models.workflow import NodeRun, WorkflowDefinition, WorkflowR
 from registry_pkgs.workflows.compiler import StepExecutor, compile_workflow, flatten_workflow_nodes
 from registry_pkgs.workflows.control import DirectiveQueue, WorkflowCancelledError
 from registry_pkgs.workflows.executor_resolver import build_executor_registry
+from registry_pkgs.workflows.hitl import hydrate_requirement, serialize_requirement
 
 logger = logging.getLogger(__name__)
 
@@ -223,6 +227,103 @@ class WorkflowRunner:
             a2a_httpx_client=self._a2a_httpx_client,
         )
 
+    async def continue_run(
+        self,
+        *,
+        existing_run_id: str,
+        registry_token: str,
+        user_id: str | None,
+    ) -> tuple[WorkflowRun, list[NodeRun]]:
+        """Resume a run that is holding at one or more pending requirements.
+
+        Called by ``WorkflowControlService.resolve_requirement`` (via BackgroundTask)
+        after the user's decision has been written into ``WorkflowRun.pending_requirements``.
+
+        Flow:
+        1. CAS state transition AWAITING_APPROVAL → RUNNING.  If another caller
+           already won the race, this method exits silently (no double-resume).
+        2. Re-build the agno Workflow from ``run.definition_snapshot`` so any pod
+           can resume — we do NOT depend on the in-memory state of whichever pod
+           originally returned ``is_paused=True``.
+        3. Hydrate ``run.pending_requirements`` back into agno ``StepRequirement``
+           objects (with the user's decision fields populated) and clear the field.
+        4. Call ``workflow.acontinue_run(...)`` which:
+            - reads its own session state from ``agno_workflow_sessions`` Mongo collection
+            - applies on_timeout / on_reject routing
+            - either runs to completion / failure, or hits the next HITL pause
+        5. ``_handle_run_output`` again — pause loops back to step 1 next time the
+           user decides; completion / failure is finalized.
+        """
+        try:
+            run_oid = PydanticObjectId(existing_run_id)
+        except Exception:
+            raise ValueError(f"continue_run: invalid run_id {existing_run_id!r}")
+
+        # CAS: only one continuation wins.  We use raw motor ``update_one`` here.
+        collection = self._db_client[self._db_name].get_collection(WorkflowRun.get_settings().name)
+        cas_result = await collection.update_one(
+            {
+                "_id": run_oid,
+                "status": WorkflowRunStatus.AWAITING_APPROVAL.value,
+            },
+            {"$set": {"status": WorkflowRunStatus.RUNNING.value}},
+        )
+        if cas_result.modified_count == 0:
+            logger.info("[run=%s] continue_run: CAS lost (not in AWAITING_APPROVAL), skipping", existing_run_id)
+            run = await WorkflowRun.get(run_oid)
+            node_runs = await NodeRun.find(NodeRun.workflow_run_id == run_oid).to_list() if run is not None else []
+            return run, node_runs  # type: ignore[return-value]
+
+        run = await WorkflowRun.get(run_oid)
+        if run is None:
+            raise ValueError(f"WorkflowRun {existing_run_id!r} not found")
+
+        if not run.definition_snapshot:
+            raise RuntimeError(
+                f"WorkflowRun {existing_run_id!r} has no definition_snapshot — cannot rebuild for continue_run"
+            )
+
+        # Reconstruct definition from the snapshot to guarantee version determinism
+        snapshot_def = WorkflowDefinition(**run.definition_snapshot)
+
+        # Pull the pending requirements out and hydrate back to agno objects.
+        pending = list(run.pending_requirements)
+        run.pending_requirements = []
+        await run.save()
+        requirements = [hydrate_requirement(item) for item in pending]
+
+        if self._directive_queue is not None:
+            self._directive_queue.register(existing_run_id)
+
+        try:
+            executor_registry = await self._build_registry(snapshot_def, registry_token, user_id)
+            workflow = compile_workflow(
+                snapshot_def,
+                run,
+                executor_registry=executor_registry,
+                db_client=self._db_client,
+                db_name=self._db_name,
+                directive_queue=self._directive_queue,
+            )
+            try:
+                result = await workflow.acontinue_run(
+                    run_id=existing_run_id,
+                    session_id=existing_run_id,
+                    step_requirements=requirements,
+                )
+                await self._handle_run_output(run, result)
+            except (WorkflowCancelledError, RunCancelledException) as exc:
+                await self._finalize_cancel(run, exc)
+            except Exception as exc:
+                await self._finalize_failure(run, exc)
+                raise
+        finally:
+            if self._directive_queue is not None:
+                self._directive_queue.unregister(existing_run_id)
+
+        node_runs = await NodeRun.find(NodeRun.workflow_run_id == run.id).to_list()
+        return run, node_runs
+
     async def _execute(
         self,
         run: WorkflowRun,
@@ -233,8 +334,11 @@ class WorkflowRunner:
     ) -> None:
         """Compile the workflow and run it via agno.
 
-        On success, ``run.sync()`` reloads the status written by WorkflowRunSyncer.
-        On failure, writes FAILED directly so the record is never left as RUNNING.
+        Handles three terminal outcomes of ``workflow.arun()``:
+        - ``is_paused=True``           → HITL pause; persist requirements + return.
+        - Normal completion / failure  → ``WorkflowRunSyncer`` already wrote status;
+                                         reload via ``run.sync()``.
+        - ``WorkflowCancelledError`` / ``RunCancelledException`` → finalize CANCELLED.
         """
         workflow = compile_workflow(
             definition,
@@ -246,26 +350,75 @@ class WorkflowRunner:
             injected_outputs=injected_outputs,
         )
         try:
-            await workflow.arun(
+            result = await workflow.arun(
                 input=user_text,
+                session_id=str(run.id),
                 # _workflow_run_id lets executor closures reference the current
                 # run (e.g. for custom logging or future retry reconstruction).
                 session_state={"user_text": user_text, "_workflow_run_id": str(run.id)},
             )
-            # Reload state written by WorkflowRunSyncer so callers see the latest status.
-            await run.sync()
-        except WorkflowCancelledError as exc:
-            run.status = WorkflowRunStatus.CANCELLED
-            run.error_summary = str(exc)
-            run.finished_at = datetime.now(UTC)
-            await run.save()
-            logger.info("[run=%s] ✗ workflow cancelled: %s", run.id, exc)
+            await self._handle_run_output(run, result)
+        except (WorkflowCancelledError, RunCancelledException) as exc:
+            await self._finalize_cancel(run, exc)
         except Exception as exc:
             # agno may not call upsert_session on a hard failure; write the error
             # directly so the record is never left dangling as RUNNING.
-            run.status = WorkflowRunStatus.FAILED
-            run.error_summary = str(exc)
-            run.finished_at = datetime.now(UTC)
-            await run.save()
-            logger.error("[run=%s] ✗ workflow failed: %s", run.id, exc, exc_info=True)
+            await self._finalize_failure(run, exc)
             raise
+
+    async def _handle_run_output(self, run: WorkflowRun, result: Any) -> None:
+        """Route the WorkflowRunOutput returned by arun / acontinue_run.
+
+        - If ``result.is_paused``: persist serialized ``step_requirements`` into
+          ``WorkflowRun.pending_requirements`` and flip status to AWAITING_APPROVAL.
+          The runner coroutine then returns (no busy-waiting; pod-restart safe).
+        - Otherwise: trust WorkflowRunSyncer to have already written terminal state,
+          and just reload from Mongo so the in-memory ``run`` reflects what
+          callers will see.
+        """
+        if getattr(result, "is_paused", False):
+            serialized: list[dict[str, Any]] = []
+            for req in getattr(result, "step_requirements", None) or []:
+                try:
+                    serialized.append(serialize_requirement(req))
+                except Exception as exc:
+                    logger.exception(
+                        "[run=%s] failed to serialize StepRequirement %r — skipping (%s)",
+                        run.id,
+                        getattr(req, "step_id", "?"),
+                        exc,
+                    )
+            run.status = WorkflowRunStatus.AWAITING_APPROVAL
+            run.pending_requirements = serialized
+            await run.save()
+            logger.info(
+                "[run=%s] ⏸ HITL pause — %d requirement(s) awaiting decision",
+                run.id,
+                len(serialized),
+            )
+            return
+
+        await run.sync()
+
+    async def _finalize_cancel(self, run: WorkflowRun, exc: BaseException) -> None:
+        """Mark the run CANCELLED and reverse-notify agno (M2)."""
+        run.status = WorkflowRunStatus.CANCELLED
+        run.error_summary = str(exc)
+        run.finished_at = datetime.now(UTC)
+        await run.save()
+        # Bridge back to agno so its in-memory cancellation state flips too —
+        # protects against agno later emitting a WorkflowCompletedEvent that
+        # would otherwise overwrite our CANCELLED with COMPLETED via WorkflowRunSyncer.
+        try:
+            await agno_acancel_run(str(run.id))
+        except Exception as inner:
+            logger.warning("[run=%s] reverse agno cancel failed: %s", run.id, inner)
+        logger.info("[run=%s] ✗ workflow cancelled: %s", run.id, exc)
+
+    async def _finalize_failure(self, run: WorkflowRun, exc: BaseException) -> None:
+        """Mark the run FAILED directly (so a half-finished run never stays RUNNING)."""
+        run.status = WorkflowRunStatus.FAILED
+        run.error_summary = str(exc)
+        run.finished_at = datetime.now(UTC)
+        await run.save()
+        logger.error("[run=%s] ✗ workflow failed: %s", run.id, exc, exc_info=True)

--- a/registry-pkgs/tests/unit/workflow/test_compiler.py
+++ b/registry-pkgs/tests/unit/workflow/test_compiler.py
@@ -881,3 +881,44 @@ class TestNestedBranches:
             "LOOP",
             "body",
         ]
+
+
+@pytest.mark.unit
+class TestEnumDriftAgainstAgno:
+    """Anti-corruption layer: surface agno enum drift the moment it happens.
+
+    Our OnRejectPolicy / OnTimeoutPolicy are the stable contract (API + DB).
+    The compiler translates them to agno's string values via _ON_REJECT_TO_AGNO
+    and _ON_TIMEOUT_TO_AGNO.  These tests fail loudly if either side changes
+    members so we never silently pass an invalid value into agno.
+    """
+
+    def test_on_reject_keys_cover_our_enum(self):
+        from registry_pkgs.models.enums import OnRejectPolicy
+        from registry_pkgs.workflows.compiler import _ON_REJECT_TO_AGNO
+
+        assert set(_ON_REJECT_TO_AGNO.keys()) == set(OnRejectPolicy)
+
+    def test_on_reject_values_are_accepted_by_agno(self):
+        from agno.workflow.types import OnReject
+
+        from registry_pkgs.workflows.compiler import _ON_REJECT_TO_AGNO
+
+        agno_values = {member.value for member in OnReject}
+        for ours, agno_str in _ON_REJECT_TO_AGNO.items():
+            assert agno_str in agno_values, f"OnRejectPolicy.{ours.name} → {agno_str!r} not in agno OnReject"
+
+    def test_on_timeout_keys_cover_our_enum(self):
+        from registry_pkgs.models.enums import OnTimeoutPolicy
+        from registry_pkgs.workflows.compiler import _ON_TIMEOUT_TO_AGNO
+
+        assert set(_ON_TIMEOUT_TO_AGNO.keys()) == set(OnTimeoutPolicy)
+
+    def test_on_timeout_values_are_accepted_by_agno(self):
+        from agno.workflow.types import OnTimeout
+
+        from registry_pkgs.workflows.compiler import _ON_TIMEOUT_TO_AGNO
+
+        agno_values = {member.value for member in OnTimeout}
+        for ours, agno_str in _ON_TIMEOUT_TO_AGNO.items():
+            assert agno_str in agno_values, f"OnTimeoutPolicy.{ours.name} → {agno_str!r} not in agno OnTimeout"

--- a/registry-pkgs/tests/unit/workflow/test_control_wrapper.py
+++ b/registry-pkgs/tests/unit/workflow/test_control_wrapper.py
@@ -147,159 +147,32 @@ class TestWorkflowRunStateMachine:
 
 
 @pytest.mark.unit
-class TestApprovalGate:
-    """Approval gate: a STEP with require_approval holds until APPROVE/REJECT/timeout."""
+class TestHumanReviewModelValidation:
+    """``WorkflowNode._validate_shape`` enforces agno's per-primitive HumanReview rules."""
 
-    def _patch_common(self, monkeypatch, fake_run):
-        monkeypatch.setattr(
-            "registry_pkgs.workflows.control.wrapper._read_mongodb_directive", AsyncMock(return_value=None)
+    def test_step_accepts_full_human_review(self):
+        from registry_pkgs.models.enums import OnRejectPolicy
+        from registry_pkgs.models.workflow import HumanReviewSpec, WorkflowNode
+
+        step = WorkflowNode(
+            name="s",
+            node_type="step",
+            executor_key="tool",
+            human_review=HumanReviewSpec(
+                requires_confirmation=True,
+                requires_user_input=True,
+                requires_output_review=True,
+                on_reject=OnRejectPolicy.SKIP,
+                timeout_seconds=60,
+            ),
         )
-        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper._record_attempt_start", AsyncMock())
-        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper._update_run_control_state", AsyncMock())
-        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper._mark_node_status", AsyncMock())
-        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper._mark_node_failed", AsyncMock())
-        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper.WorkflowRun.get", AsyncMock(return_value=fake_run))
+        assert step.human_review is not None
+        assert step.human_review.requires_confirmation is True
 
-    @pytest.mark.asyncio
-    async def test_approve_lets_step_execute(self, monkeypatch: pytest.MonkeyPatch):
-        run_id = str(PydanticObjectId())
-        queue = DirectiveQueue()
-        queue.register(run_id)
-        queue.put(run_id, WorkflowDirective.APPROVE)
-        fake_run = SimpleNamespace(pause_timeout_seconds=60, paused_at=None)
-        self._patch_common(monkeypatch, fake_run)
+    def test_parallel_rejects_any_hitl_field(self):
+        from registry_pkgs.models.workflow import HumanReviewSpec, WorkflowNode
 
-        executor = AsyncMock(return_value=SimpleNamespace(success=True, content="done", error=None))
-        wrapped = with_control(
-            executor,
-            run_id=run_id,
-            node_id="node-1",
-            node_name="gate",
-            step_config=None,
-            directive_queue=queue,
-            require_approval=True,
-        )
-
-        result = await wrapped(SimpleNamespace(input="hi"), {})
-
-        assert result.success is True
-        executor.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_reject_fails_node_without_executing(self, monkeypatch: pytest.MonkeyPatch):
-        run_id = str(PydanticObjectId())
-        queue = DirectiveQueue()
-        queue.register(run_id)
-        queue.put(run_id, WorkflowDirective.REJECT)
-        fake_run = SimpleNamespace(pause_timeout_seconds=60, paused_at=None)
-        self._patch_common(monkeypatch, fake_run)
-
-        marked = AsyncMock()
-        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper._mark_node_failed", marked)
-
-        executor = AsyncMock(return_value=SimpleNamespace(success=True, content="done", error=None))
-        wrapped = with_control(
-            executor,
-            run_id=run_id,
-            node_id="node-1",
-            node_name="gate",
-            step_config=None,
-            directive_queue=queue,
-            require_approval=True,
-        )
-
-        result = await wrapped(SimpleNamespace(input="hi"), {})
-
-        assert result.success is False
-        assert "Rejected" in (result.error or "")
-        executor.assert_not_awaited()
-        marked.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_timeout_is_treated_as_rejection(self, monkeypatch: pytest.MonkeyPatch):
-        run_id = str(PydanticObjectId())
-        queue = DirectiveQueue()
-        queue.register(run_id)  # no directive ever arrives
-        fake_run = SimpleNamespace(pause_timeout_seconds=60, paused_at=None)
-        self._patch_common(monkeypatch, fake_run)
-        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper.PAUSE_POLL_INTERVAL", 0.0)
-
-        executor = AsyncMock(return_value=SimpleNamespace(success=True, content="done", error=None))
-        wrapped = with_control(
-            executor,
-            run_id=run_id,
-            node_id="node-1",
-            node_name="gate",
-            step_config=None,
-            directive_queue=queue,
-            require_approval=True,
-            approval_timeout_seconds=1,
-        )
-
-        result = await wrapped(SimpleNamespace(input="hi"), {})
-
-        assert result.success is False
-        executor.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_cancel_while_awaiting_raises_cancelled(self, monkeypatch: pytest.MonkeyPatch):
-        run_id = str(PydanticObjectId())
-        queue = DirectiveQueue()
-        queue.register(run_id)
-        queue.put(run_id, WorkflowDirective.CANCEL)
-        fake_run = SimpleNamespace(pause_timeout_seconds=60, paused_at=None)
-        self._patch_common(monkeypatch, fake_run)
-
-        executor = AsyncMock(return_value=SimpleNamespace(success=True, content="done", error=None))
-        wrapped = with_control(
-            executor,
-            run_id=run_id,
-            node_id="node-1",
-            node_name="gate",
-            step_config=None,
-            directive_queue=queue,
-            require_approval=True,
-        )
-
-        with pytest.raises(WorkflowCancelledError):
-            await wrapped(SimpleNamespace(input="hi"), {})
-
-        executor.assert_not_awaited()
-
-
-@pytest.mark.unit
-class TestApprovalStateMachineAndModel:
-    def test_approve_only_valid_when_awaiting_approval(self):
-        from registry_pkgs.models.enums import WorkflowDirective, WorkflowRunStateMachine, WorkflowRunStatus
-
-        assert (
-            WorkflowRunStateMachine.apply_directive(WorkflowRunStatus.AWAITING_APPROVAL, WorkflowDirective.APPROVE)
-            == WorkflowRunStatus.RUNNING
-        )
-        assert (
-            WorkflowRunStateMachine.apply_directive(WorkflowRunStatus.AWAITING_APPROVAL, WorkflowDirective.REJECT)
-            == WorkflowRunStatus.RUNNING
-        )
-        with pytest.raises(ValueError, match="Cannot"):
-            WorkflowRunStateMachine.apply_directive(WorkflowRunStatus.RUNNING, WorkflowDirective.APPROVE)
-
-    def test_cancel_allowed_while_awaiting_approval(self):
-        from registry_pkgs.models.enums import WorkflowDirective, WorkflowRunStateMachine, WorkflowRunStatus
-
-        assert (
-            WorkflowRunStateMachine.apply_directive(WorkflowRunStatus.AWAITING_APPROVAL, WorkflowDirective.CANCEL)
-            == WorkflowRunStatus.CANCELLED
-        )
-
-    def test_require_approval_only_on_step_nodes(self):
-        from registry_pkgs.models.workflow import WorkflowNode
-
-        # STEP node accepts require_approval
-        step = WorkflowNode(name="s", node_type="step", executor_key="tool", require_approval=True)
-        assert step.require_approval is True
-
-        # Container node rejects require_approval
-        with pytest.raises(ValueError, match="require_approval is only supported on step nodes"):
+        with pytest.raises(ValueError, match="parallel node does not support any HITL"):
             WorkflowNode(
                 name="p",
                 node_type="parallel",
@@ -307,5 +180,51 @@ class TestApprovalStateMachineAndModel:
                     WorkflowNode(name="a", executor_key="x"),
                     WorkflowNode(name="b", executor_key="y"),
                 ],
-                require_approval=True,
+                human_review=HumanReviewSpec(requires_confirmation=True),
+            )
+
+    def test_loop_rejects_user_input_and_output_review(self):
+        from registry_pkgs.models.workflow import HumanReviewSpec, LoopConfig, WorkflowNode
+
+        # Iteration review IS allowed on loop
+        loop_ok = WorkflowNode(
+            name="loop_ok",
+            node_type="loop",
+            loop_config=LoopConfig(max_iterations=3),
+            children=[WorkflowNode(name="c", executor_key="x")],
+            human_review=HumanReviewSpec(requires_iteration_review=True),
+        )
+        assert loop_ok.human_review.requires_iteration_review is True
+
+        # But user_input + output_review are not
+        with pytest.raises(ValueError, match="requires_user_input is not supported on loop"):
+            WorkflowNode(
+                name="loop_bad",
+                node_type="loop",
+                loop_config=LoopConfig(max_iterations=3),
+                children=[WorkflowNode(name="c", executor_key="x")],
+                human_review=HumanReviewSpec(requires_user_input=True),
+            )
+
+    def test_condition_rejects_user_input(self):
+        from registry_pkgs.models.workflow import HumanReviewSpec, WorkflowNode
+
+        with pytest.raises(ValueError, match="requires_user_input is not supported on condition"):
+            WorkflowNode(
+                name="c",
+                node_type="condition",
+                condition_cel="true",
+                true_steps=[WorkflowNode(name="t", executor_key="x")],
+                human_review=HumanReviewSpec(requires_user_input=True),
+            )
+
+    def test_step_rejects_iteration_review(self):
+        from registry_pkgs.models.workflow import HumanReviewSpec, WorkflowNode
+
+        with pytest.raises(ValueError, match="requires_iteration_review is not supported on step"):
+            WorkflowNode(
+                name="s",
+                node_type="step",
+                executor_key="tool",
+                human_review=HumanReviewSpec(requires_iteration_review=True),
             )

--- a/registry-pkgs/tests/unit/workflow/test_control_wrapper.py
+++ b/registry-pkgs/tests/unit/workflow/test_control_wrapper.py
@@ -144,3 +144,168 @@ class TestWorkflowRunStateMachine:
 
         with pytest.raises(ValueError, match="Cannot retry"):
             WorkflowRunStateMachine.apply_directive(WorkflowRunStatus.CANCELLED, WorkflowDirective.RETRY)
+
+
+@pytest.mark.unit
+class TestApprovalGate:
+    """Approval gate: a STEP with require_approval holds until APPROVE/REJECT/timeout."""
+
+    def _patch_common(self, monkeypatch, fake_run):
+        monkeypatch.setattr(
+            "registry_pkgs.workflows.control.wrapper._read_mongodb_directive", AsyncMock(return_value=None)
+        )
+        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper._record_attempt_start", AsyncMock())
+        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper._update_run_control_state", AsyncMock())
+        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper._mark_node_status", AsyncMock())
+        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper._mark_node_failed", AsyncMock())
+        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper.WorkflowRun.get", AsyncMock(return_value=fake_run))
+
+    @pytest.mark.asyncio
+    async def test_approve_lets_step_execute(self, monkeypatch: pytest.MonkeyPatch):
+        run_id = str(PydanticObjectId())
+        queue = DirectiveQueue()
+        queue.register(run_id)
+        queue.put(run_id, WorkflowDirective.APPROVE)
+        fake_run = SimpleNamespace(pause_timeout_seconds=60, paused_at=None)
+        self._patch_common(monkeypatch, fake_run)
+
+        executor = AsyncMock(return_value=SimpleNamespace(success=True, content="done", error=None))
+        wrapped = with_control(
+            executor,
+            run_id=run_id,
+            node_id="node-1",
+            node_name="gate",
+            step_config=None,
+            directive_queue=queue,
+            require_approval=True,
+        )
+
+        result = await wrapped(SimpleNamespace(input="hi"), {})
+
+        assert result.success is True
+        executor.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reject_fails_node_without_executing(self, monkeypatch: pytest.MonkeyPatch):
+        run_id = str(PydanticObjectId())
+        queue = DirectiveQueue()
+        queue.register(run_id)
+        queue.put(run_id, WorkflowDirective.REJECT)
+        fake_run = SimpleNamespace(pause_timeout_seconds=60, paused_at=None)
+        self._patch_common(monkeypatch, fake_run)
+
+        marked = AsyncMock()
+        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper._mark_node_failed", marked)
+
+        executor = AsyncMock(return_value=SimpleNamespace(success=True, content="done", error=None))
+        wrapped = with_control(
+            executor,
+            run_id=run_id,
+            node_id="node-1",
+            node_name="gate",
+            step_config=None,
+            directive_queue=queue,
+            require_approval=True,
+        )
+
+        result = await wrapped(SimpleNamespace(input="hi"), {})
+
+        assert result.success is False
+        assert "Rejected" in (result.error or "")
+        executor.assert_not_awaited()
+        marked.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_timeout_is_treated_as_rejection(self, monkeypatch: pytest.MonkeyPatch):
+        run_id = str(PydanticObjectId())
+        queue = DirectiveQueue()
+        queue.register(run_id)  # no directive ever arrives
+        fake_run = SimpleNamespace(pause_timeout_seconds=60, paused_at=None)
+        self._patch_common(monkeypatch, fake_run)
+        monkeypatch.setattr("registry_pkgs.workflows.control.wrapper.PAUSE_POLL_INTERVAL", 0.0)
+
+        executor = AsyncMock(return_value=SimpleNamespace(success=True, content="done", error=None))
+        wrapped = with_control(
+            executor,
+            run_id=run_id,
+            node_id="node-1",
+            node_name="gate",
+            step_config=None,
+            directive_queue=queue,
+            require_approval=True,
+            approval_timeout_seconds=1,
+        )
+
+        result = await wrapped(SimpleNamespace(input="hi"), {})
+
+        assert result.success is False
+        executor.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cancel_while_awaiting_raises_cancelled(self, monkeypatch: pytest.MonkeyPatch):
+        run_id = str(PydanticObjectId())
+        queue = DirectiveQueue()
+        queue.register(run_id)
+        queue.put(run_id, WorkflowDirective.CANCEL)
+        fake_run = SimpleNamespace(pause_timeout_seconds=60, paused_at=None)
+        self._patch_common(monkeypatch, fake_run)
+
+        executor = AsyncMock(return_value=SimpleNamespace(success=True, content="done", error=None))
+        wrapped = with_control(
+            executor,
+            run_id=run_id,
+            node_id="node-1",
+            node_name="gate",
+            step_config=None,
+            directive_queue=queue,
+            require_approval=True,
+        )
+
+        with pytest.raises(WorkflowCancelledError):
+            await wrapped(SimpleNamespace(input="hi"), {})
+
+        executor.assert_not_awaited()
+
+
+@pytest.mark.unit
+class TestApprovalStateMachineAndModel:
+    def test_approve_only_valid_when_awaiting_approval(self):
+        from registry_pkgs.models.enums import WorkflowDirective, WorkflowRunStateMachine, WorkflowRunStatus
+
+        assert (
+            WorkflowRunStateMachine.apply_directive(WorkflowRunStatus.AWAITING_APPROVAL, WorkflowDirective.APPROVE)
+            == WorkflowRunStatus.RUNNING
+        )
+        assert (
+            WorkflowRunStateMachine.apply_directive(WorkflowRunStatus.AWAITING_APPROVAL, WorkflowDirective.REJECT)
+            == WorkflowRunStatus.RUNNING
+        )
+        with pytest.raises(ValueError, match="Cannot"):
+            WorkflowRunStateMachine.apply_directive(WorkflowRunStatus.RUNNING, WorkflowDirective.APPROVE)
+
+    def test_cancel_allowed_while_awaiting_approval(self):
+        from registry_pkgs.models.enums import WorkflowDirective, WorkflowRunStateMachine, WorkflowRunStatus
+
+        assert (
+            WorkflowRunStateMachine.apply_directive(WorkflowRunStatus.AWAITING_APPROVAL, WorkflowDirective.CANCEL)
+            == WorkflowRunStatus.CANCELLED
+        )
+
+    def test_require_approval_only_on_step_nodes(self):
+        from registry_pkgs.models.workflow import WorkflowNode
+
+        # STEP node accepts require_approval
+        step = WorkflowNode(name="s", node_type="step", executor_key="tool", require_approval=True)
+        assert step.require_approval is True
+
+        # Container node rejects require_approval
+        with pytest.raises(ValueError, match="require_approval is only supported on step nodes"):
+            WorkflowNode(
+                name="p",
+                node_type="parallel",
+                children=[
+                    WorkflowNode(name="a", executor_key="x"),
+                    WorkflowNode(name="b", executor_key="y"),
+                ],
+                require_approval=True,
+            )

--- a/registry-pkgs/tests/unit/workflow/test_human_review_validation.py
+++ b/registry-pkgs/tests/unit/workflow/test_human_review_validation.py
@@ -1,7 +1,19 @@
 import pytest
 
 from registry_pkgs.models.enums import OnRejectPolicy, WorkflowNodeType
-from registry_pkgs.models.workflow import HumanReviewSpec, _validate_human_review_for_node
+from registry_pkgs.models.workflow import HumanReviewSpec, WorkflowNode, _validate_human_review_for_node
+
+
+def _condition_node(*, on_reject: OnRejectPolicy, with_false_steps: bool) -> dict:
+    """Kwargs for a CONDITION WorkflowNode with a confirmation gate."""
+    return {
+        "name": "branch",
+        "node_type": WorkflowNodeType.CONDITION,
+        "condition_cel": "session_state.x != ''",
+        "true_steps": [WorkflowNode(name="t", executor_key="tool")],
+        "false_steps": [WorkflowNode(name="f", executor_key="tool")] if with_false_steps else [],
+        "human_review": HumanReviewSpec(requires_confirmation=True, on_reject=on_reject),
+    }
 
 
 @pytest.mark.unit
@@ -29,3 +41,21 @@ class TestElseBranchValidation:
         spec = HumanReviewSpec(requires_confirmation=True, on_reject=OnRejectPolicy.SKIP)
         # Regression guard: the new check must not reject the default policy.
         _validate_human_review_for_node(WorkflowNodeType.STEP, spec)
+
+
+@pytest.mark.unit
+class TestElseBranchRequiresFalseSteps:
+    """on_reject=else_branch routes a rejected gate into the false branch, so the
+    definition must declare one (caught at save time, not at runtime)."""
+
+    def test_else_branch_without_false_steps_rejected(self):
+        with pytest.raises(ValueError, match="requires at least one false_steps entry"):
+            WorkflowNode(**_condition_node(on_reject=OnRejectPolicy.ELSE_BRANCH, with_false_steps=False))
+
+    def test_else_branch_with_false_steps_ok(self):
+        # Must not raise — the false branch the rejection routes into exists.
+        WorkflowNode(**_condition_node(on_reject=OnRejectPolicy.ELSE_BRANCH, with_false_steps=True))
+
+    def test_non_else_branch_condition_allows_empty_false_steps(self):
+        # Regression guard: other policies don't require a false branch.
+        WorkflowNode(**_condition_node(on_reject=OnRejectPolicy.SKIP, with_false_steps=False))

--- a/registry-pkgs/tests/unit/workflow/test_human_review_validation.py
+++ b/registry-pkgs/tests/unit/workflow/test_human_review_validation.py
@@ -1,0 +1,31 @@
+import pytest
+
+from registry_pkgs.models.enums import OnRejectPolicy, WorkflowNodeType
+from registry_pkgs.models.workflow import HumanReviewSpec, _validate_human_review_for_node
+
+
+@pytest.mark.unit
+class TestElseBranchValidation:
+    @pytest.mark.parametrize(
+        "node_type",
+        [
+            WorkflowNodeType.STEP,
+            WorkflowNodeType.ROUTER,
+            WorkflowNodeType.LOOP,
+            WorkflowNodeType.PARALLEL,
+        ],
+    )
+    def test_else_branch_rejected_on_non_condition_node(self, node_type: WorkflowNodeType):
+        spec = HumanReviewSpec(on_reject=OnRejectPolicy.ELSE_BRANCH)
+        with pytest.raises(ValueError, match="else_branch is only supported on condition"):
+            _validate_human_review_for_node(node_type, spec)
+
+    def test_else_branch_allowed_on_condition_node(self):
+        spec = HumanReviewSpec(requires_confirmation=True, on_reject=OnRejectPolicy.ELSE_BRANCH)
+        # Must not raise — else_branch is the one node type where it is valid.
+        _validate_human_review_for_node(WorkflowNodeType.CONDITION, spec)
+
+    def test_non_else_branch_policy_unaffected_on_step_node(self):
+        spec = HumanReviewSpec(requires_confirmation=True, on_reject=OnRejectPolicy.SKIP)
+        # Regression guard: the new check must not reject the default policy.
+        _validate_human_review_for_node(WorkflowNodeType.STEP, spec)

--- a/registry-pkgs/tests/unit/workflow/test_persistence.py
+++ b/registry-pkgs/tests/unit/workflow/test_persistence.py
@@ -11,7 +11,7 @@ from agno.workflow import StepOutput
 from beanie import PydanticObjectId
 
 from registry_pkgs.models.enums import NodeRunStatus, WorkflowRunStatus
-from registry_pkgs.models.workflow import NodeRun, WorkflowNode
+from registry_pkgs.models.workflow import NodeRun, StepConfig, WorkflowNode
 from registry_pkgs.workflows import persistence
 
 
@@ -320,3 +320,75 @@ class TestWorkflowPersistence:
             session_data={},
             session=mongo_session,
         )
+
+    # ── on_error=skip semantics (skip-tolerated failures) ──────────────────────
+
+    def test_resolve_status_skip_tolerated_failure_keeps_run_completed(self):
+        """A failed step whose node is on_error=skip must not force the run to FAILED."""
+        node_by_name = {"opt": WorkflowNode(name="opt", executor_key="t", step_config=StepConfig(on_error="skip"))}
+        run_output = WorkflowRunOutput(content="done", status=RunStatus.completed)
+        status = persistence._resolve_workflow_run_status(
+            run_output,
+            [StepOutput(step_name="opt", content="boom", success=False, error="boom")],
+            node_by_name,
+        )
+        assert status == WorkflowRunStatus.COMPLETED
+
+    def test_resolve_status_non_skip_failure_still_forces_failed(self):
+        """A failed step on a fail/default node still forces FAILED (regression guard)."""
+        node_by_name = {"crit": WorkflowNode(name="crit", executor_key="t", step_config=StepConfig(on_error="fail"))}
+        run_output = WorkflowRunOutput(content="done", status=RunStatus.completed)
+        status = persistence._resolve_workflow_run_status(
+            run_output,
+            [StepOutput(step_name="crit", content="boom", success=False, error="boom")],
+            node_by_name,
+        )
+        assert status == WorkflowRunStatus.FAILED
+
+    def test_resolve_status_unknown_node_failure_forces_failed(self):
+        """Without node mapping a failed step is treated as a real failure (conservative)."""
+        run_output = WorkflowRunOutput(content="done", status=RunStatus.completed)
+        status = persistence._resolve_workflow_run_status(
+            run_output,
+            [StepOutput(step_name="ghost", content="boom", success=False)],
+            None,
+        )
+        assert status == WorkflowRunStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_upsert_node_run_records_skipped_for_skip_tolerated_failure(self, monkeypatch: pytest.MonkeyPatch):
+        """A failed step on an on_error=skip node is persisted as SKIPPED, not FAILED."""
+        saved = []
+
+        class FakeNodeRun:
+            workflow_run_id = _FieldExpr("workflow_run_id")
+            node_id = _FieldExpr("node_id")
+
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+                self.attempt = 0
+                self.status = NodeRunStatus.PENDING
+                self.output_snapshot = None
+                self.finished_at = None
+                self.error = None
+                self.selected_a2a_key = None
+
+            @classmethod
+            async def find_one(cls, *args, **kwargs):
+                return None
+
+            async def save(self, **kwargs):
+                saved.append((self, kwargs))
+
+        monkeypatch.setattr(persistence, "NodeRun", FakeNodeRun)
+
+        sync = _sync_with_fake_run()
+        sync._node_by_name = {
+            "opt": WorkflowNode(name="opt", executor_key="t", step_config=StepConfig(on_error="skip"))
+        }
+
+        await sync._upsert_node_run(StepOutput(step_name="opt", content="boom", success=False, error="boom"))
+
+        node_run, _ = saved[0]
+        assert node_run.status == NodeRunStatus.SKIPPED
+        assert node_run.error == "boom"  # the skip reason is retained for diagnostics

--- a/registry-pkgs/tests/unit/workflow/test_runner.py
+++ b/registry-pkgs/tests/unit/workflow/test_runner.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from agno.run.base import RunStatus
@@ -322,3 +322,46 @@ class TestExecute:
         assert run_doc.finished_at.tzinfo == UTC
         run_doc.save.assert_awaited_once()
         run_doc.sync.assert_not_called()
+
+
+@pytest.mark.unit
+class TestContinueRunHydrationFailure:
+    @pytest.mark.asyncio
+    async def test_hydration_failure_preserves_pending_and_marks_failed(self, monkeypatch: pytest.MonkeyPatch):
+        """If hydrate_requirement fails, pending_requirements must survive and the run
+        must be finalized FAILED — never wiped and stranded as RUNNING."""
+        run_oid = PydanticObjectId()
+        original_pending = [{"step_id": "s1", "schema_version": 1}]
+        run_doc = SimpleNamespace(
+            id=run_oid,
+            status=WorkflowRunStatus.RUNNING,
+            definition_snapshot={"name": "demo"},
+            pending_requirements=original_pending,
+            agno_run_id=None,
+            error_summary=None,
+            finished_at=None,
+            save=AsyncMock(),
+        )
+
+        collection = SimpleNamespace(update_one=AsyncMock(return_value=SimpleNamespace(modified_count=1)))
+        fake_db = SimpleNamespace(get_collection=lambda name: collection)
+
+        class _FakeClient:
+            def __getitem__(self, name):
+                return fake_db
+
+        monkeypatch.setattr(runner.WorkflowRun, "get_settings", lambda: SimpleNamespace(name="workflow_runs"))
+        monkeypatch.setattr(runner.WorkflowRun, "get", AsyncMock(return_value=run_doc))
+        monkeypatch.setattr(runner, "WorkflowDefinition", lambda **kwargs: SimpleNamespace())
+        monkeypatch.setattr(runner, "hydrate_requirement", Mock(side_effect=RuntimeError("schema drift")))
+
+        r = _make_runner(db_client=_FakeClient())
+
+        with pytest.raises(RuntimeError, match="schema drift"):
+            await r.continue_run(existing_run_id=str(run_oid), registry_token="tok", user_id="u1")
+
+        # The persisted pending requirements were NOT cleared (still recoverable).
+        assert run_doc.pending_requirements == original_pending
+        # The run was finalized FAILED rather than left stranded as RUNNING.
+        assert run_doc.status == WorkflowRunStatus.FAILED
+        run_doc.save.assert_awaited()

--- a/registry-pkgs/tests/unit/workflow/test_runner.py
+++ b/registry-pkgs/tests/unit/workflow/test_runner.py
@@ -270,6 +270,7 @@ class TestExecute:
 
         workflow.arun.assert_awaited_once_with(
             input="hello",
+            session_id="run-1",
             session_state={"user_text": "hello", "_workflow_run_id": "run-1"},
         )
         run_doc.sync.assert_awaited_once()

--- a/registry/src/registry/api/v1/workflow/control_routes.py
+++ b/registry/src/registry/api/v1/workflow/control_routes.py
@@ -8,8 +8,9 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from registry.auth.dependencies import CurrentUser, UserContextDict
 from registry.deps import get_acl_service, get_workflow_control_service
 from registry.schemas.workflow_schemas import (
-    ApproveRequest,
     DirectiveResponse,
+    ResolveRequirementRequest,
+    ResolveRequirementResponse,
     RetryRequest,
 )
 from registry.services.access_control_service import ACLService
@@ -162,30 +163,46 @@ async def retry_run(
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
-@router.post("/approve", response_model=DirectiveResponse)
+@router.post("/approve", response_model=ResolveRequirementResponse)
 async def approve_run(
     workflow_id: str,
     run_id: str,
-    body: ApproveRequest,
+    body: ResolveRequirementRequest,
     current_user: CurrentUser,
     service: WorkflowControlService = Depends(get_workflow_control_service),
     acl_service: ACLService = Depends(get_acl_service),
-) -> DirectiveResponse:
-    """Approve or reject a workflow run holding at an approval gate.
+) -> ResolveRequirementResponse:
+    """Resolve a pending requirement on a run holding at an HITL gate.
 
-    ``approved=true`` resumes execution; ``approved=false`` rejects the gate,
-    failing the node according to its ``on_error`` policy.
-    Returns 400 if the run is not currently AWAITING_APPROVAL.
+    Carries a rich decision: confirm / reject / edit / user_input /
+    route_select — mirroring agno's ``StepRequirement`` methods 1:1.
+
+    Status codes:
+    - ``200``  decision accepted; ``continue_run`` triggered in the background
+    - ``400``  resolution / requirement type mismatch (e.g. EDIT on a non-output-review
+               requirement); missing required field (editedOutput / userInput / selectedChoices)
+    - ``403``  caller lacks ``workflows-control`` scope or VIEW permission on the workflow
+    - ``404``  workflow, run, or step_id not found (incl. already-resolved requirement)
+    - ``409``  run not in ``awaiting_approval`` (already resolved by someone else, timed out, completed)
     """
     try:
         await _require_workflow_view(acl_service, current_user, workflow_id)
-        if body.approved:
-            run = await service.send_approve(workflow_id, run_id)
-            message = "Approval granted"
-        else:
-            run = await service.send_reject(workflow_id, run_id)
-            message = "Approval rejected"
-        return DirectiveResponse(run_id=str(run.id), status=run.status, message=message)
+        run = await service.resolve_requirement(
+            workflow_id,
+            run_id,
+            step_id=body.stepId,
+            resolution=body.resolution,
+            feedback=body.feedback,
+            edited_output=body.editedOutput,
+            user_input=body.userInput,
+            selected_choices=body.selectedChoices,
+        )
+        return ResolveRequirementResponse(
+            runId=str(run.id),
+            status=run.status,
+            resolvedStepId=body.stepId,
+            message=f"Requirement resolved as {body.resolution.value}; run resuming",
+        )
     except HTTPException:
         raise
     except Exception as exc:

--- a/registry/src/registry/api/v1/workflow/control_routes.py
+++ b/registry/src/registry/api/v1/workflow/control_routes.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import logging
 
+from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from registry.auth.dependencies import CurrentUser
-from registry.deps import get_workflow_control_service
+from registry.auth.dependencies import CurrentUser, UserContextDict
+from registry.deps import get_acl_service, get_workflow_control_service
 from registry.schemas.workflow_schemas import (
+    ApproveRequest,
     DirectiveResponse,
     RetryRequest,
 )
+from registry.services.access_control_service import ACLService
 from registry.services.workflow_control_service import WorkflowControlService
+from registry_pkgs.models.extended_acl_entry import ExtendedResourceType
 
 logger = logging.getLogger(__name__)
 
@@ -20,12 +24,35 @@ router = APIRouter(
 )
 
 
+async def _require_workflow_view(
+    acl_service: ACLService,
+    user_context: UserContextDict,
+    workflow_id: str,
+) -> None:
+    """Enforce VIEWER (VIEW) permission on the parent workflow for run directives.
+
+    Raises HTTPException(403) if the caller lacks VIEW; HTTPException(404) if the
+    workflow_id is malformed.
+    """
+    try:
+        workflow_oid = PydanticObjectId(workflow_id)
+    except Exception as exc:
+        raise HTTPException(status_code=404, detail=f"Workflow {workflow_id!r} not found") from exc
+    await acl_service.check_user_permission(
+        user_id=PydanticObjectId(user_context.get("user_id")),
+        resource_type=ExtendedResourceType.WORKFLOW,
+        resource_id=workflow_oid,
+        required_permission="VIEW",
+    )
+
+
 @router.post("/pause", response_model=DirectiveResponse)
 async def pause_run(
     workflow_id: str,
     run_id: str,
-    _current_user: CurrentUser,
+    current_user: CurrentUser,
     service: WorkflowControlService = Depends(get_workflow_control_service),
+    acl_service: ACLService = Depends(get_acl_service),
 ) -> DirectiveResponse:
     """Pause a running workflow run.
 
@@ -34,6 +61,7 @@ async def pause_run(
     Idempotent: pausing an already-paused run returns 200.
     """
     try:
+        await _require_workflow_view(acl_service, current_user, workflow_id)
         run = await service.send_pause(workflow_id, run_id)
         return DirectiveResponse(run_id=str(run.id), status=run.status, message="Pause directive sent")
     except HTTPException:
@@ -47,14 +75,16 @@ async def pause_run(
 async def resume_run(
     workflow_id: str,
     run_id: str,
-    _current_user: CurrentUser,
+    current_user: CurrentUser,
     service: WorkflowControlService = Depends(get_workflow_control_service),
+    acl_service: ACLService = Depends(get_acl_service),
 ) -> DirectiveResponse:
     """Resume a paused workflow run.
 
     Returns 400 if the run is not currently in PAUSED status.
     """
     try:
+        await _require_workflow_view(acl_service, current_user, workflow_id)
         run = await service.send_resume(workflow_id, run_id)
         return DirectiveResponse(run_id=str(run.id), status=run.status, message="Resume directive sent")
     except HTTPException:
@@ -68,8 +98,9 @@ async def resume_run(
 async def cancel_run(
     workflow_id: str,
     run_id: str,
-    _current_user: CurrentUser,
+    current_user: CurrentUser,
     service: WorkflowControlService = Depends(get_workflow_control_service),
+    acl_service: ACLService = Depends(get_acl_service),
 ) -> DirectiveResponse:
     """Cancel a running or paused workflow run.
 
@@ -77,6 +108,7 @@ async def cancel_run(
     Returns 400 if the run has already reached a terminal state (completed or failed).
     """
     try:
+        await _require_workflow_view(acl_service, current_user, workflow_id)
         run = await service.send_cancel(workflow_id, run_id)
         return DirectiveResponse(run_id=str(run.id), status=run.status, message="Cancel directive sent")
     except HTTPException:
@@ -92,8 +124,9 @@ async def retry_run(
     run_id: str,
     body: RetryRequest,
     request: Request,
-    _current_user: CurrentUser,
+    current_user: CurrentUser,
     service: WorkflowControlService = Depends(get_workflow_control_service),
+    acl_service: ACLService = Depends(get_acl_service),
 ) -> DirectiveResponse:
     """Retry a finished workflow run from a specific node.
 
@@ -106,9 +139,10 @@ async def retry_run(
     """
     auth_header = request.headers.get("Authorization", "")
     registry_token = auth_header.removeprefix("Bearer ").strip()
-    user_id = _current_user.get("user_id")
+    user_id = current_user.get("user_id")
 
     try:
+        await _require_workflow_view(acl_service, current_user, workflow_id)
         child_run = await service.send_retry(
             workflow_id,
             run_id,
@@ -125,4 +159,35 @@ async def retry_run(
         raise
     except Exception as exc:
         logger.exception("Retry request failed for run %s", run_id)
+        raise HTTPException(status_code=500, detail="Internal server error") from exc
+
+
+@router.post("/approve", response_model=DirectiveResponse)
+async def approve_run(
+    workflow_id: str,
+    run_id: str,
+    body: ApproveRequest,
+    current_user: CurrentUser,
+    service: WorkflowControlService = Depends(get_workflow_control_service),
+    acl_service: ACLService = Depends(get_acl_service),
+) -> DirectiveResponse:
+    """Approve or reject a workflow run holding at an approval gate.
+
+    ``approved=true`` resumes execution; ``approved=false`` rejects the gate,
+    failing the node according to its ``on_error`` policy.
+    Returns 400 if the run is not currently AWAITING_APPROVAL.
+    """
+    try:
+        await _require_workflow_view(acl_service, current_user, workflow_id)
+        if body.approved:
+            run = await service.send_approve(workflow_id, run_id)
+            message = "Approval granted"
+        else:
+            run = await service.send_reject(workflow_id, run_id)
+            message = "Approval rejected"
+        return DirectiveResponse(run_id=str(run.id), status=run.status, message=message)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Approve request failed for run %s", run_id)
         raise HTTPException(status_code=500, detail="Internal server error") from exc

--- a/registry/src/registry/api/v1/workflow/workflow_routes.py
+++ b/registry/src/registry/api/v1/workflow/workflow_routes.py
@@ -14,11 +14,12 @@ from fastapi import status as http_status
 
 from registry.auth.dependencies import CurrentUser, UserContextDict
 from registry.core.telemetry_decorators import track_registry_operation
-from registry.deps import get_acl_service, get_workflow_runner, get_workflow_service
+from registry.deps import get_acl_service, get_workflow_control_service, get_workflow_runner, get_workflow_service
 from registry.schemas.acl_schema import ResourcePermissions
 from registry.schemas.errors import ErrorCode, create_error_detail
 from registry.schemas.workflow_api_schemas import (
     PaginationMetadata,
+    StepRequirementSummary,
     WorkflowCreateRequest,
     WorkflowDetailResponse,
     WorkflowListResponse,
@@ -34,7 +35,9 @@ from registry.schemas.workflow_api_schemas import (
     convert_to_run_detail,
     convert_to_run_list_item,
 )
+from registry.schemas.workflow_schemas import NodeRunSummary, RunStatusResponse
 from registry.services.access_control_service import ACLService
+from registry.services.workflow_control_service import WorkflowControlService
 from registry.services.workflow_executor import execute_workflow_run_background
 from registry.services.workflow_service import WorkflowService
 from registry.utils.crypto_utils import generate_service_jwt
@@ -672,3 +675,84 @@ async def get_workflow_run(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=create_error_detail(ErrorCode.INTERNAL_ERROR, "Internal server error while getting workflow run"),
         )
+
+
+@router.get(
+    "/workflows/{workflow_id}/runs/{run_id}/status",
+    response_model=RunStatusResponse,
+    response_model_by_alias=True,
+    summary="Get Workflow Run Status",
+    description="Get run status with per-node summary. If the run is awaiting_approval and a pending requirement has timed out, a background continue_run is nudged so agno can apply the gate's on_timeout policy.",
+)
+@track_registry_operation("read", resource_type="workflow_run")
+async def get_workflow_run_status(
+    workflow_id: str,
+    run_id: str,
+    user_context: CurrentUser,
+    workflow_control_service: WorkflowControlService = Depends(get_workflow_control_service),
+    acl_service: ACLService = Depends(get_acl_service),
+):
+    """Pollable status endpoint for a workflow run (requires VIEW on the workflow).
+
+    Side effect: when the run is ``awaiting_approval`` and a pending requirement has
+    passed its ``timeout_at``, this lazily triggers ``continue_run`` so agno can
+    apply the gate's ``on_timeout`` policy. The returned status still shows
+    ``awaiting_approval`` — the actual state transition surfaces on the next poll.
+    """
+    try:
+        workflow_oid = PydanticObjectId(workflow_id)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=create_error_detail(ErrorCode.RESOURCE_NOT_FOUND, f"Workflow {workflow_id!r} not found"),
+        ) from exc
+
+    await acl_service.check_user_permission(
+        user_id=PydanticObjectId(user_context.get("user_id")),
+        resource_type=ExtendedResourceType.WORKFLOW,
+        resource_id=workflow_oid,
+        required_permission="VIEW",
+    )
+
+    try:
+        run, node_runs = await workflow_control_service.get_run_status(workflow_id, run_id)
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=create_error_detail(ErrorCode.RESOURCE_NOT_FOUND, str(exc)),
+        ) from exc
+    except Exception as exc:
+        logger.exception("Error getting workflow run status %s", run_id)
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=create_error_detail(
+                ErrorCode.INTERNAL_ERROR, "Internal server error while getting workflow run status"
+            ),
+        ) from exc
+
+    return RunStatusResponse(
+        run_id=str(run.id),
+        workflow_id=str(run.workflow_definition_id),
+        status=run.status.value if hasattr(run.status, "value") else run.status,
+        trigger_source=run.trigger_source,
+        started_at=run.started_at,
+        finished_at=run.finished_at,
+        paused_at=run.paused_at,
+        error_summary=run.error_summary,
+        parent_run_id=str(run.parent_run_id) if run.parent_run_id else None,
+        node_runs=[
+            NodeRunSummary(
+                node_id=nr.node_id,
+                node_name=nr.node_name,
+                status=nr.status.value if hasattr(nr.status, "value") else nr.status,
+                attempt=nr.attempt,
+                started_at=nr.started_at,
+                finished_at=nr.finished_at,
+                error=nr.error,
+            )
+            for nr in node_runs
+        ],
+        pendingRequirements=[StepRequirementSummary.model_validate(req) for req in (run.pending_requirements or [])],
+    )

--- a/registry/src/registry/api/v1/workflow/workflow_routes.py
+++ b/registry/src/registry/api/v1/workflow/workflow_routes.py
@@ -8,12 +8,14 @@ import logging
 import math
 from typing import Annotated, Literal
 
+from beanie import PydanticObjectId
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from fastapi import status as http_status
 
 from registry.auth.dependencies import CurrentUser, UserContextDict
 from registry.core.telemetry_decorators import track_registry_operation
-from registry.deps import get_workflow_runner, get_workflow_service
+from registry.deps import get_acl_service, get_workflow_runner, get_workflow_service
+from registry.schemas.acl_schema import ResourcePermissions
 from registry.schemas.errors import ErrorCode, create_error_detail
 from registry.schemas.workflow_api_schemas import (
     PaginationMetadata,
@@ -25,19 +27,47 @@ from registry.schemas.workflow_api_schemas import (
     WorkflowRunTriggerRequest,
     WorkflowRunTriggerResponse,
     WorkflowUpdateRequest,
+    WorkflowVersionItem,
+    WorkflowVersionListResponse,
     convert_to_detail,
     convert_to_list_item,
     convert_to_run_detail,
     convert_to_run_list_item,
 )
+from registry.services.access_control_service import ACLService
 from registry.services.workflow_executor import execute_workflow_run_background
 from registry.services.workflow_service import WorkflowService
 from registry.utils.crypto_utils import generate_service_jwt
+from registry_pkgs.models import PrincipalType
+from registry_pkgs.models.enums import RoleBits
+from registry_pkgs.models.extended_acl_entry import ExtendedResourceType
 from registry_pkgs.workflows.runner import WorkflowRunner
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+async def _authorize_workflow(
+    acl_service: ACLService,
+    workflow_service: WorkflowService,
+    user_context: UserContextDict,
+    workflow_id: str,
+    required_permission: str,
+):
+    """Resolve a workflow (404 if missing) and enforce an ACL permission on it.
+
+    Returns the (workflow, ResourcePermissions) tuple on success; raises
+    ValueError (→404) if not found or HTTPException(403) if unauthorized.
+    """
+    workflow = await workflow_service.get_workflow_by_id(workflow_id)
+    permissions = await acl_service.check_user_permission(
+        user_id=PydanticObjectId(user_context.get("user_id")),
+        resource_type=ExtendedResourceType.WORKFLOW,
+        resource_id=workflow.id,
+        required_permission=required_permission,
+    )
+    return workflow, permissions
 
 
 def _extract_bearer_token(request: Request) -> str:
@@ -92,9 +122,12 @@ async def list_workflows(
     page: Annotated[int, Query(ge=1)] = 1,
     per_page: Annotated[int, Query(ge=1, le=100)] = 20,
     workflow_service: WorkflowService = Depends(get_workflow_service),
+    acl_service: ACLService = Depends(get_acl_service),
 ):
     """
     List workflows with optional filtering and pagination.
+
+    Only workflows the caller has VIEW permission on are returned.
 
     Query Parameters:
     - query: Free-text search across workflow name, description
@@ -102,15 +135,29 @@ async def list_workflows(
     - per_page: Items per page (default: 20, min: 1, max: 100)
     """
     try:
-        # List workflows
+        user_id = user_context.get("user_id")
+        accessible_ids = await acl_service.get_accessible_resource_ids(
+            user_id=PydanticObjectId(user_id),
+            resource_type=ExtendedResourceType.WORKFLOW.value,
+        )
+
+        # List workflows restricted to ACL-accessible IDs
         workflows, total = await workflow_service.list_workflows(
             query=query,
             page=page,
             per_page=per_page,
+            accessible_workflow_ids=accessible_ids,
         )
 
-        # Convert to response items
-        workflow_items = [convert_to_list_item(workflow) for workflow in workflows]
+        # Convert to response items with per-workflow permissions
+        workflow_items = []
+        for workflow in workflows:
+            perms = await acl_service.get_user_permissions_for_resource(
+                user_id=PydanticObjectId(user_id),
+                resource_type=ExtendedResourceType.WORKFLOW.value,
+                resource_id=workflow.id,
+            )
+            workflow_items.append(convert_to_list_item(workflow, acl_permission=perms))
 
         # Calculate pagination metadata
         total_pages = math.ceil(total / per_page) if total > 0 else 0
@@ -148,14 +195,16 @@ async def get_workflow(
     workflow_id: str,
     user_context: CurrentUser,
     workflow_service: WorkflowService = Depends(get_workflow_service),
+    acl_service: ACLService = Depends(get_acl_service),
 ):
-    """Get detailed information about a workflow by ID"""
+    """Get detailed information about a workflow by ID (requires VIEW)"""
     try:
-        # Get workflow
-        workflow = await workflow_service.get_workflow_by_id(workflow_id)
+        workflow, permissions = await _authorize_workflow(
+            acl_service, workflow_service, user_context, workflow_id, "VIEW"
+        )
 
         # Convert to response model
-        return convert_to_detail(workflow)
+        return convert_to_detail(workflow, acl_permission=permissions)
 
     except ValueError as e:
         error_msg = str(e)
@@ -192,9 +241,12 @@ async def create_workflow(
     data: WorkflowCreateRequest,
     user_context: CurrentUser,
     workflow_service: WorkflowService = Depends(get_workflow_service),
+    acl_service: ACLService = Depends(get_acl_service),
 ):
-    """Create a new workflow"""
+    """Create a new workflow. The creator is granted OWNER permission."""
     try:
+        user_id = user_context.get("user_id")
+
         # Create workflow
         workflow = await workflow_service.create_workflow(data=data)
 
@@ -202,9 +254,20 @@ async def create_workflow(
             logger.error("Workflow creation failed without exception")
             raise ValueError("Failed to create workflow")
 
-        logger.info(f"Created workflow {workflow.id}: {workflow.name}")
+        # Grant OWNER permission to creator
+        await acl_service.grant_permission(
+            principal_type=PrincipalType.USER,
+            principal_id=PydanticObjectId(user_id),
+            resource_type=ExtendedResourceType.WORKFLOW,
+            resource_id=workflow.id,
+            perm_bits=RoleBits.OWNER,
+        )
+        logger.info(f"Created workflow {workflow.id}: {workflow.name}; granted OWNER to user {user_id}")
 
-        return convert_to_detail(workflow)
+        return convert_to_detail(
+            workflow,
+            acl_permission=ResourcePermissions(VIEW=True, EDIT=True, DELETE=True, SHARE=True),
+        )
 
     except ValueError as e:
         error_msg = str(e)
@@ -239,13 +302,16 @@ async def update_workflow(
     data: WorkflowUpdateRequest,
     user_context: CurrentUser,
     workflow_service: WorkflowService = Depends(get_workflow_service),
+    acl_service: ACLService = Depends(get_acl_service),
 ):
-    """Update a workflow with partial data"""
+    """Update a workflow with partial data (requires EDIT)"""
     try:
-        # Update workflow
+        _, permissions = await _authorize_workflow(acl_service, workflow_service, user_context, workflow_id, "EDIT")
+
+        # Update workflow (bumps version, snapshots prior version as history)
         workflow = await workflow_service.update_workflow(workflow_id=workflow_id, data=data)
 
-        return convert_to_detail(workflow)
+        return convert_to_detail(workflow, acl_permission=permissions)
 
     except ValueError as e:
         error_msg = str(e)
@@ -285,14 +351,21 @@ async def delete_workflow(
     workflow_id: str,
     user_context: CurrentUser,
     workflow_service: WorkflowService = Depends(get_workflow_service),
+    acl_service: ACLService = Depends(get_acl_service),
 ):
-    """Delete a workflow"""
+    """Delete a workflow (requires DELETE)"""
     try:
+        workflow, _ = await _authorize_workflow(acl_service, workflow_service, user_context, workflow_id, "DELETE")
+
         # Delete workflow
         successful_delete = await workflow_service.delete_workflow(workflow_id=workflow_id)
 
         if successful_delete:
-            logger.info(f"Deleted workflow {workflow_id}")
+            await acl_service.delete_acl_entries_for_resource(
+                resource_type=ExtendedResourceType.WORKFLOW.value,
+                resource_id=workflow.id,
+            )
+            logger.info(f"Deleted workflow {workflow_id} and its ACL entries")
             return None  # 204 No Content
         else:
             raise ValueError(f"Failed to delete workflow {workflow_id}")
@@ -323,6 +396,58 @@ async def delete_workflow(
         )
 
 
+@router.get(
+    "/workflows/{workflow_id}/versions",
+    response_model=WorkflowVersionListResponse,
+    response_model_by_alias=True,
+    summary="List Workflow Versions",
+    description="List the version history of a workflow",
+)
+@track_registry_operation("list", resource_type="workflow_version")
+async def list_workflow_versions(
+    workflow_id: str,
+    user_context: CurrentUser,
+    workflow_service: WorkflowService = Depends(get_workflow_service),
+    acl_service: ACLService = Depends(get_acl_service),
+):
+    """List the version history of a workflow (requires VIEW)."""
+    try:
+        await _authorize_workflow(acl_service, workflow_service, user_context, workflow_id, "VIEW")
+
+        versions = await workflow_service.list_versions(workflow_id)
+        return WorkflowVersionListResponse(
+            versions=[
+                WorkflowVersionItem(
+                    version=v["version"],
+                    createdAt=v["created_at"],
+                    checksum=v["checksum"],
+                )
+                for v in versions
+            ]
+        )
+
+    except ValueError as e:
+        error_msg = str(e)
+        if "not found" in error_msg.lower():
+            raise HTTPException(
+                status_code=http_status.HTTP_404_NOT_FOUND,
+                detail=create_error_detail(ErrorCode.RESOURCE_NOT_FOUND, error_msg),
+            )
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail=create_error_detail(ErrorCode.INVALID_REQUEST, error_msg),
+        )
+    except HTTPException:
+        logger.exception("HTTPException in list_workflow_versions")
+        raise
+    except Exception:
+        logger.exception("Error listing versions for workflow %s", workflow_id)
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=create_error_detail(ErrorCode.INTERNAL_ERROR, "Internal server error while listing versions"),
+        )
+
+
 # ==================== Workflow Run Endpoints ====================
 
 
@@ -343,13 +468,18 @@ async def trigger_workflow_run(
     request: Request,
     workflow_service: WorkflowService = Depends(get_workflow_service),
     workflow_runner: WorkflowRunner = Depends(get_workflow_runner),
+    acl_service: ACLService = Depends(get_acl_service),
 ):
     """
     Trigger a workflow run (async execution).
 
+    Requires VIEWER (VIEW) permission on the workflow plus the workflows-control scope.
     Returns 202 Accepted immediately. The workflow will be executed asynchronously in the background.
     """
     try:
+        # Running a workflow requires VIEWER or more on the workflow itself
+        await _authorize_workflow(acl_service, workflow_service, user_context, workflow_id, "VIEW")
+
         # Create workflow run record (status=PENDING)
         run = await workflow_service.trigger_workflow_run(
             workflow_id=workflow_id,
@@ -357,6 +487,7 @@ async def trigger_workflow_run(
             initial_input=data.initialInput,
             parent_run_id=data.parentRunId,
             resolved_dependencies=[dep.model_dump(by_alias=True) for dep in data.resolvedDependencies],
+            version=data.version,
         )
 
         registry_token = _build_registry_token(request, user_context)
@@ -422,22 +553,25 @@ async def list_workflow_runs(
     workflow_id: str,
     user_context: CurrentUser,
     status: Annotated[
-        Literal["pending", "running", "paused", "completed", "failed", "cancelled"] | None,
+        Literal["pending", "running", "paused", "awaiting_approval", "completed", "failed", "cancelled"] | None,
         Query(),
     ] = None,
     page: Annotated[int, Query(ge=1)] = 1,
     per_page: Annotated[int, Query(ge=1, le=100)] = 20,
     workflow_service: WorkflowService = Depends(get_workflow_service),
+    acl_service: ACLService = Depends(get_acl_service),
 ):
     """
-    List workflow runs with optional filtering and pagination.
+    List workflow runs with optional filtering and pagination (requires VIEW on the workflow).
 
     Query Parameters:
-    - status: Filter by run status (pending, running, paused, completed, failed, cancelled)
+    - status: Filter by run status (pending, running, paused, awaiting_approval, completed, failed, cancelled)
     - page: Page number (default: 1, min: 1)
     - per_page: Items per page (default: 20, min: 1, max: 100)
     """
     try:
+        await _authorize_workflow(acl_service, workflow_service, user_context, workflow_id, "VIEW")
+
         # List workflow runs
         runs_with_nodes, total = await workflow_service.list_workflow_runs(
             workflow_id=workflow_id,
@@ -501,9 +635,12 @@ async def get_workflow_run(
     run_id: str,
     user_context: CurrentUser,
     workflow_service: WorkflowService = Depends(get_workflow_service),
+    acl_service: ACLService = Depends(get_acl_service),
 ):
-    """Get detailed information about a workflow run by ID"""
+    """Get detailed information about a workflow run by ID (requires VIEW on the workflow)"""
     try:
+        await _authorize_workflow(acl_service, workflow_service, user_context, workflow_id, "VIEW")
+
         # Get workflow run with node runs
         run, node_runs = await workflow_service.get_workflow_run(workflow_id=workflow_id, run_id=run_id)
 

--- a/registry/src/registry/api/v1/workflow/workflow_routes.py
+++ b/registry/src/registry/api/v1/workflow/workflow_routes.py
@@ -149,15 +149,13 @@ async def list_workflows(
             accessible_workflow_ids=accessible_ids,
         )
 
-        # Convert to response items with per-workflow permissions
-        workflow_items = []
-        for workflow in workflows:
-            perms = await acl_service.get_user_permissions_for_resource(
-                user_id=PydanticObjectId(user_id),
-                resource_type=ExtendedResourceType.WORKFLOW.value,
-                resource_id=workflow.id,
-            )
-            workflow_items.append(convert_to_list_item(workflow, acl_permission=perms))
+        # Convert to response items with per-workflow permissions.
+        perms_by_id = await acl_service.get_user_permissions_for_resources(
+            user_id=PydanticObjectId(user_id),
+            resource_type=ExtendedResourceType.WORKFLOW.value,
+            resource_ids=[w.id for w in workflows],
+        )
+        workflow_items = [convert_to_list_item(w, acl_permission=perms_by_id[w.id]) for w in workflows]
 
         # Calculate pagination metadata
         total_pages = math.ceil(total / per_page) if total > 0 else 0
@@ -488,6 +486,9 @@ async def trigger_workflow_run(
             parent_run_id=data.parentRunId,
             resolved_dependencies=[dep.model_dump(by_alias=True) for dep in data.resolvedDependencies],
             version=data.version,
+            triggering_user_id=user_context.get("user_id"),
+            triggering_username=user_context.get("username"),
+            triggering_scopes=user_context.get("scopes", []),
         )
 
         registry_token = _build_registry_token(request, user_context)

--- a/registry/src/registry/container.py
+++ b/registry/src/registry/container.py
@@ -302,6 +302,7 @@ class RegistryContainer:
 
     async def shutdown(self) -> None:
         """Shutdown services that hold background tasks or external resources."""
+        await self.workflow_reaper.stop()
         await cancel_in_flight_runs()
         await self.health_service.shutdown()
         await self.mcp_proxy_client.aclose()

--- a/registry/src/registry/main.py
+++ b/registry/src/registry/main.py
@@ -6,12 +6,16 @@ import logging
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
+from agno.run.cancel import get_cancellation_manager, set_cancellation_manager
+from agno.run.cancellation_management.in_memory_cancellation_manager import InMemoryRunCancellationManager
 from fastapi import FastAPI
 
 from registry_pkgs.database import close_mongodb, init_mongodb
 from registry_pkgs.database.redis_client import close_redis_client, create_redis_client
 from registry_pkgs.telemetry import setup_metrics
 from registry_pkgs.vector.client import create_database_client
+from registry_pkgs.workflows.control import DirectiveQueue
+from registry_pkgs.workflows.hitl import MongoBackedCancellationManager
 
 from .app_factory import create_app
 from .container import RegistryContainer
@@ -81,13 +85,49 @@ async def _startup_container(app: FastAPI) -> _RuntimeResources:
         db_client=db_client,
         redis_client=redis_client,
     )
+    _install_agno_cancellation_manager(container.directive_queue)
     app.state.container = container
     await container.startup()
     return _RuntimeResources(db_client, redis_client)
 
 
+def _install_agno_cancellation_manager(directive_queue: DirectiveQueue) -> None:
+    """Install our MongoDB-backed cancellation manager process-globally.
+
+    Refuses to overwrite a non-default manager so a second app spinning up in
+    the same process (common in tests) does not silently clobber the first.
+    """
+    current = get_cancellation_manager()
+    if not isinstance(current, InMemoryRunCancellationManager):
+        raise RuntimeError(
+            f"agno cancellation manager already replaced by {type(current).__name__}; "
+            "refusing to overwrite (likely a duplicate startup)."
+        )
+    try:
+        set_cancellation_manager(MongoBackedCancellationManager(directive_queue=directive_queue))
+        logger.info("installed MongoBackedCancellationManager (agno cancel signal source, queue wired)")
+    except Exception as exc:
+        logger.error("Failed to install MongoBackedCancellationManager: %s", exc, exc_info=True)
+        raise
+
+
+def _restore_default_cancellation_manager() -> None:
+    """Reset agno's global cancellation manager back to the in-memory default.
+
+    Called from ``_shutdown_container`` so a test or sequential ``app`` startup
+    does not see our MongoDB-backed manager pointing at a closed Mongo client.
+    """
+    try:
+        set_cancellation_manager(InMemoryRunCancellationManager())
+        logger.info("restored agno default InMemoryRunCancellationManager")
+    except Exception as exc:
+        logger.warning("Failed to restore default cancellation manager: %s", exc)
+
+
 async def _shutdown_container(app: FastAPI, resources: _RuntimeResources) -> None:
     """Shutdown app-scoped services before tearing down the underlying infra clients."""
+    _restore_default_cancellation_manager()
+
     container = getattr(app.state, "container", None)
     if container is not None:
         try:

--- a/registry/src/registry/schemas/workflow_api_schemas.py
+++ b/registry/src/registry/schemas/workflow_api_schemas.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from pydantic import Field
 
+from .acl_schema import ResourcePermissions
 from .case_conversion import APIBaseModel
 
 # ==================== Nested Models ====================
@@ -78,6 +79,12 @@ class WorkflowNodeInput(APIBaseModel):
     )
     conditionCel: str | None = Field(None, description="CEL expression for condition/router nodes")
     loopConfig: LoopConfigInput | None = Field(None, description="Loop configuration for loop nodes")
+    requireApproval: bool = Field(
+        default=False, description="STEP only: hold the run for user approval before executing this node"
+    )
+    approvalTimeoutSeconds: int | None = Field(
+        None, gt=0, description="STEP only: seconds to wait for approval before treating it as a rejection"
+    )
 
 
 # Enable recursive models
@@ -101,6 +108,8 @@ class WorkflowNodeOutput(APIBaseModel):
     choices: list[RouterChoiceOutput] = Field(default_factory=list)
     conditionCel: str | None = None
     loopConfig: LoopConfigInput | None = None
+    requireApproval: bool = False
+    approvalTimeoutSeconds: int | None = None
 
 
 # Enable recursive models
@@ -153,6 +162,9 @@ class WorkflowRunTriggerRequest(APIBaseModel):
     resolvedDependencies: list[ResolvedDependencyInput] = Field(
         default_factory=list, description="Dependency resolution for retry"
     )
+    version: int | None = Field(
+        None, description="Workflow version to run; defaults to the latest version when omitted"
+    )
 
 
 # ==================== Response Schemas ====================
@@ -165,8 +177,10 @@ class WorkflowListItem(APIBaseModel):
     name: str
     description: str | None = None
     numNodes: int
+    version: int = 1
     createdAt: datetime
     updatedAt: datetime
+    aclPermission: ResourcePermissions | None = None
 
 
 class WorkflowDetailResponse(APIBaseModel):
@@ -176,8 +190,10 @@ class WorkflowDetailResponse(APIBaseModel):
     name: str
     description: str | None = None
     nodes: list[WorkflowNodeOutput]
+    version: int = 1
     createdAt: datetime
     updatedAt: datetime
+    aclPermission: ResourcePermissions | None = None
 
 
 class WorkflowListResponse(APIBaseModel):
@@ -185,6 +201,20 @@ class WorkflowListResponse(APIBaseModel):
 
     workflows: list[WorkflowListItem]
     pagination: PaginationMetadata
+
+
+class WorkflowVersionItem(APIBaseModel):
+    """Response schema for a single workflow version entry"""
+
+    version: int
+    createdAt: datetime
+    checksum: str
+
+
+class WorkflowVersionListResponse(APIBaseModel):
+    """Response schema for workflow version history"""
+
+    versions: list[WorkflowVersionItem]
 
 
 class WorkflowRunTriggerResponse(APIBaseModel):
@@ -259,7 +289,7 @@ class WorkflowRunDetailResponse(APIBaseModel):
 # ==================== Converter Functions ====================
 
 
-def convert_to_list_item(workflow: Any) -> WorkflowListItem:
+def convert_to_list_item(workflow: Any, acl_permission: ResourcePermissions | None = None) -> WorkflowListItem:
     """Convert WorkflowDefinition to WorkflowListItem"""
     from registry_pkgs.models.workflow import WorkflowDefinition
 
@@ -271,12 +301,14 @@ def convert_to_list_item(workflow: Any) -> WorkflowListItem:
         name=workflow.name,
         description=workflow.description,
         numNodes=len(workflow.nodes),
+        version=getattr(workflow, "version", 1),
         createdAt=workflow.created_at,
         updatedAt=workflow.updated_at,
+        aclPermission=acl_permission,
     )
 
 
-def convert_to_detail(workflow: Any) -> WorkflowDetailResponse:
+def convert_to_detail(workflow: Any, acl_permission: ResourcePermissions | None = None) -> WorkflowDetailResponse:
     """Convert WorkflowDefinition to WorkflowDetailResponse"""
     from registry_pkgs.models.workflow import WorkflowDefinition
 
@@ -288,8 +320,10 @@ def convert_to_detail(workflow: Any) -> WorkflowDetailResponse:
         name=workflow.name,
         description=workflow.description,
         nodes=[_convert_node_to_output(node) for node in workflow.nodes],
+        version=getattr(workflow, "version", 1),
         createdAt=workflow.created_at,
         updatedAt=workflow.updated_at,
+        aclPermission=acl_permission,
     )
 
 
@@ -330,6 +364,8 @@ def _convert_node_to_output(node: Any) -> WorkflowNodeOutput:
             if node.loop_config
             else None
         ),
+        requireApproval=node.require_approval,
+        approvalTimeoutSeconds=node.approval_timeout_seconds,
     )
 
 

--- a/registry/src/registry/schemas/workflow_api_schemas.py
+++ b/registry/src/registry/schemas/workflow_api_schemas.py
@@ -499,6 +499,77 @@ def _convert_node_to_output(node: Any) -> WorkflowNodeOutput:
     )
 
 
+def _convert_node_to_input(node: Any) -> WorkflowNodeInput:
+    """Convert WorkflowNode to WorkflowNodeInput (recursive)."""
+    return WorkflowNodeInput(
+        id=node.id,
+        name=node.name,
+        nodeType=node.node_type.value if hasattr(node.node_type, "value") else node.node_type,
+        executorKey=node.executor_key,
+        a2aPool=node.a2a_pool,
+        stepConfig=(
+            StepConfigInput(
+                maxRetries=node.step_config.max_retries,
+                onError=node.step_config.on_error,
+                backoffBaseSeconds=node.step_config.backoff_base_seconds,
+                backoffMaxSeconds=node.step_config.backoff_max_seconds,
+            )
+            if node.step_config
+            else None
+        ),
+        config=node.config,
+        children=[_convert_node_to_input(child) for child in node.children],
+        trueSteps=[_convert_node_to_input(child) for child in node.true_steps],
+        falseSteps=[_convert_node_to_input(child) for child in node.false_steps],
+        choices=[
+            RouterChoiceInput(
+                name=choice.name,
+                steps=[_convert_node_to_input(s) for s in choice.steps],
+            )
+            for choice in node.choices
+        ],
+        conditionCel=node.condition_cel,
+        loopConfig=(
+            LoopConfigInput(
+                maxIterations=node.loop_config.max_iterations, endConditionCel=node.loop_config.end_condition_cel
+            )
+            if node.loop_config
+            else None
+        ),
+        humanReview=(
+            HumanReviewInput(
+                requiresConfirmation=node.human_review.requires_confirmation,
+                confirmationMessage=node.human_review.confirmation_message,
+                requiresUserInput=node.human_review.requires_user_input,
+                userInputMessage=node.human_review.user_input_message,
+                userInputSchema=(
+                    [
+                        UserInputFieldSchema(
+                            name=f.name,
+                            fieldType=f.field_type,
+                            description=f.description,
+                            required=f.required,
+                            defaultValue=f.default_value,
+                        )
+                        for f in node.human_review.user_input_schema
+                    ]
+                    if node.human_review.user_input_schema
+                    else None
+                ),
+                requiresOutputReview=node.human_review.requires_output_review,
+                outputReviewMessage=node.human_review.output_review_message,
+                requiresIterationReview=node.human_review.requires_iteration_review,
+                iterationReviewMessage=node.human_review.iteration_review_message,
+                onReject=node.human_review.on_reject,
+                timeoutSeconds=node.human_review.timeout_seconds,
+                onTimeout=node.human_review.on_timeout,
+            )
+            if node.human_review
+            else None
+        ),
+    )
+
+
 def convert_to_run_list_item(run: Any, node_runs: list[Any] | None = None) -> WorkflowRunListItem:
     """Convert WorkflowRun to WorkflowRunListItem"""
     from registry_pkgs.models.workflow import WorkflowRun

--- a/registry/src/registry/schemas/workflow_api_schemas.py
+++ b/registry/src/registry/schemas/workflow_api_schemas.py
@@ -84,7 +84,7 @@ class PendingUserInputField(APIBaseModel):
         return field_type_to_authoring(value)
 
 
-class HumanReviewInput(APIBaseModel):
+class HumanReviewConfig(APIBaseModel):
     """Node-level HITL configuration (per-primitive validity enforced by backend).
 
     Field × node-type compatibility (mirrors agno):
@@ -108,12 +108,6 @@ class HumanReviewInput(APIBaseModel):
     onReject: OnRejectPolicy = OnRejectPolicy.SKIP
     timeoutSeconds: int | None = Field(default=None, gt=0)
     onTimeout: OnTimeoutPolicy = OnTimeoutPolicy.CANCEL
-
-
-class HumanReviewOutput(HumanReviewInput):
-    """Same shape as ``HumanReviewInput`` — distinct alias for API clarity."""
-
-    pass
 
 
 class RouterChoiceInput(APIBaseModel):
@@ -161,7 +155,7 @@ class WorkflowNodeInput(APIBaseModel):
     )
     conditionCel: str | None = Field(None, description="CEL expression for condition/router nodes")
     loopConfig: LoopConfigInput | None = Field(None, description="Loop configuration for loop nodes")
-    humanReview: HumanReviewInput | None = Field(
+    humanReview: HumanReviewConfig | None = Field(
         default=None,
         description="HITL configuration",
     )
@@ -189,7 +183,7 @@ class WorkflowNodeOutput(APIBaseModel):
     conditionCel: str | None = None
     loopConfig: LoopConfigInput | None = None
     # ``null`` when no HITL configured.
-    humanReview: HumanReviewOutput | None = None
+    humanReview: HumanReviewConfig | None = None
 
 
 # Enable recursive models
@@ -504,7 +498,7 @@ def _convert_node_to_output(node: Any) -> WorkflowNodeOutput:
         ),
         # Serialize the embedded HumanReviewSpec (None when no HITL configured).
         humanReview=(
-            HumanReviewOutput(
+            HumanReviewConfig(
                 requiresConfirmation=node.human_review.requires_confirmation,
                 confirmationMessage=node.human_review.confirmation_message,
                 requiresUserInput=node.human_review.requires_user_input,
@@ -537,7 +531,7 @@ def _convert_node_to_output(node: Any) -> WorkflowNodeOutput:
     )
 
 
-def _convert_node_to_input(node: Any) -> WorkflowNodeInput:
+def convert_node_to_input(node: Any) -> WorkflowNodeInput:
     """Convert WorkflowNode to WorkflowNodeInput (recursive)."""
     return WorkflowNodeInput(
         id=node.id,
@@ -556,13 +550,13 @@ def _convert_node_to_input(node: Any) -> WorkflowNodeInput:
             else None
         ),
         config=node.config,
-        children=[_convert_node_to_input(child) for child in node.children],
-        trueSteps=[_convert_node_to_input(child) for child in node.true_steps],
-        falseSteps=[_convert_node_to_input(child) for child in node.false_steps],
+        children=[convert_node_to_input(child) for child in node.children],
+        trueSteps=[convert_node_to_input(child) for child in node.true_steps],
+        falseSteps=[convert_node_to_input(child) for child in node.false_steps],
         choices=[
             RouterChoiceInput(
                 name=choice.name,
-                steps=[_convert_node_to_input(s) for s in choice.steps],
+                steps=[convert_node_to_input(s) for s in choice.steps],
             )
             for choice in node.choices
         ],
@@ -575,7 +569,7 @@ def _convert_node_to_input(node: Any) -> WorkflowNodeInput:
             else None
         ),
         humanReview=(
-            HumanReviewInput(
+            HumanReviewConfig(
                 requiresConfirmation=node.human_review.requires_confirmation,
                 confirmationMessage=node.human_review.confirmation_message,
                 requiresUserInput=node.human_review.requires_user_input,

--- a/registry/src/registry/schemas/workflow_api_schemas.py
+++ b/registry/src/registry/schemas/workflow_api_schemas.py
@@ -8,9 +8,11 @@ All schemas use camelCase for API input/output.
 """
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import Field
+
+from registry_pkgs.models.enums import OnRejectPolicy, OnTimeoutPolicy
 
 from .acl_schema import ResourcePermissions
 from .case_conversion import APIBaseModel
@@ -32,6 +34,51 @@ class LoopConfigInput(APIBaseModel):
 
     maxIterations: int = Field(ge=1, description="Maximum iterations (min: 1)")
     endConditionCel: str | None = Field(None, description="CEL expression for loop termination")
+
+
+# ── Human Review schemas ─────────────────────────────
+
+
+class UserInputFieldSchema(APIBaseModel):
+    """A single field in a HITL ``userInputSchema`` (form definition shown to the user)."""
+
+    name: str
+    fieldType: Literal["string", "number", "boolean", "array"]
+    description: str | None = None
+    required: bool = False
+    defaultValue: Any | None = None
+
+
+class HumanReviewInput(APIBaseModel):
+    """Node-level HITL configuration (per-primitive validity enforced by backend).
+
+    Field × node-type compatibility (mirrors agno):
+
+    - ``requiresConfirmation``: Step / Steps / Loop / Router / Condition
+    - ``requiresUserInput``:    Step / Router only
+    - ``requiresOutputReview``: Step / Router only
+    - ``requiresIterationReview``: Loop only
+    - ``onReject = else_branch``: Condition only (sends execution to falseSteps)
+    """
+
+    requiresConfirmation: bool = False
+    confirmationMessage: str | None = None
+    requiresUserInput: bool = False
+    userInputMessage: str | None = None
+    userInputSchema: list[UserInputFieldSchema] | None = None
+    requiresOutputReview: bool = False
+    outputReviewMessage: str | None = None
+    requiresIterationReview: bool = False
+    iterationReviewMessage: str | None = None
+    onReject: OnRejectPolicy = OnRejectPolicy.SKIP
+    timeoutSeconds: int | None = Field(default=None, gt=0)
+    onTimeout: OnTimeoutPolicy = OnTimeoutPolicy.CANCEL
+
+
+class HumanReviewOutput(HumanReviewInput):
+    """Same shape as ``HumanReviewInput`` — distinct alias for API clarity."""
+
+    pass
 
 
 class RouterChoiceInput(APIBaseModel):
@@ -79,11 +126,9 @@ class WorkflowNodeInput(APIBaseModel):
     )
     conditionCel: str | None = Field(None, description="CEL expression for condition/router nodes")
     loopConfig: LoopConfigInput | None = Field(None, description="Loop configuration for loop nodes")
-    requireApproval: bool = Field(
-        default=False, description="STEP only: hold the run for user approval before executing this node"
-    )
-    approvalTimeoutSeconds: int | None = Field(
-        None, gt=0, description="STEP only: seconds to wait for approval before treating it as a rejection"
+    humanReview: HumanReviewInput | None = Field(
+        default=None,
+        description="HITL configuration",
     )
 
 
@@ -108,8 +153,8 @@ class WorkflowNodeOutput(APIBaseModel):
     choices: list[RouterChoiceOutput] = Field(default_factory=list)
     conditionCel: str | None = None
     loopConfig: LoopConfigInput | None = None
-    requireApproval: bool = False
-    approvalTimeoutSeconds: int | None = None
+    # ``null`` when no HITL configured.
+    humanReview: HumanReviewOutput | None = None
 
 
 # Enable recursive models
@@ -268,11 +313,63 @@ class NodeRunOutput(APIBaseModel):
 WorkflowRunListItem.model_rebuild()
 
 
+class StepRequirementSummary(APIBaseModel):
+    """A single pending HITL requirement awaiting user decision.
+
+    Returned inside :class:`WorkflowRunDetailResponse.pendingRequirements` when the
+    run is ``awaiting_approval``.  Maps 1:1 to agno ``StepRequirement`` fields so the
+    frontend can render the correct decision UI (confirm / user_input form /
+    output_review with edit / route_selection).
+
+    See ``docs/design/workflow-api-design.md`` § StepRequirementSummary.
+    """
+
+    schemaVersion: int = 1
+    stepId: str
+    stepName: str | None = None
+    stepIndex: int | None = None
+    stepType: str | None = None  # step / loop / router / condition / steps
+
+    # Capability flags — drive which UI variant the frontend renders.
+    requiresConfirmation: bool = False
+    requiresUserInput: bool = False
+    requiresOutputReview: bool = False
+    requiresRouteSelection: bool = False
+
+    # User-facing prompts
+    confirmationMessage: str | None = None
+    userInputMessage: str | None = None
+    userInputSchema: list[UserInputFieldSchema] | None = None
+    outputReviewMessage: str | None = None
+    availableChoices: list[str] | None = None
+    allowMultipleSelections: bool = False
+
+    # Post-execution review payload (output_review only)
+    stepOutput: dict[str, Any] | None = None
+    isPostExecution: bool = False
+
+    # Decision results (None until the user resolves)
+    confirmed: bool | None = None
+    rejectionFeedback: str | None = None
+    editedOutput: Any | None = None
+    userInput: dict[str, Any] | None = None
+    selectedChoices: list[str] | None = None
+
+    # Retry + timeout
+    retryCount: int = 0
+    maxRetries: int | None = None
+    timeoutAt: datetime | None = None
+    onTimeout: OnTimeoutPolicy = OnTimeoutPolicy.CANCEL
+    onReject: OnRejectPolicy = OnRejectPolicy.SKIP
+
+
 class WorkflowRunDetailResponse(APIBaseModel):
     """Response schema for workflow run detail"""
 
     id: str
     workflowDefinitionId: str
+    # Version locked at trigger time (snapshot via definitionSnapshot).
+    workflowVersion: int | None = None
     status: str
     triggerSource: str | None = None
     startedAt: datetime
@@ -284,6 +381,9 @@ class WorkflowRunDetailResponse(APIBaseModel):
     parentRunId: str | None = None
     resolvedDependencies: list[ResolvedDependencyInput] = Field(default_factory=list)
     nodeRuns: list[NodeRunOutput] = Field(default_factory=list)
+    # Non-empty iff status == awaiting_approval.  Each element is one
+    # pending requirement; the frontend renders a decision UI per element.
+    pendingRequirements: list[StepRequirementSummary] = Field(default_factory=list)
 
 
 # ==================== Converter Functions ====================
@@ -364,8 +464,38 @@ def _convert_node_to_output(node: Any) -> WorkflowNodeOutput:
             if node.loop_config
             else None
         ),
-        requireApproval=node.require_approval,
-        approvalTimeoutSeconds=node.approval_timeout_seconds,
+        # Serialize the embedded HumanReviewSpec (None when no HITL configured).
+        humanReview=(
+            HumanReviewOutput(
+                requiresConfirmation=node.human_review.requires_confirmation,
+                confirmationMessage=node.human_review.confirmation_message,
+                requiresUserInput=node.human_review.requires_user_input,
+                userInputMessage=node.human_review.user_input_message,
+                userInputSchema=(
+                    [
+                        UserInputFieldSchema(
+                            name=f.name,
+                            fieldType=f.field_type,
+                            description=f.description,
+                            required=f.required,
+                            defaultValue=f.default_value,
+                        )
+                        for f in node.human_review.user_input_schema
+                    ]
+                    if node.human_review.user_input_schema
+                    else None
+                ),
+                requiresOutputReview=node.human_review.requires_output_review,
+                outputReviewMessage=node.human_review.output_review_message,
+                requiresIterationReview=node.human_review.requires_iteration_review,
+                iterationReviewMessage=node.human_review.iteration_review_message,
+                onReject=node.human_review.on_reject,
+                timeoutSeconds=node.human_review.timeout_seconds,
+                onTimeout=node.human_review.on_timeout,
+            )
+            if node.human_review
+            else None
+        ),
     )
 
 
@@ -399,6 +529,7 @@ def convert_to_run_detail(run: Any, node_runs: list[Any]) -> WorkflowRunDetailRe
     return WorkflowRunDetailResponse(
         id=str(run.id),
         workflowDefinitionId=str(run.workflow_definition_id),
+        workflowVersion=run.workflow_version,
         status=run.status.value if hasattr(run.status, "value") else run.status,
         triggerSource=run.trigger_source,
         startedAt=run.started_at,
@@ -417,6 +548,10 @@ def convert_to_run_detail(run: Any, node_runs: list[Any]) -> WorkflowRunDetailRe
             for dep in run.resolved_dependencies
         ],
         nodeRuns=[_convert_node_run_to_output(node_run) for node_run in node_runs],
+        # Surface the serialized agno StepRequirements to the frontend.
+        # Pydantic validates each dict against StepRequirementSummary — extra fields
+        # from agno are tolerated (model_config defaults to extra='ignore').
+        pendingRequirements=[StepRequirementSummary.model_validate(req) for req in (run.pending_requirements or [])],
     )
 
 

--- a/registry/src/registry/schemas/workflow_api_schemas.py
+++ b/registry/src/registry/schemas/workflow_api_schemas.py
@@ -10,12 +10,18 @@ All schemas use camelCase for API input/output.
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import Field
+from pydantic import AliasGenerator, ConfigDict, Field
+from pydantic.alias_generators import to_snake
 
 from registry_pkgs.models.enums import OnRejectPolicy, OnTimeoutPolicy
 
 from .acl_schema import ResourcePermissions
 from .case_conversion import APIBaseModel
+
+_AGNO_RUNTIME_VALIDATION_CONFIG = ConfigDict(
+    alias_generator=AliasGenerator(validation_alias=to_snake),
+    populate_by_name=True,
+)
 
 # ==================== Nested Models ====================
 
@@ -47,6 +53,27 @@ class UserInputFieldSchema(APIBaseModel):
     description: str | None = None
     required: bool = False
     defaultValue: Any | None = None
+
+
+class PendingUserInputField(APIBaseModel):
+    """A user-input field surfaced inside a *pending* HITL requirement.
+
+    This mirrors agno ``UserInputField.to_dict()`` (snake_case keys, Python type
+    names such as ``"str"``/``"int"``/``"dict"``) rather than the frontend
+    authoring contract :class:`UserInputFieldSchema` (camelCase, ``"string"``/
+    ``"number"``). The two are intentionally distinct: this one reflects the live
+    agno runtime payload, so ``fieldType`` is passed through verbatim instead of
+    being coerced into the authoring ``Literal``.
+    """
+
+    model_config = _AGNO_RUNTIME_VALIDATION_CONFIG
+
+    name: str
+    fieldType: str | None = None
+    description: str | None = None
+    required: bool = True
+    value: Any | None = None
+    allowedValues: list[Any] | None = None
 
 
 class HumanReviewInput(APIBaseModel):
@@ -324,6 +351,9 @@ class StepRequirementSummary(APIBaseModel):
     See ``docs/design/workflow-api-design.md`` § StepRequirementSummary.
     """
 
+    # Source dicts come from agno ``StepRequirement.to_dict()`` (snake_case keys).
+    model_config = _AGNO_RUNTIME_VALIDATION_CONFIG
+
     schemaVersion: int = 1
     stepId: str
     stepName: str | None = None
@@ -339,7 +369,7 @@ class StepRequirementSummary(APIBaseModel):
     # User-facing prompts
     confirmationMessage: str | None = None
     userInputMessage: str | None = None
-    userInputSchema: list[UserInputFieldSchema] | None = None
+    userInputSchema: list[PendingUserInputField] | None = None
     outputReviewMessage: str | None = None
     availableChoices: list[str] | None = None
     allowMultipleSelections: bool = False

--- a/registry/src/registry/schemas/workflow_api_schemas.py
+++ b/registry/src/registry/schemas/workflow_api_schemas.py
@@ -10,10 +10,11 @@ All schemas use camelCase for API input/output.
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import AliasGenerator, ConfigDict, Field
+from pydantic import AliasGenerator, ConfigDict, Field, field_validator
 from pydantic.alias_generators import to_snake
 
 from registry_pkgs.models.enums import OnRejectPolicy, OnTimeoutPolicy
+from registry_pkgs.workflows.hitl.field_types import field_type_to_authoring
 
 from .acl_schema import ResourcePermissions
 from .case_conversion import APIBaseModel
@@ -58,12 +59,13 @@ class UserInputFieldSchema(APIBaseModel):
 class PendingUserInputField(APIBaseModel):
     """A user-input field surfaced inside a *pending* HITL requirement.
 
-    This mirrors agno ``UserInputField.to_dict()`` (snake_case keys, Python type
-    names such as ``"str"``/``"int"``/``"dict"``) rather than the frontend
-    authoring contract :class:`UserInputFieldSchema` (camelCase, ``"string"``/
-    ``"number"``). The two are intentionally distinct: this one reflects the live
-    agno runtime payload, so ``fieldType`` is passed through verbatim instead of
-    being coerced into the authoring ``Literal``.
+    Source dicts come from agno ``UserInputField.to_dict()`` (snake_case keys).
+    agno echoes ``field_type`` back verbatim, so the runtime value reflects what
+    the compiler fed it — agno Python type names (``"str"``/``"float"``/...).  We
+    normalise it back to the authoring vocabulary (``"string"``/``"number"``/
+    ``"boolean"``/``"array"``) so the frontend sees one consistent field-type
+    vocabulary on both the authoring side (:class:`UserInputFieldSchema`) and the
+    pending side.
     """
 
     model_config = _AGNO_RUNTIME_VALIDATION_CONFIG
@@ -74,6 +76,12 @@ class PendingUserInputField(APIBaseModel):
     required: bool = True
     value: Any | None = None
     allowedValues: list[Any] | None = None
+
+    @field_validator("fieldType", mode="after")
+    @classmethod
+    def _normalise_field_type(cls, value: str | None) -> str | None:
+        """Map agno's runtime type name back to the authoring vocabulary."""
+        return field_type_to_authoring(value)
 
 
 class HumanReviewInput(APIBaseModel):
@@ -375,7 +383,7 @@ class StepRequirementSummary(APIBaseModel):
     allowMultipleSelections: bool = False
 
     # Post-execution review payload (output_review only)
-    stepOutput: dict[str, Any] | None = None
+    stepOutputPreview: dict[str, Any] | None = Field(default=None, validation_alias="step_output")
     isPostExecution: bool = False
 
     # Decision results (None until the user resolves)

--- a/registry/src/registry/schemas/workflow_schemas.py
+++ b/registry/src/registry/schemas/workflow_schemas.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from registry.schemas.workflow_api_schemas import StepRequirementSummary
 from registry_pkgs.models.enums import RequirementResolution
 
 
@@ -140,6 +141,9 @@ class RunStatusResponse(BaseModel):
     error_summary: str | None
     parent_run_id: str | None
     node_runs: list[NodeRunSummary]
+    # Non-empty when the run is awaiting_approval so the frontend can render
+    # the decision UI without making a second request to /runs/{run_id}.
+    pendingRequirements: list[StepRequirementSummary] = Field(default_factory=list)
 
 
 class RunSummary(BaseModel):

--- a/registry/src/registry/schemas/workflow_schemas.py
+++ b/registry/src/registry/schemas/workflow_schemas.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, Field
+
+from registry_pkgs.models.enums import RequirementResolution
 
 
 class TriggerRunRequest(BaseModel):
@@ -43,15 +46,33 @@ class RetryRequest(BaseModel):
     from_node_id: str = Field(..., description="Node ID to restart execution from")
 
 
-class ApproveRequest(BaseModel):
-    """Request body for the approval endpoint.
+class ResolveRequirementRequest(BaseModel):
+    """Request body for ``POST /approve``.
 
-    Attributes:
-        approved: ``True`` approves the gate and resumes execution; ``False``
-                  rejects it, failing the node per its ``on_error`` policy.
+    Carries a decision aligned 1:1 with agno's
+    ``StepRequirement.{confirm, reject, edit, set_user_input, set_selected_choices}``
+    methods.
     """
 
-    approved: bool = Field(..., description="True to approve and continue; False to reject")
+    stepId: str = Field(..., description="The pending requirement's step_id (from GET /runs/{id})")
+    resolution: RequirementResolution = Field(..., description="confirm / reject / edit / user_input / route_select")
+    feedback: str | None = Field(None, description="Optional reject feedback (passed to agno's on_reject=retry agent)")
+    editedOutput: Any | None = Field(None, description="EDIT resolution only — replaces the original step_output")
+    userInput: dict[str, Any] | None = Field(
+        None, description="USER_INPUT resolution only — values matching user_input_schema"
+    )
+    selectedChoices: list[str] | None = Field(
+        None, description="ROUTE_SELECT resolution only — chosen router choice name(s)"
+    )
+
+
+class ResolveRequirementResponse(BaseModel):
+    """Response for ``POST /approve``."""
+
+    runId: str = Field(..., description="The WorkflowRun ID")
+    status: str = Field(..., description="Run status after the decision was applied")
+    resolvedStepId: str = Field(..., description="The step_id of the requirement just resolved")
+    message: str = Field(..., description="Human-readable summary")
 
 
 class DirectiveResponse(BaseModel):
@@ -67,9 +88,6 @@ class DirectiveResponse(BaseModel):
     run_id: str
     status: str
     message: str
-
-
-# ── Status query responses ────────────────────────────────────────────────────
 
 
 class NodeRunSummary(BaseModel):

--- a/registry/src/registry/schemas/workflow_schemas.py
+++ b/registry/src/registry/schemas/workflow_schemas.py
@@ -43,6 +43,17 @@ class RetryRequest(BaseModel):
     from_node_id: str = Field(..., description="Node ID to restart execution from")
 
 
+class ApproveRequest(BaseModel):
+    """Request body for the approval endpoint.
+
+    Attributes:
+        approved: ``True`` approves the gate and resumes execution; ``False``
+                  rejects it, failing the node per its ``on_error`` policy.
+    """
+
+    approved: bool = Field(..., description="True to approve and continue; False to reject")
+
+
 class DirectiveResponse(BaseModel):
     """Unified response returned by all four control endpoints.
 

--- a/registry/src/registry/services/access_control_service.py
+++ b/registry/src/registry/services/access_control_service.py
@@ -359,6 +359,58 @@ class ACLService:
             logger.error(f"Error fetching permissions for user {user_id} on {resource_type}/{resource_id}: {e}")
             return ResourcePermissions()
 
+    async def get_user_permissions_for_resources(
+        self,
+        user_id: PydanticObjectId,
+        resource_type: str,
+        resource_ids: list[PydanticObjectId],
+    ) -> dict[PydanticObjectId, ResourcePermissions]:
+        """Batch variant of ``get_user_permissions_for_resource``.
+
+        Single ``$in`` MongoDB query covers every requested ``resource_id``,
+        eliminating N+1 round-trips when callers (e.g. list endpoints) need
+        per-resource permissions for many resources at once.
+
+        Missing resources are returned with an empty ``ResourcePermissions``
+        (mirrors the single-resource fallback) so callers can index without
+        ``KeyError`` checks.
+        """
+        result: dict[PydanticObjectId, ResourcePermissions] = {rid: ResourcePermissions() for rid in resource_ids}
+        if not resource_ids:
+            return result
+        try:
+            acl_entries = (
+                await ExtendedAclEntry.find(
+                    {
+                        "resourceType": resource_type,
+                        "resourceId": {"$in": resource_ids},
+                        "$or": [
+                            {"principalType": PrincipalType.USER.value, "principalId": user_id},
+                            {"principalType": PrincipalType.PUBLIC.value, "principalId": None},
+                        ],
+                    }
+                )
+                .sort([("permBits", -1)])
+                .to_list()
+            )
+        except Exception as e:
+            logger.error(f"Error batch-fetching permissions for user {user_id} on {resource_type}: {e}")
+            return result
+
+        # Entries are sorted by permBits desc → the first one we see per
+        # resource is the winner (matches single-resource precedence).
+        for entry in acl_entries:
+            rid = entry.resourceId
+            if rid in result and not any((result[rid].VIEW, result[rid].EDIT, result[rid].DELETE, result[rid].SHARE)):
+                bits = int(entry.permBits)
+                result[rid] = ResourcePermissions(
+                    VIEW=bool(bits & PermissionBits.VIEW),
+                    EDIT=bool(bits & PermissionBits.EDIT),
+                    DELETE=bool(bits & PermissionBits.DELETE),
+                    SHARE=bool(bits & PermissionBits.SHARE),
+                )
+        return result
+
     async def check_user_permission(
         self,
         user_id: PydanticObjectId,

--- a/registry/src/registry/services/workflow_control_service.py
+++ b/registry/src/registry/services/workflow_control_service.py
@@ -308,7 +308,6 @@ class WorkflowControlService:
         if new_status == run.status:
             return run
 
-        run.status = new_status
         run.pending_directive = WorkflowDirective.CANCEL
         await run.save()
         self._queue.put(run_id, WorkflowDirective.CANCEL)

--- a/registry/src/registry/services/workflow_control_service.py
+++ b/registry/src/registry/services/workflow_control_service.py
@@ -19,13 +19,18 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
+from datetime import UTC, datetime
 from typing import Any, Protocol
 
+from agno.run.cancel import acancel_run as agno_acancel_run
 from beanie import PydanticObjectId
 from fastapi import HTTPException
 
+from registry.utils.crypto_utils import generate_service_jwt
+from registry_pkgs.database.mongodb import MongoDB
 from registry_pkgs.models.enums import (
     NodeRunStatus,
+    RequirementResolution,
     ResolvedDependencyResolution,
     WorkflowDirective,
     WorkflowNodeType,
@@ -50,6 +55,14 @@ def _log_task_exception(task: asyncio.Task) -> None:
         logger.error("Background workflow task raised unhandled exception: %s", exc, exc_info=exc)
 
 
+def _fire_background(coro: Any) -> asyncio.Task:
+    """Fire-and-forget a runner coroutine — without the callback Python swallows
+    any exception silently, so always go through this helper."""
+    task = asyncio.create_task(coro)
+    task.add_done_callback(_log_task_exception)
+    return task
+
+
 class _HasRun(Protocol):
     """Structural interface for WorkflowRunner — avoids importing agno at module load time."""
 
@@ -63,6 +76,16 @@ class _HasRun(Protocol):
         existing_run_id: str,
         injected_outputs: dict[str, dict[str, Any]] | None = None,
     ) -> tuple[WorkflowRun, list[NodeRun]]:
+        pass
+
+    async def continue_run(
+        self,
+        *,
+        existing_run_id: str,
+        registry_token: str,
+        user_id: str | None,
+    ) -> tuple[WorkflowRun, list[NodeRun]]:
+        """Resume a run that hit an HITL pause after the user decided."""
         pass
 
 
@@ -129,12 +152,13 @@ class WorkflowControlService:
             status=WorkflowRunStatus.PENDING,
             trigger_source="api",
             initial_input={"user_text": user_text},
+            triggering_user_id=user_id,
         )
         await run.insert()
         logger.info("WorkflowRun %s created for definition %s", run.id, workflow_definition_id)
 
         runner = self._runner_factory()
-        task = asyncio.create_task(  # fire-and-forget; HTTP response returns immediately
+        _fire_background(
             runner.run(
                 workflow_definition_id,
                 user_text,
@@ -143,7 +167,6 @@ class WorkflowControlService:
                 existing_run_id=str(run.id),
             )
         )
-        task.add_done_callback(_log_task_exception)
         return run
 
     async def send_pause(self, workflow_definition_id: str, run_id: str) -> WorkflowRun:
@@ -183,31 +206,97 @@ class WorkflowControlService:
         logger.info("WorkflowRun %s resume requested", run_id)
         return run
 
-    async def send_approve(self, workflow_definition_id: str, run_id: str) -> WorkflowRun:
-        """Approve a run that is holding at an approval gate (AWAITING_APPROVAL → RUNNING)."""
-        run = await self._load_run(workflow_definition_id, run_id)
-        _apply(run, WorkflowDirective.APPROVE)  # raises 400 if not AWAITING_APPROVAL
-        run.pending_directive = WorkflowDirective.APPROVE
-        await run.save()
-        self._queue.put(run_id, WorkflowDirective.APPROVE)
-        logger.info("WorkflowRun %s approval granted", run_id)
-        return run
+    async def resolve_requirement(
+        self,
+        workflow_definition_id: str,
+        run_id: str,
+        *,
+        step_id: str,
+        resolution: RequirementResolution,
+        feedback: str | None = None,
+        edited_output: Any | None = None,
+        user_input: dict[str, Any] | None = None,
+        selected_choices: list[str] | None = None,
+    ) -> WorkflowRun:
+        """Resolve one pending requirement on an AWAITING_APPROVAL run.
 
-    async def send_reject(self, workflow_definition_id: str, run_id: str) -> WorkflowRun:
-        """Reject a run holding at an approval gate; the node fails per its on_error policy."""
+        1. **Validate**: run must exist + be in AWAITING_APPROVAL + have a matching
+           pending requirement with ``confirmed is None``.
+        2. **Compatibility check**: the chosen ``resolution`` must match the
+           requirement's capability flags (e.g. you can't send ``USER_INPUT`` to a
+           requirement that only needs confirmation).
+        3. **Atomic decision write**: uses MongoDB ``array_filters`` to update
+           the single matching pending_requirement element in place.  Concurrent
+           decisions on *different* stepIds are independent; concurrent decisions
+           on the *same* stepId result in 409 (only one wins).
+        4. **Trigger BackgroundTask continue_run**: the runner re-builds the agno
+           Workflow on whichever pod handles the task and calls ``acontinue_run``.
+           The HTTP request returns immediately — no waiting for the actual resume.
+        """
         run = await self._load_run(workflow_definition_id, run_id)
-        _apply(run, WorkflowDirective.REJECT)  # raises 400 if not AWAITING_APPROVAL
-        run.pending_directive = WorkflowDirective.REJECT
-        await run.save()
-        self._queue.put(run_id, WorkflowDirective.REJECT)
-        logger.info("WorkflowRun %s approval rejected", run_id)
-        return run
+
+        if run.status != WorkflowRunStatus.AWAITING_APPROVAL:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Run is not awaiting approval (current status: {run.status}). "
+                    "Refresh and verify the run state before retrying."
+                ),
+            )
+
+        target = _find_pending_requirement(run, step_id)
+        _validate_resolution_compatibility(target, resolution)
+
+        update_fields = _build_resolution_update(resolution, feedback, edited_output, user_input, selected_choices)
+        await _atomic_write_decision(run, step_id, update_fields)
+
+        logger.info("WorkflowRun %s requirement %s resolved as %s", run_id, step_id, resolution.value)
+
+        self._trigger_resume(run)
+
+        return await self._load_run(workflow_definition_id, run_id)
+
+    def _trigger_resume(self, run: WorkflowRun) -> None:
+        """Fire ``continue_run`` in the background to resume an AWAITING_APPROVAL run.
+
+        Shared by ``resolve_requirement`` (user decided) and ``get_run_status``
+        (a pending requirement timed out). The runner re-builds the agno Workflow
+        from the snapshot and calls ``acontinue_run`` — which both applies the
+        user's decision and, for any requirement past its ``timeout_at``, applies
+        agno's ``on_timeout`` policy. ``continue_run`` performs a CAS so duplicate
+        triggers (e.g. concurrent polls) are harmless — only one wins.
+        """
+        if self._runner_factory is None:
+            logger.error(
+                "_trigger_resume: runner_factory not configured — cannot continue_run for %s",
+                run.id,
+            )
+            return
+        token = _prepare_resume_credentials(run)
+        runner = self._runner_factory()
+        _fire_background(
+            runner.continue_run(
+                existing_run_id=str(run.id),
+                registry_token=token,
+                user_id=run.triggering_user_id,
+            )
+        )
 
     async def send_cancel(self, workflow_definition_id: str, run_id: str) -> WorkflowRun:
-        """Cancel a RUNNING or PAUSED workflow run.
+        """Cancel a RUNNING / PAUSED / AWAITING_APPROVAL workflow run.
 
-        Idempotent: if the run is already CANCELLED, returns successfully without
-        side effects.
+        Dual-signal design:
+        1. ``WorkflowRun.pending_directive = CANCEL`` (durable truth source).
+        2. ``DirectiveQueue.put(CANCEL)`` (in-process fast path for wait-loop).
+        3. ``agno.run.cancel.acancel_run(run_id)`` — routes through
+           ``MongoBackedCancellationManager`` which ALSO writes ``pending_directive=CANCEL``
+           so any agno-internal code path that calls ``raise_if_cancelled`` also sees it.
+
+        The triple-redundancy protects against #7929 (agno acontinue_run +
+        external_execution bypasses raise_if_cancelled) and ensures the wait-loop
+        wrapper has a safety net.
+
+        Idempotent: cancelling an already-cancelled run returns 200.
         """
         run = await self._load_run(workflow_definition_id, run_id)
         if run.pending_directive == WorkflowDirective.CANCEL:
@@ -220,6 +309,14 @@ class WorkflowControlService:
         run.pending_directive = WorkflowDirective.CANCEL
         await run.save()
         self._queue.put(run_id, WorkflowDirective.CANCEL)
+
+        # Reverse-bridge to agno's cancellation manager so any in-flight agno code
+        # path (continue_run, external_execution, streaming) also flips.
+        try:
+            await agno_acancel_run(run_id)
+        except Exception as exc:
+            logger.warning("WorkflowRun %s: agno acancel_run bridge failed: %s", run_id, exc)
+
         logger.info("WorkflowRun %s cancel requested", run_id)
 
         return run
@@ -323,9 +420,7 @@ class WorkflowControlService:
 
         user_text: str = (parent_run.initial_input or {}).get("user_text", "")
         runner = self._runner_factory()
-
-        # fire-and-forget; HTTP response returns immediately
-        task = asyncio.create_task(
+        _fire_background(
             runner.run(
                 str(parent_run.workflow_definition_id),
                 user_text,
@@ -335,7 +430,6 @@ class WorkflowControlService:
                 injected_outputs=injected_outputs,
             )
         )
-        task.add_done_callback(_log_task_exception)
         return child_run
 
     async def get_run_status(
@@ -351,8 +445,18 @@ class WorkflowControlService:
 
         Raises:
             HTTPException(404): Run not found or belongs to a different workflow.
+
+        Side effect: if the run is AWAITING_APPROVAL and a pending requirement has
+        passed its ``timeout_at``, this lazily nudges ``continue_run`` so agno can
+        apply the gate's ``on_timeout`` policy (agno checks timeouts only at
+        continue-time, never via a background timer). The returned run still shows
+        AWAITING_APPROVAL — the resume completes asynchronously and surfaces on the
+        next poll.
         """
         run = await self._load_run(workflow_definition_id, run_id)
+        if run.status == WorkflowRunStatus.AWAITING_APPROVAL and _has_timed_out_requirement(run):
+            logger.info("WorkflowRun %s has a timed-out requirement — nudging continue_run", run_id)
+            self._trigger_resume(run)
         node_runs = await NodeRun.find(NodeRun.workflow_run_id == run.id).to_list()
         return run, node_runs
 
@@ -403,3 +507,190 @@ def _apply(run: WorkflowRun, directive: WorkflowDirective) -> WorkflowRunStatus:
         return WorkflowRunStateMachine.apply_directive(run.status, directive)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _find_pending_requirement(run: WorkflowRun, step_id: str) -> dict[str, Any]:
+    """Locate the still-unresolved requirement (``confirmed is None``) for
+    ``step_id``, or raise 404 if it's unknown or already resolved."""
+    target = next(
+        (r for r in run.pending_requirements if r.get("step_id") == step_id and r.get("confirmed") is None),
+        None,
+    )
+    if not target:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No pending requirement with step_id={step_id!r} (already resolved or unknown)",
+        )
+    return target
+
+
+def _has_timed_out_requirement(run: WorkflowRun) -> bool:
+    """True if any still-unresolved pending requirement has passed its deadline.
+
+    agno serializes ``StepRequirement.timeout_at`` as an ISO-8601 string (or omits
+    it when no timeout was configured). We only detect the expiry here — agno
+    applies the actual ``on_timeout`` policy (cancel / skip / approve) itself the
+    next time ``continue_run`` runs, so detecting is enough to nudge a resume.
+    """
+    now = datetime.now(UTC)
+    for req in run.pending_requirements:
+        if req.get("confirmed") is not None:
+            continue
+        raw = req.get("timeout_at")
+        if not raw:
+            continue
+        try:
+            deadline = datetime.fromisoformat(raw)
+        except (TypeError, ValueError):
+            continue
+        if deadline.tzinfo is None:
+            deadline = deadline.replace(tzinfo=UTC)
+        if now >= deadline:
+            return True
+    return False
+
+
+async def _atomic_write_decision(
+    run: WorkflowRun,
+    step_id: str,
+    update_fields: dict[str, Any],
+) -> None:
+    """Write the user's decision into ``pending_requirements`` atomically.
+
+    Three concurrent-safety invariants enforced in a single MongoDB call:
+      1. Top-level filter ``status == AWAITING_APPROVAL`` — prevents writing a
+         decision to a run that another caller has already advanced.
+      2. ``array_filters`` matches only the element whose ``confirmed is None``
+         — a second concurrent decision on the same step_id finds nothing.
+      3. ``modified_count == 0`` ⇒ 409 — either #1 or #2 failed; the caller
+         must refresh and retry.
+
+    Uses raw motor (rather than Beanie) because array_filters is not yet
+    surfaced cleanly through the ODM.
+    """
+    set_payload = {f"pending_requirements.$[elem].{k}": v for k, v in update_fields.items()}
+    db = MongoDB.get_database()
+    collection = db.get_collection(WorkflowRun.get_settings().name)
+    raw_result = await collection.update_one(
+        {"_id": run.id, "status": WorkflowRunStatus.AWAITING_APPROVAL.value},
+        {"$set": set_payload},
+        array_filters=[{"elem.step_id": step_id, "elem.confirmed": None}],
+    )
+    if raw_result.modified_count == 0:
+        raise HTTPException(
+            status_code=409,
+            detail="Requirement was concurrently resolved or run state changed; refresh and retry",
+        )
+
+
+def _prepare_resume_credentials(run: WorkflowRun) -> str:
+    """Re-mint a short-lived service JWT representing the triggering user so
+    downstream MCP/A2A calls inside the resumed step authenticate as them.
+
+    We persist only non-sensitive identity (user_id / username / scopes) on the
+    run — never the raw bearer token — and re-sign a fresh token at resume time.
+    Returns ``""`` when no ``triggering_user_id`` was captured (e.g. script-driven
+    runs); auth-required steps will then 401, which is non-fatal to the resume.
+    """
+    if not run.triggering_user_id:
+        return ""
+    return generate_service_jwt(
+        user_id=run.triggering_user_id,
+        username=run.triggering_username,
+        scopes=run.triggering_scopes or [],
+    )
+
+
+def _validate_resolution_compatibility(
+    requirement: dict[str, Any],
+    resolution: RequirementResolution,
+) -> None:
+    """Reject decisions that don't match the requirement's capability flags.
+
+    Examples:
+    - ``USER_INPUT`` resolution on a requirement that only needs confirmation → 400
+    - ``EDIT`` resolution on a requirement whose step has not yet executed → 400
+    - ``ROUTE_SELECT`` resolution on a non-Router requirement → 400
+    """
+    if resolution in (RequirementResolution.CONFIRM, RequirementResolution.REJECT):
+        # confirm / reject are always valid (they're the base agno verbs).
+        return
+
+    if resolution == RequirementResolution.EDIT:
+        if not requirement.get("requires_output_review"):
+            raise HTTPException(
+                status_code=400,
+                detail="EDIT resolution is only valid for output_review requirements",
+            )
+        if not requirement.get("is_post_execution"):
+            raise HTTPException(
+                status_code=400,
+                detail="EDIT resolution requires the step to have executed already",
+            )
+        return
+
+    if resolution == RequirementResolution.USER_INPUT:
+        if not requirement.get("requires_user_input"):
+            raise HTTPException(
+                status_code=400,
+                detail="USER_INPUT resolution is only valid for requirements with requires_user_input",
+            )
+        return
+
+    if resolution == RequirementResolution.ROUTE_SELECT:
+        if not requirement.get("requires_route_selection"):
+            raise HTTPException(
+                status_code=400,
+                detail="ROUTE_SELECT resolution is only valid for router route-selection requirements",
+            )
+        return
+
+
+def _build_resolution_update(
+    resolution: RequirementResolution,
+    feedback: str | None,
+    edited_output: Any | None,
+    user_input: dict[str, Any] | None,
+    selected_choices: list[str] | None,
+) -> dict[str, Any]:
+    """Translate the user's decision into the dict fields agno's StepRequirement consumes.
+
+    Mirrors the methods on ``agno.workflow.types.StepRequirement``
+    (confirm / reject / edit / set_user_input / set_selected_choices) but written
+    as a dict mutation we can pass straight to MongoDB ``$set``.
+    """
+    if resolution == RequirementResolution.CONFIRM:
+        return {"confirmed": True}
+
+    if resolution == RequirementResolution.REJECT:
+        update: dict[str, Any] = {"confirmed": False}
+        if feedback is not None:
+            update["rejection_feedback"] = feedback
+        return update
+
+    if resolution == RequirementResolution.EDIT:
+        if edited_output is None:
+            raise HTTPException(
+                status_code=400,
+                detail="EDIT resolution requires non-null edited_output",
+            )
+        return {"confirmed": True, "edited_output": edited_output}
+
+    if resolution == RequirementResolution.USER_INPUT:
+        if user_input is None:
+            raise HTTPException(
+                status_code=400,
+                detail="USER_INPUT resolution requires non-null user_input",
+            )
+        # confirmed=True signals agno to proceed; user_input is consumed by the executor.
+        return {"confirmed": True, "user_input": user_input}
+
+    if resolution == RequirementResolution.ROUTE_SELECT:
+        if not selected_choices:
+            raise HTTPException(
+                status_code=400,
+                detail="ROUTE_SELECT resolution requires non-empty selected_choices",
+            )
+        return {"confirmed": True, "selected_choices": selected_choices}
+
+    raise HTTPException(status_code=400, detail=f"Unknown resolution: {resolution!r}")

--- a/registry/src/registry/services/workflow_control_service.py
+++ b/registry/src/registry/services/workflow_control_service.py
@@ -247,7 +247,9 @@ class WorkflowControlService:
         target = _find_pending_requirement(run, step_id)
         _validate_resolution_compatibility(target, resolution)
 
-        update_fields = _build_resolution_update(resolution, feedback, edited_output, user_input, selected_choices)
+        update_fields = _build_resolution_update(
+            target, resolution, feedback, edited_output, user_input, selected_choices
+        )
         await _atomic_write_decision(run, step_id, update_fields)
 
         logger.info("WorkflowRun %s requirement %s resolved as %s", run_id, step_id, resolution.value)
@@ -306,6 +308,7 @@ class WorkflowControlService:
         if new_status == run.status:
             return run
 
+        run.status = new_status
         run.pending_directive = WorkflowDirective.CANCEL
         await run.save()
         self._queue.put(run_id, WorkflowDirective.CANCEL)
@@ -647,6 +650,7 @@ def _validate_resolution_compatibility(
 
 
 def _build_resolution_update(
+    target: dict[str, Any],
     resolution: RequirementResolution,
     feedback: str | None,
     edited_output: Any | None,
@@ -683,7 +687,20 @@ def _build_resolution_update(
                 detail="USER_INPUT resolution requires non-null user_input",
             )
         # confirmed=True signals agno to proceed; user_input is consumed by the executor.
-        return {"confirmed": True, "user_input": user_input}
+        update = {"confirmed": True, "user_input": user_input}
+        # agno's StepRequirement.needs_user_input checks schema field values,
+        # so we must mirror the user_input dict back into the schema entries.
+        schema = target.get("user_input_schema")
+        if schema:
+            updated_schema = []
+            for field in schema:
+                field_copy = dict(field)
+                field_name = field_copy.get("name")
+                if field_name in user_input:
+                    field_copy["value"] = user_input[field_name]
+                updated_schema.append(field_copy)
+            update["user_input_schema"] = updated_schema
+        return update
 
     if resolution == RequirementResolution.ROUTE_SELECT:
         if not selected_choices:

--- a/registry/src/registry/services/workflow_control_service.py
+++ b/registry/src/registry/services/workflow_control_service.py
@@ -183,6 +183,26 @@ class WorkflowControlService:
         logger.info("WorkflowRun %s resume requested", run_id)
         return run
 
+    async def send_approve(self, workflow_definition_id: str, run_id: str) -> WorkflowRun:
+        """Approve a run that is holding at an approval gate (AWAITING_APPROVAL → RUNNING)."""
+        run = await self._load_run(workflow_definition_id, run_id)
+        _apply(run, WorkflowDirective.APPROVE)  # raises 400 if not AWAITING_APPROVAL
+        run.pending_directive = WorkflowDirective.APPROVE
+        await run.save()
+        self._queue.put(run_id, WorkflowDirective.APPROVE)
+        logger.info("WorkflowRun %s approval granted", run_id)
+        return run
+
+    async def send_reject(self, workflow_definition_id: str, run_id: str) -> WorkflowRun:
+        """Reject a run holding at an approval gate; the node fails per its on_error policy."""
+        run = await self._load_run(workflow_definition_id, run_id)
+        _apply(run, WorkflowDirective.REJECT)  # raises 400 if not AWAITING_APPROVAL
+        run.pending_directive = WorkflowDirective.REJECT
+        await run.save()
+        self._queue.put(run_id, WorkflowDirective.REJECT)
+        logger.info("WorkflowRun %s approval rejected", run_id)
+        return run
+
     async def send_cancel(self, workflow_definition_id: str, run_id: str) -> WorkflowRun:
         """Cancel a RUNNING or PAUSED workflow run.
 
@@ -283,6 +303,9 @@ class WorkflowControlService:
 
         child_run = WorkflowRun(
             workflow_definition_id=parent_run.workflow_definition_id,
+            # Inherit the parent's version so the retry replays the same definition
+            # snapshot deterministically and reports a consistent workflow_version.
+            workflow_version=parent_run.workflow_version,
             status=WorkflowRunStatus.PENDING,
             trigger_source="retry",
             initial_input=parent_run.initial_input,

--- a/registry/src/registry/services/workflow_service.py
+++ b/registry/src/registry/services/workflow_service.py
@@ -12,7 +12,11 @@ from typing import Any
 from uuid import uuid4
 
 from beanie import PydanticObjectId
+from fastapi import HTTPException
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
 
+from registry_pkgs.database.decorators import get_current_session, use_transaction
 from registry_pkgs.database.mongodb import MongoDB
 from registry_pkgs.models.enums import WorkflowRunStatus
 from registry_pkgs.models.workflow import (
@@ -203,6 +207,7 @@ class WorkflowService:
             logger.exception("Error creating workflow")
             raise
 
+    @use_transaction
     async def update_workflow(
         self,
         workflow_id: str,
@@ -219,7 +224,8 @@ class WorkflowService:
             Updated WorkflowDefinition document
 
         Raises:
-            ValueError: If workflow not found or validation fails
+            ValueError: If workflow not found or validation fails.
+            HTTPException(409): If the workflow was modified concurrently.
         """
         try:
             # Get existing workflow
@@ -234,41 +240,58 @@ class WorkflowService:
             # Build and validate the update FIRST. Node conversion runs the model-level
             # shape validators, so an invalid update raises here — before anything is
             # written — and can never leave an orphan/duplicate version-history row.
-            update_data: dict[str, Any] = {}
+            update_fields: dict[str, Any] = {
+                "version": previous_version + 1,
+                "updated_at": datetime.now(UTC),
+            }
 
             if data.name is not None:
-                update_data["name"] = data.name
+                update_fields["name"] = data.name
 
             if data.description is not None:
-                update_data["description"] = data.description
+                update_fields["description"] = data.description
 
             if data.nodes is not None:
-                update_data["nodes"] = [self._convert_api_node_to_model(node) for node in data.nodes]
+                update_fields["nodes"] = [
+                    self._convert_api_node_to_model(node).model_dump(mode="json") for node in data.nodes
+                ]
 
-            # Bump version and timestamp
-            update_data["version"] = previous_version + 1
-            update_data["updated_at"] = datetime.now(UTC)
+            session = get_current_session()
+            collection = MongoDB.get_database().get_collection(WorkflowDefinition.get_settings().name)
 
-            # Apply updates
-            for key, value in update_data.items():
-                setattr(workflow, key, value)
+            updated_doc = await collection.find_one_and_update(
+                {"_id": workflow.id, "version": previous_version},
+                {"$set": update_fields},
+                return_document=ReturnDocument.AFTER,
+                session=session,
+            )
+            if updated_doc is None:
+                raise HTTPException(
+                    status_code=409,
+                    detail="Workflow was modified concurrently; re-fetch and retry",
+                )
 
-            # Persist the new version (triggers validation), then archive the prior
-            # definition as history. Ordering save-before-snapshot guarantees we never
-            # archive a version that did not actually take effect.
-            await workflow.save()
-            await WorkflowVersion(
-                workflow_id=workflow.id,
-                version=previous_version,
-                definition=previous_definition,
-                checksum=previous_checksum,
-                created_at=previous_updated_at,
-            ).insert()
+            # Archive the prior definition atomically with the bump.  The unique
+            # (workflow_id, version) index is the backstop: a racing archive of the
+            # same version raises DuplicateKeyError → 409.
+            try:
+                await WorkflowVersion(
+                    workflow_id=workflow.id,
+                    version=previous_version,
+                    definition=previous_definition,
+                    checksum=previous_checksum,
+                    created_at=previous_updated_at,
+                ).insert(session=session)
+            except DuplicateKeyError as exc:
+                raise HTTPException(
+                    status_code=409,
+                    detail="Workflow version already archived; concurrent update detected",
+                ) from exc
 
-            logger.info(f"Updated workflow {workflow_id}: {workflow.name} (version {workflow.version})")
-            return workflow
+            logger.info(f"Updated workflow {workflow_id}: version {previous_version} → {update_fields['version']}")
+            return await WorkflowDefinition.get(workflow.id, session=session)
 
-        except ValueError:
+        except (ValueError, HTTPException):
             raise
         except Exception:
             logger.exception("Error updating workflow %s", workflow_id)

--- a/registry/src/registry/services/workflow_service.py
+++ b/registry/src/registry/services/workflow_service.py
@@ -4,6 +4,7 @@ Workflow Service - Business logic for Workflow Management API
 This service handles all workflow-related operations using MongoDB and Beanie ODM.
 """
 
+import hashlib
 import logging
 import re
 from datetime import UTC, datetime
@@ -13,7 +14,13 @@ from uuid import uuid4
 from beanie import PydanticObjectId
 
 from registry_pkgs.models.enums import WorkflowRunStatus
-from registry_pkgs.models.workflow import NodeRun, WorkflowDefinition, WorkflowNode, WorkflowRun
+from registry_pkgs.models.workflow import (
+    NodeRun,
+    WorkflowDefinition,
+    WorkflowNode,
+    WorkflowRun,
+    WorkflowVersion,
+)
 
 from ..schemas.workflow_api_schemas import WorkflowCreateRequest, WorkflowUpdateRequest
 
@@ -23,11 +30,17 @@ logger = logging.getLogger(__name__)
 class WorkflowService:
     """Service for Workflow operations"""
 
+    @staticmethod
+    def _checksum(definition_json: str) -> str:
+        """Return the sha256 hex digest of a definition's JSON serialization."""
+        return hashlib.sha256(definition_json.encode("utf-8")).hexdigest()
+
     async def list_workflows(
         self,
         query: str | None = None,
         page: int = 1,
         per_page: int = 20,
+        accessible_workflow_ids: list[str] | None = None,
     ) -> tuple[list[WorkflowDefinition], int]:
         """
         List workflows with optional filtering and pagination.
@@ -36,6 +49,8 @@ class WorkflowService:
             query: Free-text search across workflow name, description
             page: Page number (validated by router)
             per_page: Items per page (validated by router)
+            accessible_workflow_ids: When provided, restrict results to these workflow IDs
+                (ACL VIEW filter). An empty list yields no results.
 
         Returns:
             Tuple of (workflows list, total count)
@@ -43,6 +58,10 @@ class WorkflowService:
         try:
             # Build query filters
             filters: dict[str, Any] = {}
+
+            # Restrict to ACL-accessible workflows
+            if accessible_workflow_ids is not None:
+                filters["_id"] = {"$in": [PydanticObjectId(wid) for wid in accessible_workflow_ids]}
 
             # Free-text search
             if query:
@@ -162,7 +181,15 @@ class WorkflowService:
             # Get existing workflow
             workflow = await self.get_workflow_by_id(workflow_id)
 
-            # Update fields if provided
+            # Capture the current version's definition for history BEFORE mutating it.
+            previous_version = workflow.version
+            previous_definition = workflow.model_dump(mode="json")
+            previous_checksum = self._checksum(workflow.model_dump_json())
+            previous_updated_at = workflow.updated_at
+
+            # Build and validate the update FIRST. Node conversion runs the model-level
+            # shape validators, so an invalid update raises here — before anything is
+            # written — and can never leave an orphan/duplicate version-history row.
             update_data: dict[str, Any] = {}
 
             if data.name is not None:
@@ -174,23 +201,67 @@ class WorkflowService:
             if data.nodes is not None:
                 update_data["nodes"] = [self._convert_api_node_to_model(node) for node in data.nodes]
 
-            # Always update the timestamp
+            # Bump version and timestamp
+            update_data["version"] = previous_version + 1
             update_data["updated_at"] = datetime.now(UTC)
 
             # Apply updates
             for key, value in update_data.items():
                 setattr(workflow, key, value)
 
-            # Save to database (this will trigger Pydantic validation)
+            # Persist the new version (triggers validation), then archive the prior
+            # definition as history. Ordering save-before-snapshot guarantees we never
+            # archive a version that did not actually take effect.
             await workflow.save()
+            await WorkflowVersion(
+                workflow_id=workflow.id,
+                version=previous_version,
+                definition=previous_definition,
+                checksum=previous_checksum,
+                created_at=previous_updated_at,
+            ).insert()
 
-            logger.info(f"Updated workflow {workflow_id}: {workflow.name}")
+            logger.info(f"Updated workflow {workflow_id}: {workflow.name} (version {workflow.version})")
             return workflow
 
         except ValueError:
             raise
         except Exception:
             logger.exception("Error updating workflow %s", workflow_id)
+            raise
+
+    async def list_versions(self, workflow_id: str) -> list[dict[str, Any]]:
+        """
+        List all versions of a workflow (history + current), oldest first.
+
+        Returns:
+            List of {version, created_at, checksum} dicts.
+
+        Raises:
+            ValueError: If workflow not found.
+        """
+        try:
+            workflow = await self.get_workflow_by_id(workflow_id)
+
+            history = await WorkflowVersion.find({"workflow_id": workflow.id}).sort("version").to_list()
+            versions: list[dict[str, Any]] = [
+                {"version": v.version, "created_at": v.created_at, "checksum": v.checksum} for v in history
+            ]
+
+            # Append the current (latest) version, which is not in the history collection.
+            versions.append(
+                {
+                    "version": workflow.version,
+                    "created_at": workflow.updated_at,
+                    "checksum": self._checksum(workflow.model_dump_json()),
+                }
+            )
+            return versions
+
+        except ValueError:
+            raise
+        except Exception:
+            logger.exception("Error listing versions for workflow %s", workflow_id)
             raise
 
     async def delete_workflow(self, workflow_id: str) -> bool:
@@ -222,6 +293,9 @@ class WorkflowService:
                 await WorkflowRun.find({"_id": {"$in": run_ids}}).delete()
                 logger.info(f"Deleted {len(run_ids)} workflow runs and their node runs for workflow {workflow_id}")
 
+            # Delete version history
+            await WorkflowVersion.find({"workflow_id": workflow.id}).delete()
+
             # Delete the workflow
             await workflow.delete()
 
@@ -241,6 +315,7 @@ class WorkflowService:
         initial_input: dict[str, Any] | None = None,
         parent_run_id: str | None = None,
         resolved_dependencies: list[dict[str, Any]] | None = None,
+        version: int | None = None,
     ) -> WorkflowRun:
         """
         Trigger a workflow run (async execution).
@@ -254,6 +329,7 @@ class WorkflowService:
             initial_input: Initial input data
             parent_run_id: Parent run ID for retry
             resolved_dependencies: Dependency resolution for retry
+            version: Workflow version to run; defaults to the latest version when omitted
 
         Returns:
             Created WorkflowRun document (status=PENDING)
@@ -264,6 +340,17 @@ class WorkflowService:
         try:
             # Get existing workflow
             workflow = await self.get_workflow_by_id(workflow_id)
+
+            # Resolve the definition snapshot for the requested version (defaults to latest).
+            if version is not None and version != workflow.version:
+                workflow_version = await WorkflowVersion.find_one({"workflow_id": workflow.id, "version": version})
+                if not workflow_version:
+                    raise ValueError(f"Workflow {workflow_id} version {version} not found")
+                definition_snapshot = workflow_version.definition
+                resolved_version = version
+            else:
+                definition_snapshot = workflow.model_dump(mode="json")
+                resolved_version = workflow.version
 
             # Convert resolved_dependencies if provided
             from registry_pkgs.models.workflow import ResolvedDependency
@@ -284,11 +371,12 @@ class WorkflowService:
             # Create workflow run
             run = WorkflowRun(
                 workflow_definition_id=workflow.id,
+                workflow_version=resolved_version,
                 status=WorkflowRunStatus.PENDING,
                 trigger_source=trigger_source,
                 started_at=datetime.now(UTC),
                 initial_input=initial_input,
-                definition_snapshot=workflow.model_dump(mode="json"),
+                definition_snapshot=definition_snapshot,
                 parent_run_id=PydanticObjectId(parent_run_id) if parent_run_id else None,
                 resolved_dependencies=resolved_deps,
             )
@@ -469,4 +557,6 @@ class WorkflowService:
             choices=choices,
             condition_cel=api_node.conditionCel,
             loop_config=loop_config,
+            require_approval=api_node.requireApproval,
+            approval_timeout_seconds=api_node.approvalTimeoutSeconds,
         )

--- a/registry/src/registry/services/workflow_service.py
+++ b/registry/src/registry/services/workflow_service.py
@@ -13,9 +13,15 @@ from uuid import uuid4
 
 from beanie import PydanticObjectId
 
+from registry_pkgs.database.mongodb import MongoDB
 from registry_pkgs.models.enums import WorkflowRunStatus
 from registry_pkgs.models.workflow import (
+    HumanReviewSpec,
+    LoopConfig,
     NodeRun,
+    RouterChoice,
+    StepConfig,
+    UserInputField,
     WorkflowDefinition,
     WorkflowNode,
     WorkflowRun,
@@ -25,6 +31,44 @@ from registry_pkgs.models.workflow import (
 from ..schemas.workflow_api_schemas import WorkflowCreateRequest, WorkflowUpdateRequest
 
 logger = logging.getLogger(__name__)
+
+
+def _convert_human_review(api_human_review: Any) -> HumanReviewSpec | None:
+    """Translate the ``humanReview`` API input into the embedded ``HumanReviewSpec``.
+
+    Returns ``None`` when no HITL is configured on this node.  Per-node-type
+    field-compatibility validation runs inside ``WorkflowNode._validate_shape``.
+    """
+    if not api_human_review:
+        return None
+    hr = api_human_review
+    return HumanReviewSpec(
+        requires_confirmation=hr.requiresConfirmation,
+        confirmation_message=hr.confirmationMessage,
+        requires_user_input=hr.requiresUserInput,
+        user_input_message=hr.userInputMessage,
+        user_input_schema=(
+            [
+                UserInputField(
+                    name=f.name,
+                    field_type=f.fieldType,
+                    description=f.description,
+                    required=f.required,
+                    default_value=f.defaultValue,
+                )
+                for f in hr.userInputSchema
+            ]
+            if hr.userInputSchema
+            else None
+        ),
+        requires_output_review=hr.requiresOutputReview,
+        output_review_message=hr.outputReviewMessage,
+        requires_iteration_review=hr.requiresIterationReview,
+        iteration_review_message=hr.iterationReviewMessage,
+        on_reject=hr.onReject,
+        timeout_seconds=hr.timeoutSeconds,
+        on_timeout=hr.onTimeout,
+    )
 
 
 class WorkflowService:
@@ -290,6 +334,16 @@ class WorkflowService:
                 await NodeRun.find({"workflow_run_id": {"$in": run_ids}}).delete()
                 logger.info(f"Deleted node runs for {len(run_ids)} workflow runs")
 
+                # agno persists per-run state (HumanReview pauses, step outputs) keyed
+                # by ``session_id == str(run.id)`` — clean it up so we don't leave
+                # orphan documents (and user input data) behind.
+                session_ids = [str(rid) for rid in run_ids]
+                db = MongoDB.get_database()
+                result = await db.get_collection("agno_workflow_sessions").delete_many(
+                    {"session_id": {"$in": session_ids}}
+                )
+                logger.info(f"Deleted {result.deleted_count} agno_workflow_sessions for workflow {workflow_id}")
+
                 await WorkflowRun.find({"_id": {"$in": run_ids}}).delete()
                 logger.info(f"Deleted {len(run_ids)} workflow runs and their node runs for workflow {workflow_id}")
 
@@ -316,6 +370,9 @@ class WorkflowService:
         parent_run_id: str | None = None,
         resolved_dependencies: list[dict[str, Any]] | None = None,
         version: int | None = None,
+        triggering_user_id: str | None = None,
+        triggering_username: str | None = None,
+        triggering_scopes: list[str] | None = None,
     ) -> WorkflowRun:
         """
         Trigger a workflow run (async execution).
@@ -379,6 +436,9 @@ class WorkflowService:
                 definition_snapshot=definition_snapshot,
                 parent_run_id=PydanticObjectId(parent_run_id) if parent_run_id else None,
                 resolved_dependencies=resolved_deps,
+                triggering_user_id=triggering_user_id,
+                triggering_username=triggering_username,
+                triggering_scopes=triggering_scopes,
             )
 
             # Save to database
@@ -509,8 +569,6 @@ class WorkflowService:
         Returns:
             WorkflowNode model instance
         """
-        from registry_pkgs.models.workflow import LoopConfig, RouterChoice, StepConfig
-
         # Generate ID if not provided
         node_id = api_node.id if api_node.id else str(uuid4())
 
@@ -543,6 +601,8 @@ class WorkflowService:
             for choice in api_node.choices
         ]
 
+        human_review = _convert_human_review(api_node.humanReview)
+
         return WorkflowNode(
             id=node_id,
             name=api_node.name,
@@ -557,6 +617,5 @@ class WorkflowService:
             choices=choices,
             condition_cel=api_node.conditionCel,
             loop_config=loop_config,
-            require_approval=api_node.requireApproval,
-            approval_timeout_seconds=api_node.approvalTimeoutSeconds,
+            human_review=human_review,
         )

--- a/registry/tests/unit/api/v1/workflow/test_control_routes.py
+++ b/registry/tests/unit/api/v1/workflow/test_control_routes.py
@@ -8,14 +8,21 @@ from beanie import PydanticObjectId
 from fastapi import HTTPException, Request
 
 from registry.api.v1.workflow.control_routes import (
+    approve_run,
     cancel_run,
     pause_run,
     resume_run,
     retry_run,
 )
-from registry.schemas.workflow_schemas import RetryRequest
+from registry.schemas.workflow_schemas import ApproveRequest, RetryRequest
 from registry.services.workflow_control_service import WorkflowControlService
 from registry_pkgs.models.enums import WorkflowRunStatus
+
+
+@pytest.fixture
+def wf_id() -> str:
+    """A valid ObjectId string for the workflow path parameter (ACL helper parses it)."""
+    return str(PydanticObjectId())
 
 
 @pytest.fixture
@@ -28,6 +35,14 @@ def sample_user_context():
 
 
 @pytest.fixture
+def mock_acl():
+    """ACL service whose VIEW check always passes."""
+    acl = MagicMock()
+    acl.check_user_permission = AsyncMock()
+    return acl
+
+
+@pytest.fixture
 def mock_service():
     """Return a WorkflowControlService with all send_* methods mocked."""
     service = MagicMock(spec=WorkflowControlService)
@@ -35,6 +50,8 @@ def mock_service():
     service.send_resume = AsyncMock()
     service.send_cancel = AsyncMock()
     service.send_retry = AsyncMock()
+    service.send_approve = AsyncMock()
+    service.send_reject = AsyncMock()
     return service
 
 
@@ -47,33 +64,36 @@ def _make_run(status: WorkflowRunStatus = WorkflowRunStatus.RUNNING) -> SimpleNa
 
 
 @pytest.mark.asyncio
-async def test_pause_run_success(sample_user_context, mock_service):
+async def test_pause_run_success(wf_id, sample_user_context, mock_service, mock_acl):
     run = _make_run(WorkflowRunStatus.PAUSED)
     mock_service.send_pause.return_value = run
 
     result = await pause_run(
-        workflow_id="wf-1",
+        workflow_id=wf_id,
         run_id="run-1",
-        _current_user=sample_user_context,
+        current_user=sample_user_context,
         service=mock_service,
+        acl_service=mock_acl,
     )
 
-    mock_service.send_pause.assert_awaited_once_with("wf-1", "run-1")
+    mock_acl.check_user_permission.assert_awaited_once()
+    mock_service.send_pause.assert_awaited_once_with(wf_id, "run-1")
     assert result.run_id == str(run.id)
     assert result.status == WorkflowRunStatus.PAUSED
     assert result.message == "Pause directive sent"
 
 
 @pytest.mark.asyncio
-async def test_pause_run_raises_http_exception(sample_user_context, mock_service):
+async def test_pause_run_raises_http_exception(wf_id, sample_user_context, mock_service, mock_acl):
     mock_service.send_pause.side_effect = HTTPException(status_code=400, detail="bad state")
 
     with pytest.raises(HTTPException) as exc_info:
         await pause_run(
-            workflow_id="wf-1",
+            workflow_id=wf_id,
             run_id="run-1",
-            _current_user=sample_user_context,
+            current_user=sample_user_context,
             service=mock_service,
+            acl_service=mock_acl,
         )
 
     assert exc_info.value.status_code == 400
@@ -81,15 +101,16 @@ async def test_pause_run_raises_http_exception(sample_user_context, mock_service
 
 
 @pytest.mark.asyncio
-async def test_pause_run_wraps_unexpected_exception(sample_user_context, mock_service):
+async def test_pause_run_wraps_unexpected_exception(wf_id, sample_user_context, mock_service, mock_acl):
     mock_service.send_pause.side_effect = RuntimeError("boom")
 
     with pytest.raises(HTTPException) as exc_info:
         await pause_run(
-            workflow_id="wf-1",
+            workflow_id=wf_id,
             run_id="run-1",
-            _current_user=sample_user_context,
+            current_user=sample_user_context,
             service=mock_service,
+            acl_service=mock_acl,
         )
 
     assert exc_info.value.status_code == 500
@@ -97,48 +118,69 @@ async def test_pause_run_wraps_unexpected_exception(sample_user_context, mock_se
 
 
 @pytest.mark.asyncio
-async def test_resume_run_success(sample_user_context, mock_service):
+async def test_pause_run_forbidden_without_view(wf_id, sample_user_context, mock_service, mock_acl):
+    """A caller lacking VIEW on the workflow is rejected before the directive is sent."""
+    mock_acl.check_user_permission.side_effect = HTTPException(status_code=403, detail="no view")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await pause_run(
+            workflow_id=wf_id,
+            run_id="run-1",
+            current_user=sample_user_context,
+            service=mock_service,
+            acl_service=mock_acl,
+        )
+
+    assert exc_info.value.status_code == 403
+    mock_service.send_pause.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resume_run_success(wf_id, sample_user_context, mock_service, mock_acl):
     run = _make_run(WorkflowRunStatus.RUNNING)
     mock_service.send_resume.return_value = run
 
     result = await resume_run(
-        workflow_id="wf-1",
+        workflow_id=wf_id,
         run_id="run-1",
-        _current_user=sample_user_context,
+        current_user=sample_user_context,
         service=mock_service,
+        acl_service=mock_acl,
     )
 
-    mock_service.send_resume.assert_awaited_once_with("wf-1", "run-1")
+    mock_service.send_resume.assert_awaited_once_with(wf_id, "run-1")
     assert result.run_id == str(run.id)
     assert result.status == WorkflowRunStatus.RUNNING
     assert result.message == "Resume directive sent"
 
 
 @pytest.mark.asyncio
-async def test_resume_run_raises_http_exception(sample_user_context, mock_service):
+async def test_resume_run_raises_http_exception(wf_id, sample_user_context, mock_service, mock_acl):
     mock_service.send_resume.side_effect = HTTPException(status_code=400, detail="not paused")
 
     with pytest.raises(HTTPException) as exc_info:
         await resume_run(
-            workflow_id="wf-1",
+            workflow_id=wf_id,
             run_id="run-1",
-            _current_user=sample_user_context,
+            current_user=sample_user_context,
             service=mock_service,
+            acl_service=mock_acl,
         )
 
     assert exc_info.value.status_code == 400
 
 
 @pytest.mark.asyncio
-async def test_resume_run_wraps_unexpected_exception(sample_user_context, mock_service):
+async def test_resume_run_wraps_unexpected_exception(wf_id, sample_user_context, mock_service, mock_acl):
     mock_service.send_resume.side_effect = ValueError("unexpected")
 
     with pytest.raises(HTTPException) as exc_info:
         await resume_run(
-            workflow_id="wf-1",
+            workflow_id=wf_id,
             run_id="run-1",
-            _current_user=sample_user_context,
+            current_user=sample_user_context,
             service=mock_service,
+            acl_service=mock_acl,
         )
 
     assert exc_info.value.status_code == 500
@@ -148,48 +190,51 @@ async def test_resume_run_wraps_unexpected_exception(sample_user_context, mock_s
 # Cancel
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_cancel_run_success(sample_user_context, mock_service):
+async def test_cancel_run_success(wf_id, sample_user_context, mock_service, mock_acl):
     run = _make_run(WorkflowRunStatus.CANCELLED)
     mock_service.send_cancel.return_value = run
 
     result = await cancel_run(
-        workflow_id="wf-1",
+        workflow_id=wf_id,
         run_id="run-1",
-        _current_user=sample_user_context,
+        current_user=sample_user_context,
         service=mock_service,
+        acl_service=mock_acl,
     )
 
-    mock_service.send_cancel.assert_awaited_once_with("wf-1", "run-1")
+    mock_service.send_cancel.assert_awaited_once_with(wf_id, "run-1")
     assert result.run_id == str(run.id)
     assert result.status == WorkflowRunStatus.CANCELLED
     assert result.message == "Cancel directive sent"
 
 
 @pytest.mark.asyncio
-async def test_cancel_run_raises_http_exception(sample_user_context, mock_service):
+async def test_cancel_run_raises_http_exception(wf_id, sample_user_context, mock_service, mock_acl):
     mock_service.send_cancel.side_effect = HTTPException(status_code=400, detail="already terminal")
 
     with pytest.raises(HTTPException) as exc_info:
         await cancel_run(
-            workflow_id="wf-1",
+            workflow_id=wf_id,
             run_id="run-1",
-            _current_user=sample_user_context,
+            current_user=sample_user_context,
             service=mock_service,
+            acl_service=mock_acl,
         )
 
     assert exc_info.value.status_code == 400
 
 
 @pytest.mark.asyncio
-async def test_cancel_run_wraps_unexpected_exception(sample_user_context, mock_service):
+async def test_cancel_run_wraps_unexpected_exception(wf_id, sample_user_context, mock_service, mock_acl):
     mock_service.send_cancel.side_effect = ConnectionError("network fail")
 
     with pytest.raises(HTTPException) as exc_info:
         await cancel_run(
-            workflow_id="wf-1",
+            workflow_id=wf_id,
             run_id="run-1",
-            _current_user=sample_user_context,
+            current_user=sample_user_context,
             service=mock_service,
+            acl_service=mock_acl,
         )
 
     assert exc_info.value.status_code == 500
@@ -199,7 +244,7 @@ async def test_cancel_run_wraps_unexpected_exception(sample_user_context, mock_s
 # Retry
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_retry_run_success(sample_user_context, mock_service):
+async def test_retry_run_success(wf_id, sample_user_context, mock_service, mock_acl):
     child_run = _make_run(WorkflowRunStatus.PENDING)
     mock_service.send_retry.return_value = child_run
 
@@ -209,16 +254,17 @@ async def test_retry_run_success(sample_user_context, mock_service):
     body = RetryRequest(from_node_id="node-2")
 
     result = await retry_run(
-        workflow_id="wf-1",
+        workflow_id=wf_id,
         run_id="run-1",
         body=body,
         request=request,
-        _current_user=sample_user_context,
+        current_user=sample_user_context,
         service=mock_service,
+        acl_service=mock_acl,
     )
 
     mock_service.send_retry.assert_awaited_once_with(
-        "wf-1",
+        wf_id,
         "run-1",
         "node-2",
         registry_token="test-token-123",
@@ -230,7 +276,7 @@ async def test_retry_run_success(sample_user_context, mock_service):
 
 
 @pytest.mark.asyncio
-async def test_retry_run_strips_bearer_prefix(sample_user_context, mock_service):
+async def test_retry_run_strips_bearer_prefix(wf_id, sample_user_context, mock_service, mock_acl):
     child_run = _make_run(WorkflowRunStatus.PENDING)
     mock_service.send_retry.return_value = child_run
 
@@ -240,12 +286,13 @@ async def test_retry_run_strips_bearer_prefix(sample_user_context, mock_service)
     body = RetryRequest(from_node_id="node-1")
 
     await retry_run(
-        workflow_id="wf-1",
+        workflow_id=wf_id,
         run_id="run-1",
         body=body,
         request=request,
-        _current_user=sample_user_context,
+        current_user=sample_user_context,
         service=mock_service,
+        acl_service=mock_acl,
     )
 
     call_kwargs = mock_service.send_retry.call_args.kwargs
@@ -253,7 +300,7 @@ async def test_retry_run_strips_bearer_prefix(sample_user_context, mock_service)
 
 
 @pytest.mark.asyncio
-async def test_retry_run_empty_auth_header(sample_user_context, mock_service):
+async def test_retry_run_empty_auth_header(wf_id, sample_user_context, mock_service, mock_acl):
     child_run = _make_run(WorkflowRunStatus.PENDING)
     mock_service.send_retry.return_value = child_run
 
@@ -263,12 +310,13 @@ async def test_retry_run_empty_auth_header(sample_user_context, mock_service):
     body = RetryRequest(from_node_id="node-1")
 
     await retry_run(
-        workflow_id="wf-1",
+        workflow_id=wf_id,
         run_id="run-1",
         body=body,
         request=request,
-        _current_user=sample_user_context,
+        current_user=sample_user_context,
         service=mock_service,
+        acl_service=mock_acl,
     )
 
     call_kwargs = mock_service.send_retry.call_args.kwargs
@@ -277,7 +325,7 @@ async def test_retry_run_empty_auth_header(sample_user_context, mock_service):
 
 
 @pytest.mark.asyncio
-async def test_retry_run_raises_http_exception(sample_user_context, mock_service):
+async def test_retry_run_raises_http_exception(wf_id, sample_user_context, mock_service, mock_acl):
     mock_service.send_retry.side_effect = HTTPException(status_code=400, detail="not finished")
 
     request = MagicMock(spec=Request)
@@ -287,19 +335,20 @@ async def test_retry_run_raises_http_exception(sample_user_context, mock_service
 
     with pytest.raises(HTTPException) as exc_info:
         await retry_run(
-            workflow_id="wf-1",
+            workflow_id=wf_id,
             run_id="run-1",
             body=body,
             request=request,
-            _current_user=sample_user_context,
+            current_user=sample_user_context,
             service=mock_service,
+            acl_service=mock_acl,
         )
 
     assert exc_info.value.status_code == 400
 
 
 @pytest.mark.asyncio
-async def test_retry_run_wraps_unexpected_exception(sample_user_context, mock_service):
+async def test_retry_run_wraps_unexpected_exception(wf_id, sample_user_context, mock_service, mock_acl):
     mock_service.send_retry.side_effect = OSError("disk full")
 
     request = MagicMock(spec=Request)
@@ -309,12 +358,90 @@ async def test_retry_run_wraps_unexpected_exception(sample_user_context, mock_se
 
     with pytest.raises(HTTPException) as exc_info:
         await retry_run(
-            workflow_id="wf-1",
+            workflow_id=wf_id,
             run_id="run-1",
             body=body,
             request=request,
-            _current_user=sample_user_context,
+            current_user=sample_user_context,
             service=mock_service,
+            acl_service=mock_acl,
         )
 
     assert exc_info.value.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# Approve / Reject
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_approve_run_approved_calls_send_approve(wf_id, sample_user_context, mock_service, mock_acl):
+    run = _make_run(WorkflowRunStatus.RUNNING)
+    mock_service.send_approve.return_value = run
+
+    result = await approve_run(
+        workflow_id=wf_id,
+        run_id="run-1",
+        body=ApproveRequest(approved=True),
+        current_user=sample_user_context,
+        service=mock_service,
+        acl_service=mock_acl,
+    )
+
+    mock_service.send_approve.assert_awaited_once_with(wf_id, "run-1")
+    mock_service.send_reject.assert_not_awaited()
+    assert result.status == WorkflowRunStatus.RUNNING
+    assert result.message == "Approval granted"
+
+
+@pytest.mark.asyncio
+async def test_approve_run_rejected_calls_send_reject(wf_id, sample_user_context, mock_service, mock_acl):
+    run = _make_run(WorkflowRunStatus.RUNNING)
+    mock_service.send_reject.return_value = run
+
+    result = await approve_run(
+        workflow_id=wf_id,
+        run_id="run-1",
+        body=ApproveRequest(approved=False),
+        current_user=sample_user_context,
+        service=mock_service,
+        acl_service=mock_acl,
+    )
+
+    mock_service.send_reject.assert_awaited_once_with(wf_id, "run-1")
+    mock_service.send_approve.assert_not_awaited()
+    assert result.message == "Approval rejected"
+
+
+@pytest.mark.asyncio
+async def test_approve_run_forbidden_without_view(wf_id, sample_user_context, mock_service, mock_acl):
+    mock_acl.check_user_permission.side_effect = HTTPException(status_code=403, detail="no view")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await approve_run(
+            workflow_id=wf_id,
+            run_id="run-1",
+            body=ApproveRequest(approved=True),
+            current_user=sample_user_context,
+            service=mock_service,
+            acl_service=mock_acl,
+        )
+
+    assert exc_info.value.status_code == 403
+    mock_service.send_approve.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_approve_run_invalid_state_returns_400(wf_id, sample_user_context, mock_service, mock_acl):
+    mock_service.send_approve.side_effect = HTTPException(status_code=400, detail="not awaiting approval")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await approve_run(
+            workflow_id=wf_id,
+            run_id="run-1",
+            body=ApproveRequest(approved=True),
+            current_user=sample_user_context,
+            service=mock_service,
+            acl_service=mock_acl,
+        )
+
+    assert exc_info.value.status_code == 400

--- a/registry/tests/unit/api/v1/workflow/test_control_routes.py
+++ b/registry/tests/unit/api/v1/workflow/test_control_routes.py
@@ -14,9 +14,9 @@ from registry.api.v1.workflow.control_routes import (
     resume_run,
     retry_run,
 )
-from registry.schemas.workflow_schemas import ApproveRequest, RetryRequest
+from registry.schemas.workflow_schemas import ResolveRequirementRequest, RetryRequest
 from registry.services.workflow_control_service import WorkflowControlService
-from registry_pkgs.models.enums import WorkflowRunStatus
+from registry_pkgs.models.enums import RequirementResolution, WorkflowRunStatus
 
 
 @pytest.fixture
@@ -44,14 +44,13 @@ def mock_acl():
 
 @pytest.fixture
 def mock_service():
-    """Return a WorkflowControlService with all send_* methods mocked."""
+    """Return a WorkflowControlService with all directive methods mocked."""
     service = MagicMock(spec=WorkflowControlService)
     service.send_pause = AsyncMock()
     service.send_resume = AsyncMock()
     service.send_cancel = AsyncMock()
     service.send_retry = AsyncMock()
-    service.send_approve = AsyncMock()
-    service.send_reject = AsyncMock()
+    service.resolve_requirement = AsyncMock()
     return service
 
 
@@ -371,45 +370,78 @@ async def test_retry_run_wraps_unexpected_exception(wf_id, sample_user_context, 
 
 
 # ---------------------------------------------------------------------------
-# Approve / Reject
+# Approve (HITL): /approve → resolve_requirement with 5-way resolution
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_approve_run_approved_calls_send_approve(wf_id, sample_user_context, mock_service, mock_acl):
+async def test_approve_run_confirm_calls_resolve_requirement(wf_id, sample_user_context, mock_service, mock_acl):
     run = _make_run(WorkflowRunStatus.RUNNING)
-    mock_service.send_approve.return_value = run
+    mock_service.resolve_requirement.return_value = run
 
     result = await approve_run(
         workflow_id=wf_id,
         run_id="run-1",
-        body=ApproveRequest(approved=True),
+        body=ResolveRequirementRequest(stepId="node-1", resolution=RequirementResolution.CONFIRM),
         current_user=sample_user_context,
         service=mock_service,
         acl_service=mock_acl,
     )
 
-    mock_service.send_approve.assert_awaited_once_with(wf_id, "run-1")
-    mock_service.send_reject.assert_not_awaited()
-    assert result.status == WorkflowRunStatus.RUNNING
-    assert result.message == "Approval granted"
+    mock_service.resolve_requirement.assert_awaited_once_with(
+        wf_id,
+        "run-1",
+        step_id="node-1",
+        resolution=RequirementResolution.CONFIRM,
+        feedback=None,
+        edited_output=None,
+        user_input=None,
+        selected_choices=None,
+    )
+    assert result.resolvedStepId == "node-1"
+    assert "confirm" in result.message
 
 
 @pytest.mark.asyncio
-async def test_approve_run_rejected_calls_send_reject(wf_id, sample_user_context, mock_service, mock_acl):
+async def test_approve_run_edit_passes_edited_output(wf_id, sample_user_context, mock_service, mock_acl):
     run = _make_run(WorkflowRunStatus.RUNNING)
-    mock_service.send_reject.return_value = run
+    mock_service.resolve_requirement.return_value = run
 
-    result = await approve_run(
+    await approve_run(
         workflow_id=wf_id,
         run_id="run-1",
-        body=ApproveRequest(approved=False),
+        body=ResolveRequirementRequest(
+            stepId="node-1",
+            resolution=RequirementResolution.EDIT,
+            editedOutput={"content": "human-edited content"},
+        ),
         current_user=sample_user_context,
         service=mock_service,
         acl_service=mock_acl,
     )
+    call_kwargs = mock_service.resolve_requirement.await_args.kwargs
+    assert call_kwargs["resolution"] == RequirementResolution.EDIT
+    assert call_kwargs["edited_output"] == {"content": "human-edited content"}
 
-    mock_service.send_reject.assert_awaited_once_with(wf_id, "run-1")
-    mock_service.send_approve.assert_not_awaited()
-    assert result.message == "Approval rejected"
+
+@pytest.mark.asyncio
+async def test_approve_run_user_input_passes_form_data(wf_id, sample_user_context, mock_service, mock_acl):
+    run = _make_run(WorkflowRunStatus.RUNNING)
+    mock_service.resolve_requirement.return_value = run
+
+    await approve_run(
+        workflow_id=wf_id,
+        run_id="run-1",
+        body=ResolveRequirementRequest(
+            stepId="node-2",
+            resolution=RequirementResolution.USER_INPUT,
+            userInput={"discount_pct": 15},
+        ),
+        current_user=sample_user_context,
+        service=mock_service,
+        acl_service=mock_acl,
+    )
+    call_kwargs = mock_service.resolve_requirement.await_args.kwargs
+    assert call_kwargs["resolution"] == RequirementResolution.USER_INPUT
+    assert call_kwargs["user_input"] == {"discount_pct": 15}
 
 
 @pytest.mark.asyncio
@@ -420,28 +452,29 @@ async def test_approve_run_forbidden_without_view(wf_id, sample_user_context, mo
         await approve_run(
             workflow_id=wf_id,
             run_id="run-1",
-            body=ApproveRequest(approved=True),
+            body=ResolveRequirementRequest(stepId="node-1", resolution=RequirementResolution.CONFIRM),
             current_user=sample_user_context,
             service=mock_service,
             acl_service=mock_acl,
         )
 
     assert exc_info.value.status_code == 403
-    mock_service.send_approve.assert_not_awaited()
+    mock_service.resolve_requirement.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_approve_run_invalid_state_returns_400(wf_id, sample_user_context, mock_service, mock_acl):
-    mock_service.send_approve.side_effect = HTTPException(status_code=400, detail="not awaiting approval")
+async def test_approve_run_conflict_returns_409(wf_id, sample_user_context, mock_service, mock_acl):
+    """Run not in awaiting_approval → 409 from service propagates."""
+    mock_service.resolve_requirement.side_effect = HTTPException(status_code=409, detail="state changed")
 
     with pytest.raises(HTTPException) as exc_info:
         await approve_run(
             workflow_id=wf_id,
             run_id="run-1",
-            body=ApproveRequest(approved=True),
+            body=ResolveRequirementRequest(stepId="node-1", resolution=RequirementResolution.CONFIRM),
             current_user=sample_user_context,
             service=mock_service,
             acl_service=mock_acl,
         )
 
-    assert exc_info.value.status_code == 400
+    assert exc_info.value.status_code == 409

--- a/registry/tests/unit/api/v1/workflow/test_control_routes.py
+++ b/registry/tests/unit/api/v1/workflow/test_control_routes.py
@@ -478,3 +478,58 @@ async def test_approve_run_conflict_returns_409(wf_id, sample_user_context, mock
         )
 
     assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_approve_run_reject_calls_resolve_requirement(wf_id, sample_user_context, mock_service, mock_acl):
+    """Reject resolution must forward feedback to the service layer."""
+    run = _make_run(WorkflowRunStatus.RUNNING)
+    mock_service.resolve_requirement.return_value = run
+
+    await approve_run(
+        workflow_id=wf_id,
+        run_id="run-1",
+        body=ResolveRequirementRequest(
+            stepId="node-1",
+            resolution=RequirementResolution.REJECT,
+            feedback="Try again with more context",
+        ),
+        current_user=sample_user_context,
+        service=mock_service,
+        acl_service=mock_acl,
+    )
+
+    call_kwargs = mock_service.resolve_requirement.await_args.kwargs
+    assert call_kwargs["resolution"] == RequirementResolution.REJECT
+    assert call_kwargs["feedback"] == "Try again with more context"
+
+
+@pytest.mark.asyncio
+async def test_approve_run_reject_with_retry_policy(wf_id, sample_user_context, mock_service, mock_acl):
+    """When the gate is configured with on_reject=retry, a reject decision must set
+    confirmed=False so agno's continue_run can re-execute the step (bounded by
+    max_retries)."""
+    run = _make_run(WorkflowRunStatus.RUNNING)
+    mock_service.resolve_requirement.return_value = run
+
+    result = await approve_run(
+        workflow_id=wf_id,
+        run_id="run-1",
+        body=ResolveRequirementRequest(stepId="node-1", resolution=RequirementResolution.REJECT),
+        current_user=sample_user_context,
+        service=mock_service,
+        acl_service=mock_acl,
+    )
+
+    mock_service.resolve_requirement.assert_awaited_once_with(
+        wf_id,
+        "run-1",
+        step_id="node-1",
+        resolution=RequirementResolution.REJECT,
+        feedback=None,
+        edited_output=None,
+        user_input=None,
+        selected_choices=None,
+    )
+    assert result.resolvedStepId == "node-1"
+    assert "reject" in result.message

--- a/registry/tests/unit/api/v1/workflow/test_workflow_routes.py
+++ b/registry/tests/unit/api/v1/workflow/test_workflow_routes.py
@@ -250,7 +250,7 @@ def _fake_workflow(name: str = "wf", version: int = 1):
 
 @pytest.mark.asyncio
 async def test_list_workflows_filters_by_accessible_ids():
-    """list_workflows must restrict results to the caller's ACL-accessible IDs."""
+    """List_workflows must restrict results to the caller's ACL-accessible IDs."""
     wf = _fake_workflow()
     user_context = {"user_id": str(PydanticObjectId()), "username": "u", "groups": [], "scopes": []}
 
@@ -259,7 +259,7 @@ async def test_list_workflows_filters_by_accessible_ids():
 
     mock_acl = MagicMock()
     mock_acl.get_accessible_resource_ids = AsyncMock(return_value=[str(wf.id)])
-    mock_acl.get_user_permissions_for_resource = AsyncMock(return_value=ResourcePermissions(VIEW=True))
+    mock_acl.get_user_permissions_for_resources = AsyncMock(return_value={wf.id: ResourcePermissions(VIEW=True)})
 
     response = await workflow_routes.list_workflows(
         user_context=user_context,
@@ -268,6 +268,10 @@ async def test_list_workflows_filters_by_accessible_ids():
     )
 
     mock_acl.get_accessible_resource_ids.assert_awaited_once()
+    # Permissions resolved via a single batch query (no N+1).
+    mock_acl.get_user_permissions_for_resources.assert_awaited_once()
+    batch_kwargs = mock_acl.get_user_permissions_for_resources.await_args.kwargs
+    assert batch_kwargs["resource_ids"] == [wf.id]
     forwarded = mock_service.list_workflows.await_args.kwargs
     assert forwarded["accessible_workflow_ids"] == [str(wf.id)]
     assert len(response.workflows) == 1
@@ -418,7 +422,11 @@ def test_list_runs_status_filter_covers_all_run_statuses():
     assert {s.value for s in WorkflowRunStatus} <= literal_values
 
 
-def test_workflow_create_request_parses_approval_fields():
+def test_workflow_create_request_parses_human_review():
+    """``humanReview`` embedded object mirrors agno's HumanReview dataclass 1:1.
+
+    See ``registry_pkgs.models.workflow.HumanReviewSpec``.
+    """
     request = WorkflowCreateRequest.model_validate(
         {
             "name": "Approval Demo",
@@ -427,13 +435,21 @@ def test_workflow_create_request_parses_approval_fields():
                     "name": "gate",
                     "nodeType": "step",
                     "executorKey": "tool",
-                    "requireApproval": True,
-                    "approvalTimeoutSeconds": 120,
+                    "humanReview": {
+                        "requiresConfirmation": True,
+                        "confirmationMessage": "Proceed?",
+                        "onReject": "skip",
+                        "timeoutSeconds": 120,
+                        "onTimeout": "cancel",
+                    },
                 }
             ],
         }
     )
 
     node = request.nodes[0]
-    assert node.requireApproval is True
-    assert node.approvalTimeoutSeconds == 120
+    assert node.humanReview is not None
+    assert node.humanReview.requiresConfirmation is True
+    assert node.humanReview.timeoutSeconds == 120
+    assert node.humanReview.onReject.value == "skip"
+    assert node.humanReview.onTimeout.value == "cancel"

--- a/registry/tests/unit/api/v1/workflow/test_workflow_routes.py
+++ b/registry/tests/unit/api/v1/workflow/test_workflow_routes.py
@@ -1,9 +1,12 @@
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from beanie import PydanticObjectId
 from fastapi import HTTPException, Request
 
 from registry.api.v1.workflow import workflow_routes
+from registry.schemas.acl_schema import ResourcePermissions
 from registry.schemas.workflow_api_schemas import WorkflowCreateRequest
 
 
@@ -195,8 +198,11 @@ async def test_create_workflow_route_forwards_condition_request_to_service():
     mock_service = MagicMock()
     mock_service.create_workflow = AsyncMock(return_value=fake_workflow)
 
+    mock_acl = MagicMock()
+    mock_acl.grant_permission = AsyncMock()
+
     user_context = {
-        "user_id": "u1",
+        "user_id": str(PydanticObjectId()),
         "username": "tester",
         "groups": [],
         "scopes": ["workflow:create"],
@@ -206,9 +212,14 @@ async def test_create_workflow_route_forwards_condition_request_to_service():
         data=request,
         user_context=user_context,
         workflow_service=mock_service,
+        acl_service=mock_acl,
     )
 
     mock_service.create_workflow.assert_awaited_once()
+    mock_acl.grant_permission.assert_awaited_once()
+    grant_kwargs = mock_acl.grant_permission.await_args.kwargs
+    assert grant_kwargs["resource_type"].value == "workflow"
+    assert grant_kwargs["perm_bits"] == 15  # OWNER
     forwarded = mock_service.create_workflow.await_args.kwargs["data"]
     cond = forwarded.nodes[0]
     assert cond.nodeType == "condition"
@@ -221,3 +232,208 @@ async def test_create_workflow_route_forwards_condition_request_to_service():
     assert detail_cond.nodeType == "condition"
     assert [n.name for n in detail_cond.trueSteps] == ["C"]
     assert [n.name for n in detail_cond.falseSteps] == ["D"]
+
+
+def _fake_workflow(name: str = "wf", version: int = 1):
+    from registry_pkgs.models.workflow import WorkflowDefinition, WorkflowNode
+
+    return WorkflowDefinition.model_construct(
+        id=PydanticObjectId(),
+        name=name,
+        description=None,
+        nodes=[WorkflowNode(name="s", node_type="step", executor_key="tool")],
+        version=version,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_workflows_filters_by_accessible_ids():
+    """list_workflows must restrict results to the caller's ACL-accessible IDs."""
+    wf = _fake_workflow()
+    user_context = {"user_id": str(PydanticObjectId()), "username": "u", "groups": [], "scopes": []}
+
+    mock_service = MagicMock()
+    mock_service.list_workflows = AsyncMock(return_value=([wf], 1))
+
+    mock_acl = MagicMock()
+    mock_acl.get_accessible_resource_ids = AsyncMock(return_value=[str(wf.id)])
+    mock_acl.get_user_permissions_for_resource = AsyncMock(return_value=ResourcePermissions(VIEW=True))
+
+    response = await workflow_routes.list_workflows(
+        user_context=user_context,
+        workflow_service=mock_service,
+        acl_service=mock_acl,
+    )
+
+    mock_acl.get_accessible_resource_ids.assert_awaited_once()
+    forwarded = mock_service.list_workflows.await_args.kwargs
+    assert forwarded["accessible_workflow_ids"] == [str(wf.id)]
+    assert len(response.workflows) == 1
+    assert response.workflows[0].aclPermission.VIEW is True
+
+
+@pytest.mark.asyncio
+async def test_get_workflow_propagates_403_without_view():
+    user_context = {"user_id": str(PydanticObjectId()), "username": "u", "groups": [], "scopes": []}
+
+    mock_service = MagicMock()
+    mock_service.get_workflow_by_id = AsyncMock(return_value=_fake_workflow())
+
+    mock_acl = MagicMock()
+    mock_acl.check_user_permission = AsyncMock(side_effect=HTTPException(status_code=403, detail="no view"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await workflow_routes.get_workflow(
+            workflow_id=str(PydanticObjectId()),
+            user_context=user_context,
+            workflow_service=mock_service,
+            acl_service=mock_acl,
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_workflow_versions_returns_history():
+    user_context = {"user_id": str(PydanticObjectId()), "username": "u", "groups": [], "scopes": []}
+
+    mock_service = MagicMock()
+    mock_service.get_workflow_by_id = AsyncMock(return_value=_fake_workflow())
+    mock_service.list_versions = AsyncMock(
+        return_value=[
+            {"version": 1, "created_at": datetime.now(UTC), "checksum": "aaa"},
+            {"version": 2, "created_at": datetime.now(UTC), "checksum": "bbb"},
+        ]
+    )
+
+    mock_acl = MagicMock()
+    mock_acl.check_user_permission = AsyncMock(return_value=ResourcePermissions(VIEW=True))
+
+    response = await workflow_routes.list_workflow_versions(
+        workflow_id=str(PydanticObjectId()),
+        user_context=user_context,
+        workflow_service=mock_service,
+        acl_service=mock_acl,
+    )
+
+    assert [v.version for v in response.versions] == [1, 2]
+    assert response.versions[1].checksum == "bbb"
+
+
+@pytest.mark.asyncio
+async def test_trigger_run_forwards_requested_version(monkeypatch):
+    from types import SimpleNamespace
+
+    from registry.schemas.workflow_api_schemas import WorkflowRunTriggerRequest
+    from registry_pkgs.models.enums import WorkflowRunStatus
+
+    monkeypatch.setattr(workflow_routes, "generate_service_jwt", MagicMock(return_value="svc-token"))
+
+    user_context = {"user_id": str(PydanticObjectId()), "username": "u", "groups": [], "scopes": []}
+
+    run = SimpleNamespace(
+        id=PydanticObjectId(),
+        workflow_definition_id=PydanticObjectId(),
+        status=WorkflowRunStatus.PENDING,
+        trigger_source="api",
+        started_at=datetime.now(UTC),
+    )
+
+    mock_service = MagicMock()
+    mock_service.get_workflow_by_id = AsyncMock(return_value=_fake_workflow(version=3))
+    mock_service.trigger_workflow_run = AsyncMock(return_value=run)
+
+    mock_acl = MagicMock()
+    mock_acl.check_user_permission = AsyncMock(return_value=ResourcePermissions(VIEW=True))
+
+    request = MagicMock(spec=Request)
+    request.headers = {"Authorization": "Bearer abc"}
+    background_tasks = MagicMock()
+
+    await workflow_routes.trigger_workflow_run(
+        workflow_id=str(PydanticObjectId()),
+        data=WorkflowRunTriggerRequest(version=2),
+        background_tasks=background_tasks,
+        user_context=user_context,
+        request=request,
+        workflow_service=mock_service,
+        workflow_runner=MagicMock(),
+        acl_service=mock_acl,
+    )
+
+    assert mock_service.trigger_workflow_run.await_args.kwargs["version"] == 2
+    background_tasks.add_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_trigger_run_forbidden_without_view():
+    """POST /runs requires VIEWER on the workflow; missing VIEW → 403 before triggering."""
+    from registry.schemas.workflow_api_schemas import WorkflowRunTriggerRequest
+
+    user_context = {"user_id": str(PydanticObjectId()), "username": "u", "groups": [], "scopes": []}
+
+    mock_service = MagicMock()
+    mock_service.get_workflow_by_id = AsyncMock(return_value=_fake_workflow())
+    mock_service.trigger_workflow_run = AsyncMock()
+
+    mock_acl = MagicMock()
+    mock_acl.check_user_permission = AsyncMock(side_effect=HTTPException(status_code=403, detail="no view"))
+
+    request = MagicMock(spec=Request)
+    request.headers = {"Authorization": "Bearer abc"}
+
+    with pytest.raises(HTTPException) as exc_info:
+        await workflow_routes.trigger_workflow_run(
+            workflow_id=str(PydanticObjectId()),
+            data=WorkflowRunTriggerRequest(),
+            background_tasks=MagicMock(),
+            user_context=user_context,
+            request=request,
+            workflow_service=mock_service,
+            workflow_runner=MagicMock(),
+            acl_service=mock_acl,
+        )
+
+    assert exc_info.value.status_code == 403
+    mock_service.trigger_workflow_run.assert_not_awaited()
+
+
+def test_list_runs_status_filter_covers_all_run_statuses():
+    """The list_workflow_runs status filter must accept every WorkflowRunStatus
+    value (including awaiting_approval) so runs in any state can be filtered."""
+    import inspect
+    import typing
+
+    from registry_pkgs.models.enums import WorkflowRunStatus
+
+    annotation = inspect.signature(workflow_routes.list_workflow_runs).parameters["status"].annotation
+    # Annotated[Literal[...] | None, Query()] → first arg is the `Literal[...] | None` union
+    union = typing.get_args(annotation)[0]
+    literal_values: set[str] = set()
+    for member in typing.get_args(union):
+        literal_values |= set(typing.get_args(member))  # Literal members; NoneType yields ()
+
+    assert {s.value for s in WorkflowRunStatus} <= literal_values
+
+
+def test_workflow_create_request_parses_approval_fields():
+    request = WorkflowCreateRequest.model_validate(
+        {
+            "name": "Approval Demo",
+            "nodes": [
+                {
+                    "name": "gate",
+                    "nodeType": "step",
+                    "executorKey": "tool",
+                    "requireApproval": True,
+                    "approvalTimeoutSeconds": 120,
+                }
+            ],
+        }
+    )
+
+    node = request.nodes[0]
+    assert node.requireApproval is True
+    assert node.approvalTimeoutSeconds == 120

--- a/registry/tests/unit/api/v1/workflow/test_workflow_routes.py
+++ b/registry/tests/unit/api/v1/workflow/test_workflow_routes.py
@@ -453,3 +453,156 @@ def test_workflow_create_request_parses_human_review():
     assert node.humanReview.timeoutSeconds == 120
     assert node.humanReview.onReject.value == "skip"
     assert node.humanReview.onTimeout.value == "cancel"
+
+
+@pytest.mark.asyncio
+async def test_get_workflow_run_status_returns_run_status_response():
+    """GET /runs/{run_id}/status must return a RunStatusResponse with per-node summary."""
+    from datetime import UTC, datetime
+    from types import SimpleNamespace
+
+    from registry.api.v1.workflow.workflow_routes import get_workflow_run_status
+    from registry.schemas.workflow_schemas import RunStatusResponse
+    from registry_pkgs.models.enums import WorkflowRunStatus
+
+    wf_id = str(PydanticObjectId())
+    run_id = str(PydanticObjectId())
+    user_id = str(PydanticObjectId())
+
+    run = SimpleNamespace(
+        id=PydanticObjectId(run_id),
+        workflow_definition_id=PydanticObjectId(wf_id),
+        status=WorkflowRunStatus.RUNNING,
+        trigger_source="api",
+        started_at=datetime.now(UTC),
+        finished_at=None,
+        paused_at=None,
+        error_summary=None,
+        parent_run_id=None,
+        pending_requirements=[],
+    )
+
+    node_run = SimpleNamespace(
+        node_id="n1",
+        node_name="step-1",
+        status=WorkflowRunStatus.COMPLETED,
+        attempt=1,
+        started_at=datetime.now(UTC),
+        finished_at=datetime.now(UTC),
+        error=None,
+    )
+
+    mock_control = MagicMock()
+    mock_control.get_run_status = AsyncMock(return_value=(run, [node_run]))
+
+    mock_acl = MagicMock()
+    mock_acl.check_user_permission = AsyncMock(return_value=None)
+
+    user_context = {"user_id": user_id, "username": "u", "groups": [], "scopes": []}
+
+    response = await get_workflow_run_status(
+        workflow_id=wf_id,
+        run_id=run_id,
+        user_context=user_context,
+        workflow_control_service=mock_control,
+        acl_service=mock_acl,
+    )
+
+    assert isinstance(response, RunStatusResponse)
+    assert response.run_id == run_id
+    assert response.workflow_id == wf_id
+    assert response.status == WorkflowRunStatus.RUNNING.value
+    assert len(response.node_runs) == 1
+    assert response.node_runs[0].node_id == "n1"
+    mock_control.get_run_status.assert_awaited_once_with(wf_id, run_id)
+
+
+@pytest.mark.asyncio
+async def test_get_workflow_run_status_nudges_continue_run_on_expired_requirement(monkeypatch):
+    """The status endpoint must trigger the lazy timeout nudge when a pending
+    requirement has passed its deadline."""
+    import asyncio
+    from datetime import UTC, datetime, timedelta
+    from types import SimpleNamespace
+
+    from registry.api.v1.workflow.workflow_routes import get_workflow_run_status
+    from registry.services import workflow_control_service as wcs_module
+    from registry_pkgs.models.enums import WorkflowRunStatus
+    from registry_pkgs.workflows.control import DirectiveQueue
+
+    wf_id = str(PydanticObjectId())
+    run_id = str(PydanticObjectId())
+    user_id = str(PydanticObjectId())
+    past = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
+
+    run = SimpleNamespace(
+        id=PydanticObjectId(run_id),
+        workflow_definition_id=PydanticObjectId(wf_id),
+        status=WorkflowRunStatus.AWAITING_APPROVAL,
+        trigger_source="api",
+        started_at=datetime.now(UTC),
+        finished_at=None,
+        paused_at=None,
+        error_summary=None,
+        parent_run_id=None,
+        pending_requirements=[{"step_id": "s1", "confirmed": None, "timeout_at": past}],
+        triggering_user_id="user-1",
+        triggering_username="u",
+        triggering_scopes=[],
+    )
+
+    fake_node_run = MagicMock()
+    fake_node_run.find.return_value.to_list = AsyncMock(return_value=[])
+    monkeypatch.setattr(wcs_module, "NodeRun", fake_node_run)
+    monkeypatch.setattr(wcs_module, "generate_service_jwt", MagicMock(return_value="svc"))
+
+    continue_mock = AsyncMock()
+    service = wcs_module.WorkflowControlService(
+        directive_queue=DirectiveQueue(),
+        runner_factory=lambda: SimpleNamespace(continue_run=continue_mock),
+    )
+    service._load_run = AsyncMock(return_value=run)
+
+    mock_acl = MagicMock()
+    mock_acl.check_user_permission = AsyncMock(return_value=None)
+
+    user_context = {"user_id": user_id, "username": "u", "groups": [], "scopes": []}
+
+    await get_workflow_run_status(
+        workflow_id=wf_id,
+        run_id=run_id,
+        user_context=user_context,
+        workflow_control_service=service,
+        acl_service=mock_acl,
+    )
+    await asyncio.sleep(0)  # let the fire-and-forget resume settle
+
+    continue_mock.assert_awaited_once()
+    assert continue_mock.await_args.kwargs["existing_run_id"] == run_id
+
+
+def test_workflow_create_request_parses_human_review_with_retry():
+    """``onReject: 'retry'`` must round-trip through the create request schema."""
+    request = WorkflowCreateRequest.model_validate(
+        {
+            "name": "Retry Demo",
+            "nodes": [
+                {
+                    "name": "gate",
+                    "nodeType": "step",
+                    "executorKey": "tool",
+                    "humanReview": {
+                        "requiresConfirmation": True,
+                        "confirmationMessage": "Proceed?",
+                        "onReject": "retry",
+                        "timeoutSeconds": 60,
+                        "onTimeout": "cancel",
+                    },
+                }
+            ],
+        }
+    )
+
+    node = request.nodes[0]
+    assert node.humanReview is not None
+    assert node.humanReview.onReject.value == "retry"

--- a/registry/tests/unit/core/test_main.py
+++ b/registry/tests/unit/core/test_main.py
@@ -22,6 +22,23 @@ def _mock_async_context_manager() -> AsyncMock:
 class TestMainApplication:
     """Test suite for main application functionality."""
 
+    @pytest.fixture(autouse=True)
+    def _reset_agno_cancellation_manager(self):
+        """Restore agno's global cancellation manager after each test.
+
+        ``lifespan`` installs a process-global MongoBackedCancellationManager
+        during startup. A startup that fails *after* that install (e.g.
+        ``test_lifespan_startup_container_failure``) never reaches shutdown, so
+        the global leaks and the next lifespan startup trips the install guard.
+        """
+        yield
+        from agno.run.cancel import set_cancellation_manager
+        from agno.run.cancellation_management.in_memory_cancellation_manager import (
+            InMemoryRunCancellationManager,
+        )
+
+        set_cancellation_manager(InMemoryRunCancellationManager())
+
     @pytest.fixture
     def mock_services(self):
         """Mock the startup/shutdown dependencies used by lifespan."""

--- a/registry/tests/unit/middleware/test_rbac.py
+++ b/registry/tests/unit/middleware/test_rbac.py
@@ -685,3 +685,165 @@ class TestIntegrationScenarios:
         # Group should be mapped to servers-read scope
         resp = client.get("/servers")
         assert resp.status_code == 200
+
+    def test_workflows_read_allows_get_workflows(self, monkeypatch):
+        """workflows-read scope allows listing and reading workflows."""
+        from registry.middleware import rbac as rbac_module
+
+        mock_settings = MagicMock()
+        mock_settings.api_version = "v1"
+        mock_settings.scopes_config = {
+            "workflows-read": [
+                {"endpoint": "/workflows", "method": "GET"},
+                {"endpoint": "/workflows/{workflow_id}", "method": "GET"},
+                {"endpoint": "/workflows/{workflow_id}/runs", "method": "GET"},
+                {"endpoint": "/workflows/{workflow_id}/runs/{run_id}", "method": "GET"},
+                {"endpoint": "/workflows/{workflow_id}/runs/{run_id}/status", "method": "GET"},
+                {"endpoint": "/workflows/{workflow_id}/versions", "method": "GET"},
+            ],
+        }
+        monkeypatch.setattr(rbac_module, "settings", mock_settings)
+
+        app = self._build_app()
+
+        @app.get("/workflows")
+        def list_workflows():
+            return {"workflows": []}
+
+        @app.get("/workflows/{workflow_id}")
+        def get_workflow(workflow_id: str):
+            return {"id": workflow_id}
+
+        @app.get("/workflows/{workflow_id}/runs/{run_id}/status")
+        def get_run_status(workflow_id: str, run_id: str):
+            return {"run_id": run_id}
+
+        app.add_middleware(ScopePermissionMiddleware)
+        app.add_middleware(self._auth_middleware_factory({"scopes": ["workflows-read"]}))
+
+        client = TestClient(app)
+        assert client.get("/workflows").status_code == 200
+        assert client.get("/workflows/abc").status_code == 200
+        assert client.get("/workflows/abc/runs/123/status").status_code == 200
+
+    def test_workflows_read_denies_write_operations(self, monkeypatch):
+        """workflows-read scope does not allow creating, updating, or deleting workflows."""
+        from registry.middleware import rbac as rbac_module
+
+        mock_settings = MagicMock()
+        mock_settings.api_version = "v1"
+        mock_settings.scopes_config = {
+            "workflows-read": [
+                {"endpoint": "/workflows", "method": "GET"},
+                {"endpoint": "/workflows/{workflow_id}", "method": "GET"},
+            ],
+            "workflows-write": [
+                {"endpoint": "/workflows", "method": "POST"},
+                {"endpoint": "/workflows/{workflow_id}", "method": "PUT,DELETE"},
+            ],
+        }
+        monkeypatch.setattr(rbac_module, "settings", mock_settings)
+
+        app = self._build_app()
+
+        @app.get("/workflows")
+        def list_workflows():
+            return {"workflows": []}
+
+        @app.post("/workflows")
+        def create_workflow():
+            return {"ok": True}
+
+        @app.put("/workflows/{workflow_id}")
+        def update_workflow(workflow_id: str):
+            return {"id": workflow_id}
+
+        @app.delete("/workflows/{workflow_id}")
+        def delete_workflow(workflow_id: str):
+            return {"deleted": workflow_id}
+
+        app.add_middleware(ScopePermissionMiddleware)
+        app.add_middleware(self._auth_middleware_factory({"scopes": ["workflows-read"]}))
+
+        client = TestClient(app)
+        assert client.get("/workflows").status_code == 200
+        assert client.post("/workflows").status_code == 403
+        assert client.put("/workflows/abc").status_code == 403
+        assert client.delete("/workflows/abc").status_code == 403
+
+    def test_workflows_control_allows_run_directives(self, monkeypatch):
+        """workflows-control scope allows triggering and controlling workflow runs."""
+        from registry.middleware import rbac as rbac_module
+
+        mock_settings = MagicMock()
+        mock_settings.api_version = "v1"
+        mock_settings.scopes_config = {
+            "workflows-read": [
+                {"endpoint": "/workflows/{workflow_id}", "method": "GET"},
+            ],
+            "workflows-control": [
+                {"endpoint": "/workflows/{workflow_id}/runs", "method": "POST"},
+                {"endpoint": "/workflows/{workflow_id}/runs/{run_id}/pause", "method": "POST"},
+                {"endpoint": "/workflows/{workflow_id}/runs/{run_id}/resume", "method": "POST"},
+                {"endpoint": "/workflows/{workflow_id}/runs/{run_id}/cancel", "method": "POST"},
+                {"endpoint": "/workflows/{workflow_id}/runs/{run_id}/retry", "method": "POST"},
+                {"endpoint": "/workflows/{workflow_id}/runs/{run_id}/approve", "method": "POST"},
+            ],
+        }
+        monkeypatch.setattr(rbac_module, "settings", mock_settings)
+
+        app = self._build_app()
+
+        @app.get("/workflows/{workflow_id}")
+        def get_workflow(workflow_id: str):
+            return {"id": workflow_id}
+
+        @app.post("/workflows/{workflow_id}/runs")
+        def trigger_run(workflow_id: str):
+            return {"run_id": "r1"}
+
+        @app.post("/workflows/{workflow_id}/runs/{run_id}/approve")
+        def approve_run(workflow_id: str, run_id: str):
+            return {"ok": True}
+
+        app.add_middleware(ScopePermissionMiddleware)
+        app.add_middleware(self._auth_middleware_factory({"scopes": ["workflows-read", "workflows-control"]}))
+
+        client = TestClient(app)
+        assert client.get("/workflows/abc").status_code == 200
+        assert client.post("/workflows/abc/runs").status_code == 200
+        assert client.post("/workflows/abc/runs/123/approve").status_code == 200
+
+    def test_workflows_control_denied_without_scope(self, monkeypatch):
+        """A user with only workflows-read cannot trigger or control runs."""
+        from registry.middleware import rbac as rbac_module
+
+        mock_settings = MagicMock()
+        mock_settings.api_version = "v1"
+        mock_settings.scopes_config = {
+            "workflows-read": [
+                {"endpoint": "/workflows/{workflow_id}", "method": "GET"},
+            ],
+            "workflows-control": [
+                {"endpoint": "/workflows/{workflow_id}/runs", "method": "POST"},
+                {"endpoint": "/workflows/{workflow_id}/runs/{run_id}/approve", "method": "POST"},
+            ],
+        }
+        monkeypatch.setattr(rbac_module, "settings", mock_settings)
+
+        app = self._build_app()
+
+        @app.get("/workflows/{workflow_id}")
+        def get_workflow(workflow_id: str):
+            return {"id": workflow_id}
+
+        @app.post("/workflows/{workflow_id}/runs")
+        def trigger_run(workflow_id: str):
+            return {"run_id": "r1"}
+
+        app.add_middleware(ScopePermissionMiddleware)
+        app.add_middleware(self._auth_middleware_factory({"scopes": ["workflows-read"]}))
+
+        client = TestClient(app)
+        assert client.get("/workflows/abc").status_code == 200
+        assert client.post("/workflows/abc/runs").status_code == 403

--- a/registry/tests/unit/middleware/test_rbac.py
+++ b/registry/tests/unit/middleware/test_rbac.py
@@ -769,7 +769,8 @@ class TestIntegrationScenarios:
         assert client.get("/workflows").status_code == 200
         assert client.post("/workflows").status_code == 403
         assert client.put("/workflows/abc").status_code == 403
-        assert client.delete("/workflows/abc").status_code == 403
+        delete_response = client.delete("/workflows/abc")
+        assert delete_response.status_code == 403
 
     def test_workflows_control_allows_run_directives(self, monkeypatch):
         """workflows-control scope allows triggering and controlling workflow runs."""

--- a/registry/tests/unit/schemas/test_workflow_api_schemas.py
+++ b/registry/tests/unit/schemas/test_workflow_api_schemas.py
@@ -202,8 +202,8 @@ def test_step_requirement_summary_hydrates_pending_user_input_fields():
     field = summary.userInputSchema[0]
     assert isinstance(field, PendingUserInputField)
     assert field.name == "fullName"
-    # agno runtime type name is passed through verbatim (not coerced to "string").
-    assert field.fieldType == "str"
+    # agno runtime type name ("str") is normalised back to the authoring vocabulary.
+    assert field.fieldType == "string"
     assert field.required is True
 
 
@@ -212,11 +212,18 @@ def test_pending_user_input_field_round_trips_snake_to_camel():
         {"name": "age", "field_type": "int", "allowed_values": [18, 21], "required": False}
     )
 
-    assert field.fieldType == "int"
+    # agno's "int" is normalised to the authoring "number".
+    assert field.fieldType == "number"
     assert field.allowedValues == [18, 21]
     assert field.required is False
 
     dumped = field.model_dump()
-    assert dumped["fieldType"] == "int"
+    assert dumped["fieldType"] == "number"
     assert dumped["allowedValues"] == [18, 21]
     assert "field_type" not in dumped
+
+
+def test_pending_user_input_field_passes_through_authoring_vocab():
+    """Already-authoring values stay stable (idempotent normalisation)."""
+    field = PendingUserInputField.model_validate({"name": "tags", "field_type": "array"})
+    assert field.fieldType == "array"

--- a/registry/tests/unit/schemas/test_workflow_api_schemas.py
+++ b/registry/tests/unit/schemas/test_workflow_api_schemas.py
@@ -1,8 +1,10 @@
 from datetime import UTC, datetime
 
 from registry.schemas.workflow_api_schemas import (
+    PendingUserInputField,
     RouterChoiceInput,
     RouterChoiceOutput,
+    StepRequirementSummary,
     WorkflowNodeInput,
     WorkflowNodeOutput,
     WorkflowRunDetailResponse,
@@ -140,3 +142,81 @@ def test_workflow_run_detail_response_uses_independent_list_defaults():
 
     assert second.resolvedDependencies == []
     assert second.nodeRuns == []
+
+
+def _agno_requirement_dict(**overrides):
+    """Mirror agno ``StepRequirement.to_dict()`` + serde envelope (snake_case keys)."""
+    base = {
+        "step_id": "step-1",
+        "step_name": "Approve",
+        "step_index": 0,
+        "step_type": "step",
+        "requires_confirmation": True,
+        "confirmation_message": "Proceed?",
+        "on_reject": "cancel",
+        "requires_user_input": False,
+        "requires_route_selection": False,
+        "allow_multiple_selections": False,
+        "requires_output_review": False,
+        "is_post_execution": False,
+        "retry_count": 0,
+        "on_timeout": "cancel",
+        "schema_version": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_step_requirement_summary_accepts_agno_snake_case_keys():
+    summary = StepRequirementSummary.model_validate(_agno_requirement_dict())
+
+    assert summary.stepId == "step-1"
+    assert summary.schemaVersion == 1
+    assert summary.requiresConfirmation is True
+
+    # Serialization stays camelCase for the frontend contract.
+    dumped = summary.model_dump()
+    assert "stepId" in dumped
+    assert "step_id" not in dumped
+
+
+def test_step_requirement_summary_hydrates_pending_user_input_fields():
+    payload = _agno_requirement_dict(
+        requires_user_input=True,
+        user_input_message="Enter your name",
+        user_input_schema=[
+            {
+                "name": "fullName",
+                "field_type": "str",
+                "description": "Full legal name",
+                "required": True,
+                "value": None,
+                "allowed_values": None,
+            }
+        ],
+    )
+
+    summary = StepRequirementSummary.model_validate(payload)
+
+    assert summary.userInputSchema is not None
+    field = summary.userInputSchema[0]
+    assert isinstance(field, PendingUserInputField)
+    assert field.name == "fullName"
+    # agno runtime type name is passed through verbatim (not coerced to "string").
+    assert field.fieldType == "str"
+    assert field.required is True
+
+
+def test_pending_user_input_field_round_trips_snake_to_camel():
+    field = PendingUserInputField.model_validate(
+        {"name": "age", "field_type": "int", "allowed_values": [18, 21], "required": False}
+    )
+
+    assert field.fieldType == "int"
+    assert field.allowedValues == [18, 21]
+    assert field.required is False
+
+    dumped = field.model_dump()
+    assert dumped["fieldType"] == "int"
+    assert dumped["allowedValues"] == [18, 21]
+    assert "field_type" not in dumped

--- a/registry/tests/unit/services/test_access_control_service.py
+++ b/registry/tests/unit/services/test_access_control_service.py
@@ -339,3 +339,67 @@ class TestACLService:
             resource_type=ResourceType.MCPSERVER,
         )
         assert result == []
+
+    @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.ExtendedAclEntry")
+    async def test_get_user_permissions_for_resources_batches_single_query(self, mock_acl_entry):
+        """Batch resolution uses a single $in query and resolves per-resource permissions."""
+        service = ACLService(user_service=Mock(), group_service=Mock())
+        rid_a, rid_b, rid_missing = PydanticObjectId(), PydanticObjectId(), PydanticObjectId()
+
+        entry_a = MagicMock(resourceId=rid_a, permBits=PermissionBits.VIEW | PermissionBits.EDIT)
+        entry_b = MagicMock(resourceId=rid_b, permBits=PermissionBits.VIEW)
+
+        mock_find_result = MagicMock()
+        mock_sort_result = MagicMock()
+        mock_sort_result.to_list = AsyncMock(return_value=[entry_a, entry_b])
+        mock_find_result.sort = MagicMock(return_value=mock_sort_result)
+        mock_acl_entry.find = MagicMock(return_value=mock_find_result)
+
+        result = await service.get_user_permissions_for_resources(
+            user_id=PydanticObjectId(),
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_ids=[rid_a, rid_b, rid_missing],
+        )
+
+        # Exactly one DB query covering all ids via $in.
+        mock_acl_entry.find.assert_called_once()
+        query = mock_acl_entry.find.call_args.args[0]
+        assert query["resourceId"] == {"$in": [rid_a, rid_b, rid_missing]}
+
+        assert result[rid_a].VIEW and result[rid_a].EDIT
+        assert result[rid_b].VIEW and not result[rid_b].EDIT
+        # A resource with no ACL entry falls back to empty permissions (no KeyError).
+        assert result[rid_missing] == ResourcePermissions()
+
+    @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.ExtendedAclEntry")
+    async def test_get_user_permissions_for_resources_empty_input_skips_query(self, mock_acl_entry):
+        """Empty resource_ids short-circuits without touching the database."""
+        service = ACLService(user_service=Mock(), group_service=Mock())
+        mock_acl_entry.find = MagicMock(side_effect=AssertionError("find must not be called"))
+
+        result = await service.get_user_permissions_for_resources(
+            user_id=PydanticObjectId(),
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_ids=[],
+        )
+
+        assert result == {}
+        mock_acl_entry.find.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.ExtendedAclEntry")
+    async def test_get_user_permissions_for_resources_exception_returns_empty_perms(self, mock_acl_entry):
+        """A DB failure degrades to empty permissions for every requested resource."""
+        service = ACLService(user_service=Mock(), group_service=Mock())
+        rid = PydanticObjectId()
+        mock_acl_entry.find = MagicMock(side_effect=Exception("db error"))
+
+        result = await service.get_user_permissions_for_resources(
+            user_id=PydanticObjectId(),
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_ids=[rid],
+        )
+
+        assert result == {rid: ResourcePermissions()}

--- a/registry/tests/unit/services/test_workflow_control_service.py
+++ b/registry/tests/unit/services/test_workflow_control_service.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from beanie import PydanticObjectId
+
+from registry.services import workflow_control_service as wcs
+from registry.services.workflow_control_service import WorkflowControlService
+from registry_pkgs.models.enums import WorkflowRunStatus
+from registry_pkgs.workflows.control import DirectiveQueue
+
+
+@pytest.mark.asyncio
+async def test_send_retry_child_inherits_workflow_version(monkeypatch: pytest.MonkeyPatch):
+    """A retry child run must inherit the parent's workflow_version so the replay
+    stays tied to the same definition version (deterministic replay)."""
+    parent_run = SimpleNamespace(
+        id=PydanticObjectId(),
+        workflow_definition_id=PydanticObjectId(),
+        workflow_version=2,
+        status=WorkflowRunStatus.FAILED,
+        initial_input={"user_text": "hi"},
+        definition_snapshot={
+            "name": "wf",
+            "version": 2,
+            "nodes": [{"id": "n1", "name": "s", "node_type": "step", "executor_key": "tool"}],
+        },
+    )
+
+    captured: dict = {}
+
+    class _FakeRun:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.id = PydanticObjectId()
+
+        async def insert(self):
+            return None
+
+    monkeypatch.setattr(wcs, "WorkflowRun", _FakeRun)
+
+    from registry_pkgs.models.workflow import WorkflowNode
+
+    class _FakeDefinition:
+        def __init__(self, **kwargs):
+            self.nodes = [WorkflowNode(**n) for n in kwargs.get("nodes", [])]
+
+    monkeypatch.setattr("registry_pkgs.models.workflow.WorkflowDefinition", _FakeDefinition)
+
+    fake_node_run = MagicMock()
+    fake_node_run.find.return_value.to_list = AsyncMock(return_value=[])
+    monkeypatch.setattr(wcs, "NodeRun", fake_node_run)
+
+    service = WorkflowControlService(
+        directive_queue=DirectiveQueue(),
+        runner_factory=lambda: SimpleNamespace(run=AsyncMock()),
+    )
+    service._load_run = AsyncMock(return_value=parent_run)
+
+    await service.send_retry(
+        str(parent_run.workflow_definition_id),
+        str(parent_run.id),
+        "n1",
+        registry_token="tok",
+        user_id="user-1",
+    )
+    # Let the fire-and-forget runner task settle to avoid pending-task warnings.
+    await asyncio.sleep(0)
+
+    assert captured["workflow_version"] == 2
+    assert captured["parent_run_id"] == parent_run.id
+    assert captured["definition_snapshot"] == parent_run.definition_snapshot

--- a/registry/tests/unit/services/test_workflow_control_service.py
+++ b/registry/tests/unit/services/test_workflow_control_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -73,3 +74,204 @@ async def test_send_retry_child_inherits_workflow_version(monkeypatch: pytest.Mo
     assert captured["workflow_version"] == 2
     assert captured["parent_run_id"] == parent_run.id
     assert captured["definition_snapshot"] == parent_run.definition_snapshot
+
+
+@pytest.mark.asyncio
+async def test_trigger_run_persists_user_id(monkeypatch: pytest.MonkeyPatch):
+    """trigger_run must capture the triggering user_id onto WorkflowRun (no raw
+    token is ever persisted — resume re-mints a service JWT from identity)."""
+    captured: dict = {}
+
+    class _FakeRun:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.id = PydanticObjectId()
+
+        async def insert(self):
+            return None
+
+    monkeypatch.setattr(wcs, "WorkflowRun", _FakeRun)
+    monkeypatch.setattr(
+        "registry_pkgs.models.workflow.WorkflowDefinition.get",
+        AsyncMock(return_value=SimpleNamespace(id=PydanticObjectId())),
+    )
+
+    service = WorkflowControlService(
+        directive_queue=DirectiveQueue(),
+        runner_factory=lambda: SimpleNamespace(run=AsyncMock()),
+    )
+
+    await service.trigger_run(
+        workflow_definition_id=str(PydanticObjectId()),
+        user_text="hello",
+        registry_token="raw-jwt",
+        user_id="user-42",
+    )
+    await asyncio.sleep(0)  # let the fire-and-forget runner task settle
+
+    assert captured["triggering_user_id"] == "user-42"
+    # The raw bearer token must never be persisted on the run.
+    assert "triggering_registry_token_encrypted" not in captured
+
+
+def test_prepare_resume_credentials_remints_service_jwt(monkeypatch: pytest.MonkeyPatch):
+    """Resume re-mints a service JWT from the persisted non-sensitive identity."""
+    minted = "fresh-service-jwt"
+    jwt_mock = MagicMock(return_value=minted)
+    monkeypatch.setattr(wcs, "generate_service_jwt", jwt_mock)
+
+    run = SimpleNamespace(
+        triggering_user_id="user-42",
+        triggering_username="alice",
+        triggering_scopes=["workflows-read", "workflows-control"],
+    )
+
+    token = wcs._prepare_resume_credentials(run)
+
+    assert token == minted
+    jwt_mock.assert_called_once_with(
+        user_id="user-42",
+        username="alice",
+        scopes=["workflows-read", "workflows-control"],
+    )
+
+
+def test_prepare_resume_credentials_without_user_id_returns_empty(monkeypatch: pytest.MonkeyPatch):
+    """Script-driven runs with no triggering_user_id resume unauthenticated ("")."""
+    jwt_mock = MagicMock()
+    monkeypatch.setattr(wcs, "generate_service_jwt", jwt_mock)
+
+    run = SimpleNamespace(triggering_user_id=None, triggering_username=None, triggering_scopes=None)
+
+    assert wcs._prepare_resume_credentials(run) == ""
+    jwt_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_trigger_run_handles_empty_token(monkeypatch: pytest.MonkeyPatch):
+    """When no user_id is provided (script-driven), triggering_user_id stays None."""
+    captured: dict = {}
+
+    class _FakeRun:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.id = PydanticObjectId()
+
+        async def insert(self):
+            return None
+
+    monkeypatch.setattr(wcs, "WorkflowRun", _FakeRun)
+    monkeypatch.setattr(
+        "registry_pkgs.models.workflow.WorkflowDefinition.get",
+        AsyncMock(return_value=SimpleNamespace(id=PydanticObjectId())),
+    )
+
+    service = WorkflowControlService(
+        directive_queue=DirectiveQueue(),
+        runner_factory=lambda: SimpleNamespace(run=AsyncMock()),
+    )
+
+    await service.trigger_run(
+        workflow_definition_id=str(PydanticObjectId()),
+        user_text="hello",
+        registry_token="",  # empty
+        user_id=None,
+    )
+    await asyncio.sleep(0)
+
+    assert captured["triggering_user_id"] is None
+    assert "triggering_registry_token_encrypted" not in captured
+
+
+def _req(*, confirmed=None, timeout_at=None, step_id="s1"):
+    """Build a serialized pending-requirement dict like agno's StepRequirement.to_dict()."""
+    return {"step_id": step_id, "confirmed": confirmed, "timeout_at": timeout_at}
+
+
+class TestHasTimedOutRequirement:
+    """_has_timed_out_requirement detects unresolved requirements past timeout_at."""
+
+    def test_past_deadline_returns_true(self):
+        past = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
+        run = SimpleNamespace(pending_requirements=[_req(timeout_at=past)])
+        assert wcs._has_timed_out_requirement(run) is True
+
+    def test_future_deadline_returns_false(self):
+        future = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+        run = SimpleNamespace(pending_requirements=[_req(timeout_at=future)])
+        assert wcs._has_timed_out_requirement(run) is False
+
+    def test_no_timeout_at_returns_false(self):
+        run = SimpleNamespace(pending_requirements=[_req(timeout_at=None)])
+        assert wcs._has_timed_out_requirement(run) is False
+
+    def test_already_resolved_requirement_is_ignored(self):
+        past = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
+        run = SimpleNamespace(pending_requirements=[_req(confirmed=True, timeout_at=past)])
+        assert wcs._has_timed_out_requirement(run) is False
+
+    def test_naive_datetime_is_treated_as_utc(self):
+        past_naive = (datetime.now(UTC) - timedelta(minutes=1)).replace(tzinfo=None).isoformat()
+        run = SimpleNamespace(pending_requirements=[_req(timeout_at=past_naive)])
+        assert wcs._has_timed_out_requirement(run) is True
+
+
+@pytest.mark.asyncio
+async def test_get_run_status_nudges_continue_run_when_requirement_timed_out(monkeypatch: pytest.MonkeyPatch):
+    """A polled AWAITING_APPROVAL run with an expired requirement triggers continue_run
+    so agno can apply the gate's on_timeout policy."""
+    past = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
+    run = SimpleNamespace(
+        id=PydanticObjectId(),
+        status=WorkflowRunStatus.AWAITING_APPROVAL,
+        pending_requirements=[_req(timeout_at=past)],
+        triggering_user_id="user-1",
+        triggering_username="u",
+        triggering_scopes=[],
+    )
+
+    fake_node_run = MagicMock()
+    fake_node_run.find.return_value.to_list = AsyncMock(return_value=[])
+    monkeypatch.setattr(wcs, "NodeRun", fake_node_run)
+    monkeypatch.setattr(wcs, "generate_service_jwt", MagicMock(return_value="svc"))
+
+    continue_mock = AsyncMock()
+    service = WorkflowControlService(
+        directive_queue=DirectiveQueue(),
+        runner_factory=lambda: SimpleNamespace(continue_run=continue_mock),
+    )
+    service._load_run = AsyncMock(return_value=run)
+
+    await service.get_run_status(str(PydanticObjectId()), str(run.id))
+    await asyncio.sleep(0)  # let the fire-and-forget resume settle
+
+    continue_mock.assert_awaited_once()
+    assert continue_mock.await_args.kwargs["existing_run_id"] == str(run.id)
+
+
+@pytest.mark.asyncio
+async def test_get_run_status_does_not_nudge_when_not_timed_out(monkeypatch: pytest.MonkeyPatch):
+    """No expired requirement → no continue_run side effect on a status poll."""
+    future = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+    run = SimpleNamespace(
+        id=PydanticObjectId(),
+        status=WorkflowRunStatus.AWAITING_APPROVAL,
+        pending_requirements=[_req(timeout_at=future)],
+        triggering_user_id="user-1",
+    )
+
+    fake_node_run = MagicMock()
+    fake_node_run.find.return_value.to_list = AsyncMock(return_value=[])
+    monkeypatch.setattr(wcs, "NodeRun", fake_node_run)
+
+    continue_mock = AsyncMock()
+    service = WorkflowControlService(
+        directive_queue=DirectiveQueue(),
+        runner_factory=lambda: SimpleNamespace(continue_run=continue_mock),
+    )
+    service._load_run = AsyncMock(return_value=run)
+
+    await service.get_run_status(str(PydanticObjectId()), str(run.id))
+    await asyncio.sleep(0)
+
+    continue_mock.assert_not_awaited()

--- a/registry/tests/unit/services/test_workflow_service.py
+++ b/registry/tests/unit/services/test_workflow_service.py
@@ -1,6 +1,9 @@
 import re
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
+from beanie import PydanticObjectId
 
 from registry.schemas.workflow_api_schemas import (
     RouterChoiceInput,
@@ -367,3 +370,117 @@ async def test_trigger_run_resolves_requested_historical_version(monkeypatch: py
 
     assert captured["workflow_version"] == 2
     assert captured["definition_snapshot"] == {"snapshot": "v2"}
+
+
+@pytest.mark.asyncio
+async def test_delete_workflow_cascades_agno_sessions(monkeypatch: pytest.MonkeyPatch):
+    """delete_workflow must purge agno_workflow_sessions keyed by run id (GC + PII cleanup)."""
+    workflow_oid = PydanticObjectId()
+    run_ids = [PydanticObjectId(), PydanticObjectId()]
+    deleted_session_query = {}
+    workflow_deleted = []
+
+    async def _wf_delete():
+        workflow_deleted.append(True)
+
+    workflow = SimpleNamespace(id=workflow_oid, name="wf", delete=_wf_delete)
+    monkeypatch.setattr(WorkflowService, "get_workflow_by_id", AsyncMock(return_value=workflow))
+
+    runs = [SimpleNamespace(id=rid) for rid in run_ids]
+
+    class _RunQuery:
+        async def to_list(self):
+            return runs
+
+        async def delete(self):
+            return None
+
+    class _DeleteQuery:
+        async def delete(self):
+            return None
+
+    # Replace the whole Beanie classes: ``delete_workflow`` evaluates
+    # ``WorkflowRun.workflow_definition_id == ...`` at class level, which is a
+    # field descriptor only available once Beanie is initialized.
+    class _FakeWorkflowRun:
+        workflow_definition_id = "workflow_definition_id"
+
+        @staticmethod
+        def find(*_a, **_k):
+            return _RunQuery()
+
+    class _FakeNodeRun:
+        @staticmethod
+        def find(*_a, **_k):
+            return _DeleteQuery()
+
+    class _FakeWorkflowVersion:
+        @staticmethod
+        def find(*_a, **_k):
+            return _DeleteQuery()
+
+    monkeypatch.setattr(workflow_service, "WorkflowRun", _FakeWorkflowRun)
+    monkeypatch.setattr(workflow_service, "NodeRun", _FakeNodeRun)
+    monkeypatch.setattr(workflow_service, "WorkflowVersion", _FakeWorkflowVersion)
+
+    class _Collection:
+        async def delete_many(self, query):
+            deleted_session_query.update(query)
+            return SimpleNamespace(deleted_count=len(run_ids))
+
+    class _Db:
+        def get_collection(self, name):
+            assert name == "agno_workflow_sessions"
+            return _Collection()
+
+    monkeypatch.setattr(workflow_service.MongoDB, "get_database", staticmethod(lambda: _Db()))
+
+    result = await WorkflowService().delete_workflow(str(workflow_oid))
+
+    assert result is True
+    assert workflow_deleted == [True]
+    assert deleted_session_query == {"session_id": {"$in": [str(rid) for rid in run_ids]}}
+
+
+@pytest.mark.asyncio
+async def test_trigger_workflow_run_persists_triggering_identity(monkeypatch: pytest.MonkeyPatch):
+    """The live trigger path must persist the triggering user's non-sensitive
+    identity (user_id / username / scopes) so an HITL resume can re-mint a
+    service JWT on their behalf."""
+    fake_wf = _FakeWorkflow(version=3)
+
+    async def fake_get(self, workflow_id):
+        return fake_wf
+
+    monkeypatch.setattr(WorkflowService, "get_workflow_by_id", fake_get)
+
+    historical = SimpleNamespace(version=2, definition={"snapshot": "v2"})
+
+    async def fake_find_one(*_a, **_k):
+        return historical
+
+    monkeypatch.setattr(workflow_service.WorkflowVersion, "find_one", fake_find_one)
+
+    captured: dict = {}
+
+    class _FakeRun:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.id = PydanticObjectId()
+
+        async def insert(self):
+            return None
+
+    monkeypatch.setattr(workflow_service, "WorkflowRun", _FakeRun)
+
+    await WorkflowService().trigger_workflow_run(
+        workflow_id=str(fake_wf.id),
+        version=2,
+        triggering_user_id="user-42",
+        triggering_username="alice",
+        triggering_scopes=["workflows-read", "workflows-control"],
+    )
+
+    assert captured["triggering_user_id"] == "user-42"
+    assert captured["triggering_username"] == "alice"
+    assert captured["triggering_scopes"] == ["workflows-read", "workflows-control"]

--- a/registry/tests/unit/services/test_workflow_service.py
+++ b/registry/tests/unit/services/test_workflow_service.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 from beanie import PydanticObjectId
+from fastapi import HTTPException
+from pymongo.errors import DuplicateKeyError
 
 from registry.schemas.workflow_api_schemas import (
     RouterChoiceInput,
@@ -12,6 +14,7 @@ from registry.schemas.workflow_api_schemas import (
 )
 from registry.services import workflow_service
 from registry.services.workflow_service import WorkflowService
+from registry_pkgs.database.mongodb import MongoDB
 
 
 class _WorkflowFindQuery:
@@ -224,6 +227,69 @@ class _FakeWorkflow:
         self.saved = True
 
 
+# ── Transaction + collection mocks for update_workflow (@use_transaction) ──────
+
+
+class _FakeTxnCtx:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeTxnSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def start_transaction(self):
+        return _FakeTxnCtx()
+
+
+class _FakeTxnClient:
+    def start_session(self):
+        return _FakeTxnSession()
+
+
+def _patch_update_transaction(monkeypatch, *, found_doc, refreshed=None, insert_exc=None):
+    """Patch the transaction + collection machinery used by update_workflow.
+
+    Args:
+        found_doc:   What ``find_one_and_update`` returns (None simulates a lost
+                     optimistic-lock race → 409).
+        refreshed:   Object returned by the final ``WorkflowDefinition.get`` re-fetch.
+        insert_exc:  Exception raised by ``WorkflowVersion.insert`` (e.g. DuplicateKeyError).
+
+    Returns ``(collection, inserted)`` where ``collection.find_one_and_update`` is an
+    AsyncMock and ``inserted`` collects archived WorkflowVersion kwargs.
+    """
+    from registry.services.workflow_service import WorkflowDefinition
+
+    monkeypatch.setattr(MongoDB, "get_client", lambda: _FakeTxnClient())
+    collection = SimpleNamespace(find_one_and_update=AsyncMock(return_value=found_doc))
+    fake_db = SimpleNamespace(get_collection=lambda _name: collection)
+    monkeypatch.setattr(MongoDB, "get_database", lambda: fake_db)
+    monkeypatch.setattr(WorkflowDefinition, "get_settings", lambda: SimpleNamespace(name="workflow_definitions"))
+    monkeypatch.setattr(WorkflowDefinition, "get", AsyncMock(return_value=refreshed))
+
+    inserted: list[dict] = []
+
+    class _FakeWorkflowVersion:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def insert(self, session=None):
+            if insert_exc is not None:
+                raise insert_exc
+            inserted.append(self.kwargs)
+
+    monkeypatch.setattr(workflow_service, "WorkflowVersion", _FakeWorkflowVersion)
+    return collection, inserted
+
+
 @pytest.mark.asyncio
 async def test_update_workflow_bumps_version_and_snapshots_history(monkeypatch: pytest.MonkeyPatch):
     from registry.schemas.workflow_api_schemas import WorkflowUpdateRequest
@@ -235,28 +301,26 @@ async def test_update_workflow_bumps_version_and_snapshots_history(monkeypatch: 
 
     monkeypatch.setattr(WorkflowService, "get_workflow_by_id", fake_get)
 
-    inserted: list[dict] = []
-
-    class _FakeWorkflowVersion:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-        async def insert(self):
-            inserted.append(self.kwargs)
-
-    monkeypatch.setattr(workflow_service, "WorkflowVersion", _FakeWorkflowVersion)
+    refreshed = SimpleNamespace(id=fake_wf.id, version=5, name="new-name")
+    collection, inserted = _patch_update_transaction(
+        monkeypatch, found_doc={"_id": fake_wf.id, "version": 5}, refreshed=refreshed
+    )
 
     result = await WorkflowService().update_workflow(
         workflow_id=str(fake_wf.id),
         data=WorkflowUpdateRequest(name="new-name"),
     )
 
-    # Version bumped on the live document
+    # Returned the re-fetched, version-bumped document.
     assert result.version == 5
     assert result.name == "new-name"
-    assert fake_wf.saved is True
 
-    # Prior version (4) archived into history with a checksum
+    # The bump used an optimistic conditional filter (version == previous_version).
+    call = collection.find_one_and_update.await_args
+    assert call.args[0] == {"_id": fake_wf.id, "version": 4}
+    assert call.args[1]["$set"]["version"] == 5
+
+    # Prior version (4) archived into history with a checksum.
     assert len(inserted) == 1
     assert inserted[0]["version"] == 4
     assert inserted[0]["workflow_id"] == fake_wf.id
@@ -264,9 +328,58 @@ async def test_update_workflow_bumps_version_and_snapshots_history(monkeypatch: 
 
 
 @pytest.mark.asyncio
+async def test_update_workflow_returns_409_on_concurrent_modification(monkeypatch: pytest.MonkeyPatch):
+    """When a concurrent writer bumped the version first, the conditional update
+    matches nothing → 409 (lost-update prevention), and no history row is written."""
+    from registry.schemas.workflow_api_schemas import WorkflowUpdateRequest
+
+    fake_wf = _FakeWorkflow(version=4)
+
+    async def fake_get(self, workflow_id):
+        return fake_wf
+
+    monkeypatch.setattr(WorkflowService, "get_workflow_by_id", fake_get)
+    _collection, inserted = _patch_update_transaction(monkeypatch, found_doc=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await WorkflowService().update_workflow(
+            workflow_id=str(fake_wf.id), data=WorkflowUpdateRequest(name="new-name")
+        )
+
+    assert exc_info.value.status_code == 409
+    assert inserted == []  # no version archived when the bump lost the race
+
+
+@pytest.mark.asyncio
+async def test_update_workflow_returns_409_on_duplicate_version(monkeypatch: pytest.MonkeyPatch):
+    """A racing archive of the same (workflow_id, version) violates the unique index;
+    the DuplicateKeyError is mapped to 409 rather than bubbling up as a 500."""
+    from registry.schemas.workflow_api_schemas import WorkflowUpdateRequest
+
+    fake_wf = _FakeWorkflow(version=4)
+
+    async def fake_get(self, workflow_id):
+        return fake_wf
+
+    monkeypatch.setattr(WorkflowService, "get_workflow_by_id", fake_get)
+    _patch_update_transaction(
+        monkeypatch,
+        found_doc={"_id": fake_wf.id, "version": 5},
+        insert_exc=DuplicateKeyError("E11000 duplicate key"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await WorkflowService().update_workflow(
+            workflow_id=str(fake_wf.id), data=WorkflowUpdateRequest(name="new-name")
+        )
+
+    assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
 async def test_update_workflow_invalid_nodes_writes_nothing(monkeypatch: pytest.MonkeyPatch):
-    """A model-validation failure mid-update must not bump the version, save the
-    document, or leave an orphan version-history row."""
+    """A model-validation failure mid-update must not bump the version or leave an
+    orphan version-history row (validation runs before any DB write)."""
     from registry.schemas.workflow_api_schemas import WorkflowNodeInput, WorkflowUpdateRequest
 
     fake_wf = _FakeWorkflow(version=4)
@@ -275,17 +388,7 @@ async def test_update_workflow_invalid_nodes_writes_nothing(monkeypatch: pytest.
         return fake_wf
 
     monkeypatch.setattr(WorkflowService, "get_workflow_by_id", fake_get)
-
-    inserted: list[dict] = []
-
-    class _FakeWorkflowVersion:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-        async def insert(self):
-            inserted.append(self.kwargs)
-
-    monkeypatch.setattr(workflow_service, "WorkflowVersion", _FakeWorkflowVersion)
+    collection, inserted = _patch_update_transaction(monkeypatch, found_doc={"_id": fake_wf.id, "version": 5})
 
     # A parallel node with no children fails WorkflowNode shape validation during conversion.
     bad_update = WorkflowUpdateRequest(nodes=[WorkflowNodeInput(name="p", nodeType="parallel")])
@@ -293,10 +396,9 @@ async def test_update_workflow_invalid_nodes_writes_nothing(monkeypatch: pytest.
     with pytest.raises(ValueError, match="parallel node requires at least 2 children"):
         await WorkflowService().update_workflow(workflow_id=str(fake_wf.id), data=bad_update)
 
-    # No history row written, version not bumped, document not saved.
+    # Validation raised before the conditional update or any history write.
+    collection.find_one_and_update.assert_not_awaited()
     assert inserted == []
-    assert fake_wf.version == 4
-    assert fake_wf.saved is False
 
 
 @pytest.mark.asyncio

--- a/registry/tests/unit/services/test_workflow_service.py
+++ b/registry/tests/unit/services/test_workflow_service.py
@@ -191,3 +191,179 @@ def test_convert_api_node_preserves_explicit_id():
     api_node = WorkflowNodeInput(id="custom-id", name="x", nodeType="step", executorKey="tool")
     model = WorkflowService()._convert_api_node_to_model(api_node)
     assert model.id == "custom-id"
+
+
+# ---------------------------------------------------------------------------
+# Versioning
+# ---------------------------------------------------------------------------
+class _FakeWorkflow:
+    """Stand-in for a loaded WorkflowDefinition supporting version + save."""
+
+    def __init__(self, version: int = 1):
+        from datetime import UTC, datetime
+
+        from beanie import PydanticObjectId
+
+        self.id = PydanticObjectId()
+        self.name = "old-name"
+        self.description = None
+        self.version = version
+        self.updated_at = datetime.now(UTC)
+        self.saved = False
+
+    def model_dump(self, mode: str | None = None):
+        return {"name": self.name, "version": self.version}
+
+    def model_dump_json(self):
+        return f'{{"name": "{self.name}", "version": {self.version}}}'
+
+    async def save(self):
+        self.saved = True
+
+
+@pytest.mark.asyncio
+async def test_update_workflow_bumps_version_and_snapshots_history(monkeypatch: pytest.MonkeyPatch):
+    from registry.schemas.workflow_api_schemas import WorkflowUpdateRequest
+
+    fake_wf = _FakeWorkflow(version=4)
+
+    async def fake_get(self, workflow_id):
+        return fake_wf
+
+    monkeypatch.setattr(WorkflowService, "get_workflow_by_id", fake_get)
+
+    inserted: list[dict] = []
+
+    class _FakeWorkflowVersion:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def insert(self):
+            inserted.append(self.kwargs)
+
+    monkeypatch.setattr(workflow_service, "WorkflowVersion", _FakeWorkflowVersion)
+
+    result = await WorkflowService().update_workflow(
+        workflow_id=str(fake_wf.id),
+        data=WorkflowUpdateRequest(name="new-name"),
+    )
+
+    # Version bumped on the live document
+    assert result.version == 5
+    assert result.name == "new-name"
+    assert fake_wf.saved is True
+
+    # Prior version (4) archived into history with a checksum
+    assert len(inserted) == 1
+    assert inserted[0]["version"] == 4
+    assert inserted[0]["workflow_id"] == fake_wf.id
+    assert isinstance(inserted[0]["checksum"], str) and len(inserted[0]["checksum"]) == 64
+
+
+@pytest.mark.asyncio
+async def test_update_workflow_invalid_nodes_writes_nothing(monkeypatch: pytest.MonkeyPatch):
+    """A model-validation failure mid-update must not bump the version, save the
+    document, or leave an orphan version-history row."""
+    from registry.schemas.workflow_api_schemas import WorkflowNodeInput, WorkflowUpdateRequest
+
+    fake_wf = _FakeWorkflow(version=4)
+
+    async def fake_get(self, workflow_id):
+        return fake_wf
+
+    monkeypatch.setattr(WorkflowService, "get_workflow_by_id", fake_get)
+
+    inserted: list[dict] = []
+
+    class _FakeWorkflowVersion:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def insert(self):
+            inserted.append(self.kwargs)
+
+    monkeypatch.setattr(workflow_service, "WorkflowVersion", _FakeWorkflowVersion)
+
+    # A parallel node with no children fails WorkflowNode shape validation during conversion.
+    bad_update = WorkflowUpdateRequest(nodes=[WorkflowNodeInput(name="p", nodeType="parallel")])
+
+    with pytest.raises(ValueError, match="parallel node requires at least 2 children"):
+        await WorkflowService().update_workflow(workflow_id=str(fake_wf.id), data=bad_update)
+
+    # No history row written, version not bumped, document not saved.
+    assert inserted == []
+    assert fake_wf.version == 4
+    assert fake_wf.saved is False
+
+
+@pytest.mark.asyncio
+async def test_list_versions_includes_history_and_current(monkeypatch: pytest.MonkeyPatch):
+    fake_wf = _FakeWorkflow(version=3)
+
+    async def fake_get(self, workflow_id):
+        return fake_wf
+
+    monkeypatch.setattr(WorkflowService, "get_workflow_by_id", fake_get)
+
+    from datetime import UTC, datetime
+    from types import SimpleNamespace
+
+    history = [
+        SimpleNamespace(version=1, created_at=datetime.now(UTC), checksum="c1"),
+        SimpleNamespace(version=2, created_at=datetime.now(UTC), checksum="c2"),
+    ]
+
+    class _Query:
+        def sort(self, *_a, **_k):
+            return self
+
+        async def to_list(self):
+            return history
+
+    monkeypatch.setattr(workflow_service.WorkflowVersion, "find", lambda *_a, **_k: _Query())
+
+    versions = await WorkflowService().list_versions(str(fake_wf.id))
+
+    assert [v["version"] for v in versions] == [1, 2, 3]  # history + current
+    assert versions[-1]["version"] == 3  # current appended last
+
+
+@pytest.mark.asyncio
+async def test_trigger_run_resolves_requested_historical_version(monkeypatch: pytest.MonkeyPatch):
+    from types import SimpleNamespace
+
+    fake_wf = _FakeWorkflow(version=3)
+
+    async def fake_get(self, workflow_id):
+        return fake_wf
+
+    monkeypatch.setattr(WorkflowService, "get_workflow_by_id", fake_get)
+
+    historical = SimpleNamespace(version=2, definition={"snapshot": "v2"})
+
+    async def fake_find_one(*_a, **_k):
+        return historical
+
+    monkeypatch.setattr(workflow_service.WorkflowVersion, "find_one", fake_find_one)
+
+    captured: dict = {}
+
+    class _FakeRun:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            from beanie import PydanticObjectId
+
+            self.id = PydanticObjectId()
+            self.status = kwargs.get("status")
+            self.trigger_source = kwargs.get("trigger_source")
+            self.workflow_definition_id = kwargs.get("workflow_definition_id")
+
+        async def insert(self):
+            return None
+
+    monkeypatch.setattr(workflow_service, "WorkflowRun", _FakeRun)
+
+    await WorkflowService().trigger_workflow_run(workflow_id=str(fake_wf.id), version=2)
+
+    assert captured["workflow_version"] == 2
+    assert captured["definition_snapshot"] == {"snapshot": "v2"}

--- a/scripts/verify_workflow_control_e2e.py
+++ b/scripts/verify_workflow_control_e2e.py
@@ -1,0 +1,1108 @@
+"""End-to-end verification for AS-1543 features against a real MongoDB.
+
+Covers 9 modules / 34 checks:
+  A. ACL                  (2)  — creator OWNER, 403 without scope+ACL
+  B. Versioning           (7)  — PUT bump, checksum, history, version param, in-flight snapshot
+  C. HITL approval gate   (11) — confirm/reject(skip/cancel/else_branch)/user_input/edit/route_select
+                                 + multi-step chain, Condition+confirm, cross-session restore.
+                                 Assertions verify branch selection + data propagation, not just COMPLETED.
+  D. Cancel               (5)  — running/awaiting-approval/agno bridge/idempotent/terminal-state
+  E. Cascade delete       (1)  — workflow_definitions + runs + node_runs + versions + agno sessions
+  F. Run query            (2)  — list, detail with pendingRequirements
+  G. Retry                (1)  — retry a COMPLETED run from a node
+  H. Pause/Resume smoke   (1)  — pause → resume → completes
+  I. Error paths          (4)  — 404 / 400 invalid version / 409 terminal cancel / 400 bad node
+
+Usage:
+    uv run python scripts/verify_workflow_control_e2e.py                    # run all
+    uv run python scripts/verify_workflow_control_e2e.py --modules A,C,D    # subset
+    uv run python scripts/verify_workflow_control_e2e.py --keep-data        # keep test data on exit
+
+Pattern follows ``scripts/test_control_e2e.py``: direct service+runner calls
+against real MongoDB; ACL/route layers covered by their unit tests.  Mock step
+executor returns instantly so e2e total runtime stays under ~2 min.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+
+from agno.models.aws import AwsBedrock
+from agno.workflow import StepInput, StepOutput
+from agno.workflow.step import StepExecutor
+from beanie import PydanticObjectId
+from dotenv import load_dotenv
+from fastapi import HTTPException
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+from registry import settings  # noqa: E402
+from registry.schemas.workflow_api_schemas import (  # noqa: E402
+    HumanReviewInput,
+    UserInputFieldSchema,
+    WorkflowCreateRequest,
+    WorkflowNodeInput,
+    WorkflowUpdateRequest,
+    _convert_node_to_input,
+)
+from registry.services.access_control_service import ACLService  # noqa: E402
+from registry.services.group_service import GroupService  # noqa: E402
+from registry.services.user_service import UserService  # noqa: E402
+from registry.services.workflow_control_service import WorkflowControlService  # noqa: E402
+from registry.services.workflow_service import WorkflowService  # noqa: E402
+from registry_pkgs.core.config import MongoConfig  # noqa: E402
+from registry_pkgs.database.mongodb import MongoDB  # noqa: E402
+from registry_pkgs.models import PrincipalType  # noqa: E402
+from registry_pkgs.models.enums import (  # noqa: E402
+    OnRejectPolicy,
+    OnTimeoutPolicy,
+    RequirementResolution,
+    RoleBits,
+    WorkflowRunStatus,
+)
+from registry_pkgs.models.extended_acl_entry import ExtendedResourceType  # noqa: E402
+from registry_pkgs.models.workflow import NodeRun, WorkflowDefinition, WorkflowRun, WorkflowVersion  # noqa: E402
+from registry_pkgs.workflows.compiler import flatten_workflow_nodes  # noqa: E402
+from registry_pkgs.workflows.control import DirectiveQueue  # noqa: E402
+from registry_pkgs.workflows.runner import WorkflowRunner  # noqa: E402
+
+logging.basicConfig(level=logging.WARNING, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+logger = logging.getLogger("as1543_e2e")
+
+PASS = "✅"
+FAIL = "❌"
+SKIP = "·"
+PREFIX = "__as1543_e2e__"
+USER_A = PydanticObjectId()
+USER_B = PydanticObjectId()
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Mock runner — instant executors for fast e2e
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class MockRunner(WorkflowRunner):
+    """Replace MCP/A2A executors with instant in-process mocks."""
+
+    async def _build_registry(self, definition, registry_token, user_id):
+        all_nodes = flatten_workflow_nodes(definition.nodes)
+        keys = list(dict.fromkeys(n.executor_key for n in all_nodes if n.executor_key))
+
+        def make(key: str) -> StepExecutor:
+            async def mock(step_input: StepInput, session_state: dict | None = None) -> StepOutput:
+                await asyncio.sleep(0.05)
+                # Echo prior step content + any HITL user_input so downstream nodes
+                # (and the persisted NodeRun.output_snapshot) can verify propagation.
+                # agno surfaces collected user_input via step_input.additional_data.
+                prior = getattr(step_input, "previous_step_content", None)
+                extra = getattr(step_input, "additional_data", None) or {}
+                user_input = extra.get("user_input")
+                content = f"{key}:OK(prior={prior!r}"
+                if user_input:
+                    content += f", user_input={user_input!r}"
+                content += ")"
+                return StepOutput(content=content, success=True)
+
+            return mock
+
+        return {k: make(k) for k in keys}
+
+
+def _build_runner(queue: DirectiveQueue) -> MockRunner:
+    llm = AwsBedrock(
+        id=os.getenv("BEDROCK_MODEL", "us.amazon.nova-lite-v1:0"),
+        aws_region=settings.aws_region,
+        aws_session_token=settings.aws_session_token,
+        aws_access_key_id=settings.aws_access_key_id,
+        aws_secret_access_key=settings.aws_secret_access_key,
+    )
+    return MockRunner(
+        llm=llm,
+        registry_url=os.getenv("REGISTRY_URL", "http://localhost:7860"),
+        db_client=MongoDB.get_client(),
+        db_name=MongoDB.database_name,
+        jwt_config=settings.jwt_signing_config,
+        directive_queue=queue,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Test infra
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class Report:
+    """Per-module results."""
+
+    def __init__(self, module: str) -> None:
+        self.module = module
+        self.checks: list[tuple[str, bool, str]] = []
+
+    def check(self, name: str, ok: bool, detail: str = "") -> bool:
+        self.checks.append((name, ok, detail))
+        glyph = PASS if ok else FAIL
+        suffix = f" — {detail}" if detail else ""
+        print(f"  {glyph}  {name}{suffix}")
+        return ok
+
+    @property
+    def passed(self) -> int:
+        return sum(1 for _, ok, _ in self.checks if ok)
+
+    @property
+    def total(self) -> int:
+        return len(self.checks)
+
+
+async def _poll(predicate, timeout: float = 30.0, interval: float = 0.2):
+    """Poll an async predicate until it returns truthy or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = await predicate()
+        if result:
+            return result
+        await asyncio.sleep(interval)
+    return None
+
+
+async def _make_workflow(
+    workflow_service: WorkflowService,
+    acl_service: ACLService,
+    name: str,
+    nodes: list[WorkflowNodeInput],
+    *,
+    creator: PydanticObjectId = USER_A,
+) -> WorkflowDefinition:
+    req = WorkflowCreateRequest(name=PREFIX + name, description="e2e", nodes=nodes)
+    workflow = await workflow_service.create_workflow(data=req)
+    await acl_service.grant_permission(
+        principal_type=PrincipalType.USER,
+        principal_id=creator,
+        resource_type=ExtendedResourceType.WORKFLOW,
+        resource_id=workflow.id,
+        perm_bits=RoleBits.OWNER,
+    )
+    return workflow
+
+
+def _step_input(name: str, executor_key: str = "tool-x", **kw) -> WorkflowNodeInput:
+    return WorkflowNodeInput(name=name, nodeType="step", executorKey=executor_key, **kw)
+
+
+def _hitl_input(**kw) -> HumanReviewInput:
+    """Build a HumanReviewInput with sensible defaults; override via kwargs."""
+    defaults: dict = {
+        "requiresConfirmation": False,
+        "requiresUserInput": False,
+        "requiresOutputReview": False,
+        "requiresIterationReview": False,
+        "onReject": OnRejectPolicy.SKIP,
+        "onTimeout": OnTimeoutPolicy.CANCEL,
+    }
+    defaults.update(kw)
+    return HumanReviewInput(**defaults)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Trigger-and-wait helper used by HITL / Cancel / Retry modules
+# ────────────────────────────────────────────────────────────────────────────
+
+
+async def _trigger_run_inproc(
+    runner: MockRunner,
+    workflow_id: str,
+) -> tuple[str, asyncio.Task]:
+    """Insert a PENDING WorkflowRun and start runner.run() in the background.
+
+    Returns (run_id, task).  Caller is responsible for awaiting the task or
+    cancelling it during cleanup.
+    """
+    run = WorkflowRun(
+        workflow_definition_id=PydanticObjectId(workflow_id),
+        status=WorkflowRunStatus.PENDING,
+        trigger_source="e2e",
+        initial_input={"user_text": "e2e"},
+        triggering_user_id=str(USER_A),
+    )
+    await run.insert()
+    task = asyncio.create_task(
+        runner.run(workflow_id, "e2e", registry_token="test", user_id=str(USER_A), existing_run_id=str(run.id))
+    )
+    return str(run.id), task
+
+
+async def _wait_status(run_id: str, *targets: WorkflowRunStatus, timeout: float = 30.0) -> WorkflowRun | None:
+    async def check():
+        run = await WorkflowRun.get(PydanticObjectId(run_id))
+        if run is None:
+            return None
+        return run if run.status in targets else None
+
+    return await _poll(check, timeout=timeout)
+
+
+async def _node_runs(run_id: str) -> list[NodeRun]:
+    return await NodeRun.find(NodeRun.workflow_run_id == PydanticObjectId(run_id)).to_list()
+
+
+async def _completed_names(run_id: str) -> set[str]:
+    """Names of NodeRuns that reached COMPLETED for this run."""
+    return {nr.node_name for nr in await _node_runs(run_id) if str(nr.status) == "completed"}
+
+
+async def _node_output(run_id: str, node_name: str) -> str:
+    """Persisted output_snapshot content for a named node ('' if absent)."""
+    for nr in await _node_runs(run_id):
+        if nr.node_name == node_name and nr.output_snapshot:
+            return nr.output_snapshot.get("content", "") or ""
+    return ""
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Module A — ACL  (2 checks)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+async def module_a(workflow_service, control_service, acl_service) -> Report:
+    r = Report("A. ACL")
+    nodes = [_step_input("only-step")]
+
+    # A1: creator gets OWNER (permBits=15)
+    workflow = await workflow_service.create_workflow(
+        data=WorkflowCreateRequest(name=PREFIX + "acl-creator", description="", nodes=nodes)
+    )
+    await acl_service.grant_permission(
+        principal_type=PrincipalType.USER,
+        principal_id=USER_A,
+        resource_type=ExtendedResourceType.WORKFLOW,
+        resource_id=workflow.id,
+        perm_bits=RoleBits.OWNER,
+    )
+    perms = await acl_service.get_user_permissions_for_resource(
+        user_id=USER_A,
+        resource_type=ExtendedResourceType.WORKFLOW.value,
+        resource_id=workflow.id,
+    )
+    r.check(
+        "A1 creator gets OWNER (VIEW+EDIT+DELETE+SHARE)",
+        perms.VIEW and perms.EDIT and perms.DELETE and perms.SHARE,
+        f"permBits view={perms.VIEW} edit={perms.EDIT} delete={perms.DELETE} share={perms.SHARE}",
+    )
+
+    # A2: user_b without ACL → check_user_permission raises 403
+    raised = False
+    try:
+        await acl_service.check_user_permission(
+            user_id=USER_B,
+            resource_type=ExtendedResourceType.WORKFLOW.value,
+            resource_id=workflow.id,
+            required_permission="VIEW",
+        )
+    except HTTPException as exc:
+        raised = exc.status_code == 403
+    r.check("A2 user_b without ACL → 403 on VIEW check", raised)
+
+    return r
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Module B — Versioning  (7 checks)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+async def module_b(workflow_service, control_service, acl_service) -> Report:
+    r = Report("B. Versioning")
+
+    # B1: POST → version=1 + checksum stored
+    nodes_v1 = [_step_input("s1", "tool-v1")]
+    wf = await _make_workflow(workflow_service, acl_service, "ver-1", nodes_v1)
+    r.check("B1 newly-created workflow.version == 1", wf.version == 1, f"version={wf.version}")
+
+    # B2: PUT → version bumps, prior captured in WorkflowVersion
+    nodes_v2 = [_step_input("s1", "tool-v2"), _step_input("s2", "tool-v2b")]
+    updated = await workflow_service.update_workflow(
+        str(wf.id),
+        WorkflowUpdateRequest(name=wf.name, description=wf.description, nodes=nodes_v2),
+    )
+    r.check("B2 PUT bumps to version=2", updated.version == 2, f"version={updated.version}")
+
+    history = await WorkflowVersion.find(WorkflowVersion.workflow_id == wf.id).sort("version").to_list()
+    r.check("B2' prior version archived (1 history row)", len(history) == 1)
+
+    # B3: GET /versions returns history + current (per service design).
+    versions = await workflow_service.list_versions(str(wf.id))
+    version_nums = sorted(v["version"] if isinstance(v, dict) else v.version for v in versions)
+    r.check(
+        "B3 GET /versions returns history + current ([v1, v2])",
+        version_nums == [1, 2],
+        f"got versions={version_nums}",
+    )
+
+    # B4: trigger run with version=1 → run uses v1 snapshot
+    run1 = await workflow_service.trigger_workflow_run(workflow_id=str(wf.id), version=1)
+    snap_node_count = len(run1.definition_snapshot.get("nodes", []))
+    r.check(
+        "B4 POST /runs version=1 → run.definition_snapshot has v1's node count (1)",
+        snap_node_count == 1,
+        f"snapshot nodes={snap_node_count}, version={run1.workflow_version}",
+    )
+
+    # B5: trigger without version → uses latest (v2 with 2 nodes)
+    run2 = await workflow_service.trigger_workflow_run(workflow_id=str(wf.id))
+    snap_node_count_latest = len(run2.definition_snapshot.get("nodes", []))
+    r.check(
+        "B5 POST /runs no version → latest (v2's 2 nodes)",
+        snap_node_count_latest == 2 and run2.workflow_version == 2,
+        f"snapshot nodes={snap_node_count_latest}, version={run2.workflow_version}",
+    )
+
+    # B6: in-flight invariance — PUT after run1 was triggered must not alter run1's snapshot
+    # (We already triggered run1 against v1; bump again to v3 and re-read.)
+    nodes_v3 = [_step_input("s1", "tool-v3"), _step_input("s2", "tool-v3b"), _step_input("s3", "tool-v3c")]
+    await workflow_service.update_workflow(
+        str(wf.id),
+        WorkflowUpdateRequest(name=wf.name, description=wf.description, nodes=nodes_v3),
+    )
+    run1_reloaded = await WorkflowRun.get(PydanticObjectId(str(run1.id)))
+    r.check(
+        "B6 in-flight run1 snapshot unchanged after subsequent PUT (D9 invariant)",
+        len(run1_reloaded.definition_snapshot.get("nodes", [])) == 1,
+        f"run1 still has {len(run1_reloaded.definition_snapshot.get('nodes', []))} nodes",
+    )
+
+    return r
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Module C — HITL approval gate  (11 checks)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+async def module_c(workflow_service, control_service, acl_service, queue, runner) -> Report:
+    r = Report("C. HITL approval gate")
+
+    async def _run_with_hitl(name: str, nodes: list[WorkflowNodeInput]) -> tuple[str, str, asyncio.Task]:
+        """Create a workflow + start a run; wait for AWAITING_APPROVAL."""
+        wf = await _make_workflow(workflow_service, acl_service, name, nodes)
+        run_id, task = await _trigger_run_inproc(runner, str(wf.id))
+        run = await _wait_status(
+            run_id, WorkflowRunStatus.AWAITING_APPROVAL, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED
+        )
+        assert run is not None, f"run {run_id} never paused/finished within timeout"
+        return str(wf.id), run_id, task
+
+    # ── C1: confirm → COMPLETED ─────────────────────────────────────────────
+    hitl_step = _step_input(
+        "approval",
+        "tool-c1",
+        humanReview=_hitl_input(requiresConfirmation=True),
+    )
+    wf_id, run_id, task = await _run_with_hitl("c1-confirm", [hitl_step])
+    pending = (await WorkflowRun.get(PydanticObjectId(run_id))).pending_requirements
+    step_id = pending[0]["step_id"]
+    await control_service.resolve_requirement(wf_id, run_id, step_id=step_id, resolution=RequirementResolution.CONFIRM)
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED)
+    r.check(
+        "C1 confirm → COMPLETED",
+        final is not None and final.status == WorkflowRunStatus.COMPLETED,
+        f"final={final.status if final else 'timeout'}",
+    )
+    await _await_or_cancel(task)
+
+    # ── C2: reject + on_reject=skip ─────────────────────────────────────────
+    nodes_c2 = [
+        _step_input(
+            "gate", "tool-c2-gate", humanReview=_hitl_input(requiresConfirmation=True, onReject=OnRejectPolicy.SKIP)
+        ),
+        _step_input("after", "tool-c2-after"),
+    ]
+    wf_id, run_id, task = await _run_with_hitl("c2-reject-skip", nodes_c2)
+    pending = (await WorkflowRun.get(PydanticObjectId(run_id))).pending_requirements
+    await control_service.resolve_requirement(
+        wf_id, run_id, step_id=pending[0]["step_id"], resolution=RequirementResolution.REJECT
+    )
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED)
+    r.check(
+        "C2 reject + on_reject=skip → COMPLETED (gate skipped)",
+        final is not None and final.status == WorkflowRunStatus.COMPLETED,
+        f"final={final.status if final else 'timeout'}",
+    )
+    await _await_or_cancel(task)
+
+    # ── C3: reject + on_reject=cancel ───────────────────────────────────────
+    nodes_c3 = [
+        _step_input(
+            "gate", "tool-c3-gate", humanReview=_hitl_input(requiresConfirmation=True, onReject=OnRejectPolicy.CANCEL)
+        ),
+        _step_input("after", "tool-c3-after"),
+    ]
+    wf_id, run_id, task = await _run_with_hitl("c3-reject-cancel", nodes_c3)
+    pending = (await WorkflowRun.get(PydanticObjectId(run_id))).pending_requirements
+    await control_service.resolve_requirement(
+        wf_id, run_id, step_id=pending[0]["step_id"], resolution=RequirementResolution.REJECT
+    )
+    final = await _wait_status(
+        run_id, WorkflowRunStatus.CANCELLED, WorkflowRunStatus.FAILED, WorkflowRunStatus.COMPLETED
+    )
+    r.check(
+        "C3 reject + on_reject=cancel → CANCELLED",
+        final is not None and final.status == WorkflowRunStatus.CANCELLED,
+        f"final={final.status if final else 'timeout'}",
+    )
+    await _await_or_cancel(task)
+
+    # ── C4: Condition + on_reject=else_branch → false-branch executes ──────
+    # Validates _ON_REJECT_TO_AGNO["else_branch"] = "else" fix.
+    cond = WorkflowNodeInput(
+        name="branch",
+        nodeType="condition",
+        conditionCel="session_state.user_text != ''",  # always true; reject overrides
+        trueSteps=[_step_input("true-step", "tool-c4-true")],
+        falseSteps=[_step_input("false-step", "tool-c4-false")],
+        humanReview=_hitl_input(requiresConfirmation=True, onReject=OnRejectPolicy.ELSE_BRANCH),
+    )
+    wf_id, run_id, task = await _run_with_hitl("c4-else", [cond])
+    pending = (await WorkflowRun.get(PydanticObjectId(run_id))).pending_requirements
+    if pending:
+        await control_service.resolve_requirement(
+            wf_id, run_id, step_id=pending[0]["step_id"], resolution=RequirementResolution.REJECT
+        )
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED)
+    # Condition CEL is always true; only the REJECT→else_branch override can route
+    # to the false leg.  Asserting false ran AND true skipped therefore also proves
+    # the gate fired (without it, the true leg would run).  Guards the
+    # _ON_REJECT_TO_AGNO["else_branch"] = "else" mapping.
+    completed_names = await _completed_names(run_id)
+    r.check(
+        "C4 reject + on_reject=else_branch → false branch ran, true branch skipped",
+        final is not None
+        and final.status == WorkflowRunStatus.COMPLETED
+        and "false-step" in completed_names
+        and "true-step" not in completed_names,
+        f"completed nodes={sorted(completed_names)}, final={final.status if final else 'timeout'}",
+    )
+    await _await_or_cancel(task)
+
+    # ── C5: user_input → injected into session for downstream ──────────────
+    nodes_c5 = [
+        _step_input(
+            "collect",
+            "tool-c5-collect",
+            humanReview=_hitl_input(
+                requiresUserInput=True,
+                userInputSchema=[UserInputFieldSchema(name="discount", fieldType="number", required=True)],
+            ),
+        ),
+        _step_input("after", "tool-c5-after"),
+    ]
+    wf_id, run_id, task = await _run_with_hitl("c5-user-input", nodes_c5)
+    pending = (await WorkflowRun.get(PydanticObjectId(run_id))).pending_requirements
+    await control_service.resolve_requirement(
+        wf_id,
+        run_id,
+        step_id=pending[0]["step_id"],
+        resolution=RequirementResolution.USER_INPUT,
+        user_input={"discount": 15},
+    )
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED)
+    collect_out = await _node_output(run_id, "collect")
+    r.check(
+        "C5 user_input reaches the gated step (discount=15 in output)",
+        final is not None and final.status == WorkflowRunStatus.COMPLETED and "'discount': 15" in collect_out,
+        f"final={final.status if final else 'timeout'}, collect_output={collect_out!r}",
+    )
+    await _await_or_cancel(task)
+
+    # ── C6: output_review + edit → downstream sees edited output ───────────
+    nodes_c6 = [
+        _step_input(
+            "produces",
+            "tool-c6-prod",
+            humanReview=_hitl_input(requiresOutputReview=True),
+        ),
+        _step_input("consumes", "tool-c6-cons"),
+    ]
+    wf_id, run_id, task = await _run_with_hitl("c6-edit", nodes_c6)
+    pending = (await WorkflowRun.get(PydanticObjectId(run_id))).pending_requirements
+    await control_service.resolve_requirement(
+        wf_id,
+        run_id,
+        step_id=pending[0]["step_id"],
+        resolution=RequirementResolution.EDIT,
+        edited_output="EDITED_BY_USER",
+    )
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED)
+    produces_out = await _node_output(run_id, "produces")
+    consumes_out = await _node_output(run_id, "consumes")
+    r.check(
+        "C6 output_review + edit → edited output replaces node result AND flows downstream",
+        final is not None
+        and final.status == WorkflowRunStatus.COMPLETED
+        and produces_out == "EDITED_BY_USER"
+        and "EDITED_BY_USER" in consumes_out,
+        f"final={final.status if final else 'timeout'}, produces={produces_out!r}, consumes={consumes_out!r}",
+    )
+    await _await_or_cancel(task)
+
+    # ── C7: cross-session restore (simulate pod restart by recreating service) ─
+    nodes_c7 = [_step_input("gate", "tool-c7", humanReview=_hitl_input(requiresConfirmation=True))]
+    wf_id, run_id, task = await _run_with_hitl("c7-restore", nodes_c7)
+    pending = (await WorkflowRun.get(PydanticObjectId(run_id))).pending_requirements
+    step_id = pending[0]["step_id"]
+    # Drop & rebuild control service to simulate a process boundary.
+    fresh_queue = DirectiveQueue()
+    fresh_runner = _build_runner(fresh_queue)
+    fresh_service = WorkflowControlService(directive_queue=fresh_queue, runner_factory=lambda: fresh_runner)
+    await fresh_service.resolve_requirement(wf_id, run_id, step_id=step_id, resolution=RequirementResolution.CONFIRM)
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED, timeout=20)
+    r.check(
+        "C7 fresh service can resume from DB (pod-restart safe)",
+        final is not None and final.status == WorkflowRunStatus.COMPLETED,
+        f"final={final.status if final else 'timeout'}",
+    )
+    await _await_or_cancel(task)
+
+    # ── C8: multi-step chain with HITL in the middle ────────────────────────
+    chain = [
+        _step_input("first", "tool-c8-1"),
+        _step_input("gate", "tool-c8-2", humanReview=_hitl_input(requiresConfirmation=True)),
+        _step_input("last", "tool-c8-3"),
+    ]
+    wf_id, run_id, task = await _run_with_hitl("c8-chain", chain)
+    pending = (await WorkflowRun.get(PydanticObjectId(run_id))).pending_requirements
+    await control_service.resolve_requirement(
+        wf_id, run_id, step_id=pending[0]["step_id"], resolution=RequirementResolution.CONFIRM
+    )
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED)
+    names = await _completed_names(run_id)
+    r.check(
+        "C8 multi-step A→GATE→B all complete after gate confirmed",
+        final is not None and final.status == WorkflowRunStatus.COMPLETED and {"first", "gate", "last"} <= names,
+        f"completed={sorted(names)}",
+    )
+    await _await_or_cancel(task)
+
+    # ── C9: Condition + requires_confirmation (happy path, no reject) ──────
+    cond9 = WorkflowNodeInput(
+        name="route",
+        nodeType="condition",
+        conditionCel="session_state.user_text != ''",
+        trueSteps=[_step_input("true-leg", "tool-c9-t")],
+        falseSteps=[_step_input("false-leg", "tool-c9-f")],
+        humanReview=_hitl_input(requiresConfirmation=True),
+    )
+    wf_id, run_id, task = await _run_with_hitl("c9-cond-confirm", [cond9])
+    pending = (await WorkflowRun.get(PydanticObjectId(run_id))).pending_requirements
+    r.check("C9a condition gate paused for confirmation", len(pending) > 0, f"pending={len(pending)}")
+    if pending:
+        await control_service.resolve_requirement(
+            wf_id, run_id, step_id=pending[0]["step_id"], resolution=RequirementResolution.CONFIRM
+        )
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED)
+    completed_names = await _completed_names(run_id)
+    r.check(
+        "C9 Condition + confirm → true branch ran, false branch skipped",
+        final is not None
+        and final.status == WorkflowRunStatus.COMPLETED
+        and "true-leg" in completed_names
+        and "false-leg" not in completed_names,
+        f"completed={sorted(completed_names)}",
+    )
+    await _await_or_cancel(task)
+
+    # ── C10: Router + route_select (HITL pick a named choice) ───────────────
+    router = WorkflowNodeInput(
+        name="router",
+        nodeType="router",
+        conditionCel="'tech'",  # default selector ignored when user_input picks
+        choices=[
+            {"name": "tech", "steps": [{"name": "tech-leg", "nodeType": "step", "executorKey": "tool-c10-tech"}]},
+            {"name": "general", "steps": [{"name": "general-leg", "nodeType": "step", "executorKey": "tool-c10-gen"}]},
+        ],
+        humanReview=_hitl_input(requiresUserInput=True),
+    )
+    try:
+        wf_id, run_id, task = await _run_with_hitl("c10-router", [router])
+        pending = (await WorkflowRun.get(PydanticObjectId(run_id))).pending_requirements
+        if pending:
+            await control_service.resolve_requirement(
+                wf_id,
+                run_id,
+                step_id=pending[0]["step_id"],
+                resolution=RequirementResolution.ROUTE_SELECT,
+                selected_choices=["general"],
+            )
+        final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED, timeout=20)
+        # Default selector picks "tech"; the user's ROUTE_SELECT picks "general".
+        # Asserting general ran AND tech skipped proves the user override took
+        # effect (and that the HITL gate actually fired).
+        completed_names = await _completed_names(run_id)
+        r.check(
+            "C10 Router + route_select → user-picked 'general' leg ran, default 'tech' skipped",
+            final is not None
+            and final.status == WorkflowRunStatus.COMPLETED
+            and "general-leg" in completed_names
+            and "tech-leg" not in completed_names,
+            f"final={final.status if final else 'timeout'}, completed={sorted(completed_names)}",
+        )
+        await _await_or_cancel(task)
+    except Exception as exc:
+        r.check("C10 Router + route_select", False, f"setup/exec error: {exc}")
+
+    return r
+
+
+async def _await_or_cancel(task: asyncio.Task) -> None:
+    """Drain the runner task without raising on cancel/expected errors."""
+    try:
+        await asyncio.wait_for(task, timeout=10)
+    except TimeoutError:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass  # Expected after cancellation.
+    except Exception as exc:
+        logger.debug("_await_or_cancel ignored: %s", exc)
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Module D — Cancel  (5 checks)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+async def module_d(workflow_service, control_service, acl_service, queue, runner) -> Report:
+    r = Report("D. Cancel")
+
+    # D1: cancel a RUNNING run
+    wf = await _make_workflow(
+        workflow_service, acl_service, "d1-running", [_step_input("a", "tool-d1a"), _step_input("b", "tool-d1b")]
+    )
+    run_id, task = await _trigger_run_inproc(runner, str(wf.id))
+    await asyncio.sleep(0.05)
+    await control_service.send_cancel(str(wf.id), run_id)
+    final = await _wait_status(
+        run_id, WorkflowRunStatus.CANCELLED, WorkflowRunStatus.FAILED, WorkflowRunStatus.COMPLETED
+    )
+    r.check(
+        "D1 cancel a RUNNING run → CANCELLED",
+        final is not None and final.status == WorkflowRunStatus.CANCELLED,
+        f"final={final.status if final else 'timeout'}",
+    )
+    await _await_or_cancel(task)
+
+    # D2: cancel an AWAITING_APPROVAL run
+    wf = await _make_workflow(
+        workflow_service,
+        acl_service,
+        "d2-awaiting",
+        [_step_input("gate", "tool-d2", humanReview=_hitl_input(requiresConfirmation=True))],
+    )
+    run_id, task = await _trigger_run_inproc(runner, str(wf.id))
+    await _wait_status(run_id, WorkflowRunStatus.AWAITING_APPROVAL)
+    await control_service.send_cancel(str(wf.id), run_id)
+    final = await _wait_status(run_id, WorkflowRunStatus.CANCELLED, WorkflowRunStatus.FAILED)
+    r.check(
+        "D2 cancel during AWAITING_APPROVAL → CANCELLED",
+        final is not None and final.status == WorkflowRunStatus.CANCELLED,
+        f"final={final.status if final else 'timeout'}",
+    )
+    await _await_or_cancel(task)
+
+    # D3: agno session bridged (pending_directive=CANCEL written by manager)
+    run = await WorkflowRun.get(PydanticObjectId(run_id))
+    r.check(
+        "D3 cancel bridges to pending_directive=CANCEL",
+        run is not None and str(run.pending_directive) == "cancel",
+        f"pending_directive={run.pending_directive if run else 'no run'}",
+    )
+
+    # D4: idempotent cancel — second call still 200, no exception
+    try:
+        await control_service.send_cancel(str(wf.id), run_id)
+        r.check("D4 idempotent cancel (second call OK)", True)
+    except Exception as exc:
+        r.check("D4 idempotent cancel", False, f"raised: {exc}")
+
+    # D5: cancel a terminal (already CANCELLED) run — should remain CANCELLED
+    try:
+        await control_service.send_cancel(str(wf.id), run_id)
+        run_after = await WorkflowRun.get(PydanticObjectId(run_id))
+        r.check(
+            "D5 cancel terminal run is no-op", run_after is not None and run_after.status == WorkflowRunStatus.CANCELLED
+        )
+    except HTTPException as exc:
+        # 400 on terminal is also acceptable behavior (state machine rejects)
+        r.check(
+            "D5 cancel terminal run gives clear response",
+            exc.status_code in (200, 400),
+            f"status_code={exc.status_code}",
+        )
+
+    return r
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Module E — Cascade delete  (1 check)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+async def module_e(workflow_service, control_service, acl_service, queue, runner) -> Report:
+    r = Report("E. Cascade delete")
+
+    wf = await _make_workflow(workflow_service, acl_service, "e1-cascade", [_step_input("only", "tool-e1")])
+    # Generate runs + a HITL pause so agno_workflow_sessions exists.
+    await workflow_service.trigger_workflow_run(workflow_id=str(wf.id))
+    hitl_wf = await _make_workflow(
+        workflow_service,
+        acl_service,
+        "e1-cascade-hitl",
+        [_step_input("gate", "tool-e1-h", humanReview=_hitl_input(requiresConfirmation=True))],
+    )
+    run_id, task = await _trigger_run_inproc(runner, str(hitl_wf.id))
+    await _wait_status(run_id, WorkflowRunStatus.AWAITING_APPROVAL)
+
+    db = MongoDB.get_database()
+    sessions_before = await db.get_collection("agno_workflow_sessions").count_documents({"session_id": run_id})
+
+    # Update workflow once so a WorkflowVersion row exists.
+    await workflow_service.update_workflow(
+        str(hitl_wf.id),
+        WorkflowUpdateRequest(
+            name=hitl_wf.name,
+            description="updated",
+            nodes=[_convert_node_to_input(n) for n in hitl_wf.nodes],
+        ),
+    )
+
+    await workflow_service.delete_workflow(str(hitl_wf.id))
+
+    def_left = await WorkflowDefinition.get(hitl_wf.id)
+    runs_left = await WorkflowRun.find(WorkflowRun.workflow_definition_id == hitl_wf.id).count()
+    versions_left = await WorkflowVersion.find(WorkflowVersion.workflow_id == hitl_wf.id).count()
+    sessions_left = await db.get_collection("agno_workflow_sessions").count_documents({"session_id": run_id})
+
+    all_clean = def_left is None and runs_left == 0 and versions_left == 0 and sessions_left == 0
+    r.check(
+        "E1 DELETE cascades to definitions/runs/versions/agno_sessions",
+        all_clean,
+        f"def={def_left is None} runs={runs_left} versions={versions_left} agno_sessions={sessions_left} (before={sessions_before})",
+    )
+    await _await_or_cancel(task)
+
+    return r
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Module F — Run query  (2 checks)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+async def module_f(workflow_service, control_service, acl_service, queue, runner) -> Report:
+    r = Report("F. Run query")
+
+    wf = await _make_workflow(workflow_service, acl_service, "f1-list", [_step_input("only", "tool-f1")])
+    await workflow_service.trigger_workflow_run(workflow_id=str(wf.id))
+    await workflow_service.trigger_workflow_run(workflow_id=str(wf.id))
+    listed, total = await workflow_service.list_workflow_runs(workflow_id=str(wf.id))
+    r.check(
+        "F1 GET /runs returns inserted runs", total >= 2 and len(listed) >= 2, f"total={total} returned={len(listed)}"
+    )
+
+    # F2: get run detail includes pending_requirements when awaiting
+    wf2 = await _make_workflow(
+        workflow_service,
+        acl_service,
+        "f2-detail",
+        [_step_input("gate", "tool-f2", humanReview=_hitl_input(requiresConfirmation=True))],
+    )
+    run_id, task = await _trigger_run_inproc(runner, str(wf2.id))
+    await _wait_status(run_id, WorkflowRunStatus.AWAITING_APPROVAL)
+    run, _ = await workflow_service.get_workflow_run(str(wf2.id), run_id)
+    r.check(
+        "F2 GET /runs/{id} includes pending_requirements when paused",
+        run is not None and len(run.pending_requirements) > 0,
+        f"pending_requirements count={len(run.pending_requirements) if run else 'n/a'}",
+    )
+    # Cleanup
+    await control_service.send_cancel(str(wf2.id), run_id)
+    await _await_or_cancel(task)
+
+    return r
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Module G — Retry  (1 check)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+async def module_g(workflow_service, control_service, acl_service, queue, runner) -> Report:
+    r = Report("G. Retry")
+
+    wf = await _make_workflow(
+        workflow_service, acl_service, "g1-retry", [_step_input("a", "tool-g1-a"), _step_input("b", "tool-g1-b")]
+    )
+    # Seed run to completion
+    run_id, task = await _trigger_run_inproc(runner, str(wf.id))
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED, timeout=20)
+    await _await_or_cancel(task)
+
+    if final is None or final.status != WorkflowRunStatus.COMPLETED:
+        r.check(
+            "G1 retry from node → child run created",
+            False,
+            f"seed run did not complete: {final.status if final else 'timeout'}",
+        )
+        return r
+
+    first_node_id = wf.nodes[0].id
+    child = await control_service.send_retry(
+        str(wf.id),
+        run_id,
+        first_node_id,
+        registry_token="test",
+        user_id=str(USER_A),
+    )
+    r.check(
+        "G1 retry from first node → child WorkflowRun created",
+        child is not None
+        and child.parent_run_id == final.id
+        and str(child.status) in ("pending", "running", "completed"),
+        f"child_id={child.id} parent={child.parent_run_id} status={child.status}",
+    )
+
+    return r
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Module H — Pause/Resume smoke  (1 check)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+async def module_h(workflow_service, control_service, acl_service, queue, runner) -> Report:
+    r = Report("H. Pause/Resume smoke")
+
+    wf = await _make_workflow(
+        workflow_service, acl_service, "h1-pause-resume", [_step_input("a", "tool-h1-a"), _step_input("b", "tool-h1-b")]
+    )
+    run_id, task = await _trigger_run_inproc(runner, str(wf.id))
+    await asyncio.sleep(0.05)
+    try:
+        await control_service.send_pause(str(wf.id), run_id)
+        await _wait_status(run_id, WorkflowRunStatus.PAUSED, timeout=5)
+        await control_service.send_resume(str(wf.id), run_id)
+    except HTTPException as exc:
+        # Race: run might have already completed before we paused.  Acceptable
+        # as long as it reached a terminal state.
+        logger.debug("pause/resume race: %s", exc)
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED, timeout=20)
+    r.check(
+        "H1 pause then resume → run completes",
+        final is not None and final.status == WorkflowRunStatus.COMPLETED,
+        f"final={final.status if final else 'timeout'}",
+    )
+    await _await_or_cancel(task)
+    return r
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Module I — Error paths  (4 checks)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+async def module_i(workflow_service, control_service, acl_service, queue, runner) -> Report:
+    r = Report("I. Error paths")
+
+    # I1: GET unknown workflow → ValueError / HTTPException(404)
+    try:
+        await workflow_service.get_workflow_by_id(str(PydanticObjectId()))
+        r.check("I1 404 on unknown workflow id", False, "no exception raised")
+    except (ValueError, HTTPException) as exc:
+        code = getattr(exc, "status_code", None)
+        r.check("I1 404 on unknown workflow id", code in (404, None), f"raised {type(exc).__name__}({code})")
+
+    # I2: POST /runs with version=999 (non-existent) → 400/404
+    wf = await _make_workflow(workflow_service, acl_service, "i2-bad-ver", [_step_input("x", "tool-i2")])
+    try:
+        await workflow_service.trigger_workflow_run(workflow_id=str(wf.id), version=999)
+        r.check("I2 400/404 on bad version param", False, "no exception")
+    except (ValueError, HTTPException) as exc:
+        code = getattr(exc, "status_code", None)
+        r.check("I2 400/404 on bad version param", code in (400, 404, None), f"raised {type(exc).__name__}({code})")
+
+    # I3: cancel a terminal run → 400 or idempotent 200
+    wf2 = await _make_workflow(workflow_service, acl_service, "i3-terminal", [_step_input("only", "tool-i3")])
+    run_id, task = await _trigger_run_inproc(runner, str(wf2.id))
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED, timeout=10)
+    await _await_or_cancel(task)
+    cancel_ok = False
+    try:
+        await control_service.send_cancel(str(wf2.id), run_id)
+        # Idempotent: no exception is acceptable; run stays terminal
+        cancel_ok = True
+    except HTTPException as exc:
+        cancel_ok = exc.status_code == 400
+    r.check(
+        "I3 cancel on terminal run handled (400 or idempotent)",
+        cancel_ok,
+        f"after-status={final.status if final else 'unknown'}",
+    )
+
+    # I4: invalid node shape (Condition without condition_cel) → ValueError at validation
+    try:
+        bad = WorkflowNodeInput(name="bad", nodeType="condition", trueSteps=[_step_input("x", "tool")])
+        await workflow_service.create_workflow(
+            data=WorkflowCreateRequest(name=PREFIX + "i4-bad", description="", nodes=[bad])
+        )
+        r.check("I4 400 on invalid node shape", False, "no exception raised")
+    except (ValueError, HTTPException) as exc:
+        code = getattr(exc, "status_code", None)
+        r.check(
+            "I4 400 on invalid node shape (Condition without condition_cel)",
+            code in (400, 422, None),
+            f"raised {type(exc).__name__}({code})",
+        )
+
+    return r
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Cleanup
+# ════════════════════════════════════════════════════════════════════════════
+
+
+async def cleanup() -> None:
+    db = MongoDB.get_database()
+    # Find all workflows we created by name prefix
+    name_filter = {"name": {"$regex": f"^{PREFIX}"}}
+    wf_ids = [wf["_id"] async for wf in db.get_collection("workflow_definitions").find(name_filter, {"_id": 1})]
+    if wf_ids:
+        run_docs = [
+            r
+            async for r in db.get_collection("workflow_runs").find(
+                {"workflow_definition_id": {"$in": wf_ids}}, {"_id": 1}
+            )
+        ]
+        run_ids = [d["_id"] for d in run_docs]
+        if run_ids:
+            await db.get_collection("node_runs").delete_many({"workflow_run_id": {"$in": run_ids}})
+            await db.get_collection("workflow_runs").delete_many({"_id": {"$in": run_ids}})
+            await db.get_collection("agno_workflow_sessions").delete_many(
+                {"session_id": {"$in": [str(rid) for rid in run_ids]}}
+            )
+        await db.get_collection("workflow_versions").delete_many({"workflow_id": {"$in": wf_ids}})
+        await db.get_collection("workflow_definitions").delete_many({"_id": {"$in": wf_ids}})
+    await db.get_collection("aclentries").delete_many(
+        {"resourceType": ExtendedResourceType.WORKFLOW.value, "principalId": {"$in": [USER_A, USER_B]}}
+    )
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Main
+# ════════════════════════════════════════════════════════════════════════════
+
+
+MODULES = {
+    "A": module_a,
+    "B": module_b,
+    "C": module_c,
+    "D": module_d,
+    "E": module_e,
+    "F": module_f,
+    "G": module_g,
+    "H": module_h,
+    "I": module_i,
+}
+
+
+async def amain(selected: list[str], keep_data: bool) -> int:
+    await MongoDB.connect_db(
+        config=MongoConfig(
+            mongo_uri=os.getenv("MONGO_URI", "mongodb://127.0.0.1:27017/jarvis"),
+            mongodb_username=os.getenv("MONGODB_USERNAME", ""),
+            mongodb_password=os.getenv("MONGODB_PASSWORD", ""),
+        ),
+    )
+
+    workflow_service = WorkflowService()
+    queue = DirectiveQueue()
+    runner = _build_runner(queue)
+    acl_service = ACLService(user_service=UserService(), group_service=GroupService())
+    control_service = WorkflowControlService(directive_queue=queue, runner_factory=lambda: runner)
+
+    reports: list[Report] = []
+    t0 = time.monotonic()
+    try:
+        for key in selected:
+            fn = MODULES[key]
+            print(f"\n── {key} ─────────────────────────────────────────────────")
+            try:
+                # Modules A/B accept (workflow_service, control_service, acl_service)
+                # Modules C-I need queue + runner too.
+                if key in {"A", "B"}:
+                    report = await fn(workflow_service, control_service, acl_service)
+                else:
+                    report = await fn(workflow_service, control_service, acl_service, queue, runner)
+                reports.append(report)
+            except Exception as exc:
+                print(f"  {FAIL}  module {key} crashed: {exc}")
+                traceback.print_exc()
+                rep = Report(f"{key}. (crashed)")
+                rep.check("module crashed", False, str(exc))
+                reports.append(rep)
+    finally:
+        if not keep_data:
+            print("\n── cleaning up test data ──")
+            try:
+                await cleanup()
+                print(f"  {PASS}  removed all {PREFIX}* records")
+            except Exception as exc:
+                print(f"  {FAIL}  cleanup error: {exc}")
+        else:
+            print("\n  (--keep-data set; test records left in MongoDB)")
+
+        await MongoDB.close_db()
+
+    # Summary
+    print("\n" + "═" * 60)
+    print(f"SUMMARY  modules={len(reports)}  duration={time.monotonic() - t0:.1f}s")
+    print("═" * 60)
+    total_pass = 0
+    total_all = 0
+    for rep in reports:
+        glyph = PASS if rep.passed == rep.total else FAIL
+        print(f"  {glyph}  {rep.module:<35} {rep.passed}/{rep.total}")
+        total_pass += rep.passed
+        total_all += rep.total
+    print("─" * 60)
+    overall = PASS if total_pass == total_all else FAIL
+    print(f"  {overall}  TOTAL                              {total_pass}/{total_all}")
+    print("═" * 60)
+    return 0 if total_pass == total_all else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--modules", default="A,B,C,D,E,F,G,H,I", help="Comma-separated module letters (default: all).")
+    parser.add_argument(
+        "--keep-data", action="store_true", help="Don't delete __as1543_e2e__* records at end (for debugging)."
+    )
+    args = parser.parse_args()
+    selected = [m.strip().upper() for m in args.modules.split(",") if m.strip()]
+    bad = [m for m in selected if m not in MODULES]
+    if bad:
+        print(f"Unknown module(s): {bad}.  Valid: {sorted(MODULES.keys())}", file=sys.stderr)
+        return 2
+    return asyncio.run(amain(selected, args.keep_data))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_workflow_control_e2e.py
+++ b/scripts/verify_workflow_control_e2e.py
@@ -47,13 +47,13 @@ load_dotenv(Path(__file__).resolve().parents[1] / ".env")
 
 from registry import settings
 from registry.schemas.workflow_api_schemas import (
-    HumanReviewInput,
+    HumanReviewConfig,
     StepConfigInput,
     UserInputFieldSchema,
     WorkflowCreateRequest,
     WorkflowNodeInput,
     WorkflowUpdateRequest,
-    _convert_node_to_input,
+    convert_node_to_input,
 )
 from registry.services.access_control_service import ACLService
 from registry.services.group_service import GroupService
@@ -264,8 +264,8 @@ def _step_input(name: str, executor_key: str = "tool-x", **kw) -> WorkflowNodeIn
     return WorkflowNodeInput(name=name, nodeType="step", executorKey=executor_key, **kw)
 
 
-def _hitl_input(**kw) -> HumanReviewInput:
-    """Build a HumanReviewInput with sensible defaults; override via kwargs."""
+def _hitl_input(**kw) -> HumanReviewConfig:
+    """Build a HumanReviewConfig with sensible defaults; override via kwargs."""
     defaults: dict = {
         "requiresConfirmation": False,
         "requiresUserInput": False,
@@ -275,7 +275,7 @@ def _hitl_input(**kw) -> HumanReviewInput:
         "onTimeout": OnTimeoutPolicy.CANCEL,
     }
     defaults.update(kw)
-    return HumanReviewInput(**defaults)
+    return HumanReviewConfig(**defaults)
 
 
 # ────────────────────────────────────────────────────────────────────────────
@@ -916,7 +916,7 @@ async def module_e(workflow_service, control_service, acl_service, queue, runner
         WorkflowUpdateRequest(
             name=hitl_wf.name,
             description="updated",
-            nodes=[_convert_node_to_input(n) for n in hitl_wf.nodes],
+            nodes=[convert_node_to_input(n) for n in hitl_wf.nodes],
         ),
     )
 

--- a/scripts/verify_workflow_control_e2e.py
+++ b/scripts/verify_workflow_control_e2e.py
@@ -310,6 +310,27 @@ async def module_a(workflow_service, control_service, acl_service) -> Report:
         raised = exc.status_code == 403
     r.check("A2 user_b without ACL → 403 on VIEW check", raised)
 
+    # GET /workflows only returns workflows the caller has VIEW on (req case ①).
+    # Build one workflow owned by USER_A and one owned by USER_B, then assert the
+    # ACL-restricted listing path (get_accessible_resource_ids + list_workflows)
+    # hides the other user's workflow.
+    wf_a = await _make_workflow(workflow_service, acl_service, "acl-list-a", nodes, creator=USER_A)
+    wf_b = await _make_workflow(workflow_service, acl_service, "acl-list-b", nodes, creator=USER_B)
+    accessible = await acl_service.get_accessible_resource_ids(
+        user_id=USER_A,
+        resource_type=ExtendedResourceType.WORKFLOW.value,
+    )
+    listed, _ = await workflow_service.list_workflows(query=PREFIX + "acl-list", accessible_workflow_ids=accessible)
+    listed_ids = {str(w.id) for w in listed}
+    r.check(
+        "A3 list_workflows hides other users' workflows (VIEW-filtered)",
+        str(wf_a.id) in accessible
+        and str(wf_b.id) not in accessible
+        and str(wf_a.id) in listed_ids
+        and str(wf_b.id) not in listed_ids,
+        f"A_visible={str(wf_a.id) in listed_ids} B_hidden={str(wf_b.id) not in listed_ids}",
+    )
+
     return r
 
 
@@ -656,6 +677,53 @@ async def module_c(workflow_service, control_service, acl_service, queue, runner
         await _await_or_cancel(task)
     except Exception as exc:
         r.check("C10 Router + route_select", False, f"setup/exec error: {exc}")
+
+    # reject + on_reject=retry → step re-runs and re-pauses, then confirm ─
+    # agno re-executes the rejected step (retry_count+1) and pauses again at the
+    # gate.  Validates the _ON_REJECT_TO_AGNO["retry"]="retry" mapping plus our
+    # continue_run re-pause persistence (new pending_requirements w/ retry_count≥1).
+    nodes_c11 = [
+        _step_input(
+            "gate", "tool-c11", humanReview=_hitl_input(requiresConfirmation=True, onReject=OnRejectPolicy.RETRY)
+        ),
+    ]
+    wf_id, run_id, task = await _run_with_hitl("c11-retry", nodes_c11)
+    first = (await WorkflowRun.get(PydanticObjectId(run_id))).pending_requirements
+    await control_service.resolve_requirement(
+        wf_id, run_id, step_id=first[0]["step_id"], resolution=RequirementResolution.REJECT
+    )
+
+    async def _re_paused():
+        run = await WorkflowRun.get(PydanticObjectId(run_id))
+        if run is None or run.status != WorkflowRunStatus.AWAITING_APPROVAL:
+            return None
+        for req in run.pending_requirements:
+            if req.get("confirmed") is None and (req.get("retry_count") or 0) >= 1:
+                return run
+        return None
+
+    repaused = await _poll(_re_paused, timeout=30)
+    r.check(
+        "C11a reject + on_reject=retry → step re-runs and re-pauses (retry_count≥1)",
+        repaused is not None,
+        f"status={getattr(await WorkflowRun.get(PydanticObjectId(run_id)), 'status', None)}",
+    )
+    if repaused is not None:
+        await control_service.resolve_requirement(
+            wf_id,
+            run_id,
+            step_id=repaused.pending_requirements[0]["step_id"],
+            resolution=RequirementResolution.CONFIRM,
+        )
+    final = await _wait_status(
+        run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED, WorkflowRunStatus.CANCELLED
+    )
+    r.check(
+        "C11 retry then confirm → COMPLETED",
+        final is not None and final.status == WorkflowRunStatus.COMPLETED,
+        f"final={final.status if final else 'timeout'}",
+    )
+    await _await_or_cancel(task)
 
     return r
 

--- a/scripts/verify_workflow_control_e2e.py
+++ b/scripts/verify_workflow_control_e2e.py
@@ -1,17 +1,19 @@
 """End-to-end verification for AS-1543 features against a real MongoDB.
 
-Covers 9 modules / 34 checks:
-  A. ACL                  (2)  — creator OWNER, 403 without scope+ACL
+Covers 11 modules / 49 checks:
+  A. ACL                  (3)  — creator OWNER, 403 without scope+ACL, list VIEW-filter
   B. Versioning           (7)  — PUT bump, checksum, history, version param, in-flight snapshot
-  C. HITL approval gate   (11) — confirm/reject(skip/cancel/else_branch)/user_input/edit/route_select
+  C. HITL approval gate   (13) — confirm/reject(skip/cancel/retry/else_branch)/user_input/edit/route_select
                                  + multi-step chain, Condition+confirm, cross-session restore.
                                  Assertions verify branch selection + data propagation, not just COMPLETED.
   D. Cancel               (5)  — running/awaiting-approval/agno bridge/idempotent/terminal-state
   E. Cascade delete       (1)  — workflow_definitions + runs + node_runs + versions + agno sessions
   F. Run query            (2)  — list, detail with pendingRequirements
-  G. Retry                (1)  — retry a COMPLETED run from a node
+  G. Retry                (6)  — COMPLETED/FAILED retry, middle-node reuse, 400 on non-terminal/cancelled/bad-node
   H. Pause/Resume smoke   (1)  — pause → resume → completes
   I. Error paths          (4)  — 404 / 400 invalid version / 409 terminal cancel / 400 bad node
+  J. Timeout (lazy nudge) (3)  — on_timeout skip/cancel via get_run_status; no-op before deadline
+  K. Step error retry     (4)  — on_error retry recover/exhaust, skip, fail-fast (attempt counts)
 
 Usage:
     uv run python scripts/verify_workflow_control_e2e.py                    # run all
@@ -43,35 +45,36 @@ from fastapi import HTTPException
 
 load_dotenv(Path(__file__).resolve().parents[1] / ".env")
 
-from registry import settings  # noqa: E402
-from registry.schemas.workflow_api_schemas import (  # noqa: E402
+from registry import settings
+from registry.schemas.workflow_api_schemas import (
     HumanReviewInput,
+    StepConfigInput,
     UserInputFieldSchema,
     WorkflowCreateRequest,
     WorkflowNodeInput,
     WorkflowUpdateRequest,
     _convert_node_to_input,
 )
-from registry.services.access_control_service import ACLService  # noqa: E402
-from registry.services.group_service import GroupService  # noqa: E402
-from registry.services.user_service import UserService  # noqa: E402
-from registry.services.workflow_control_service import WorkflowControlService  # noqa: E402
-from registry.services.workflow_service import WorkflowService  # noqa: E402
-from registry_pkgs.core.config import MongoConfig  # noqa: E402
-from registry_pkgs.database.mongodb import MongoDB  # noqa: E402
-from registry_pkgs.models import PrincipalType  # noqa: E402
-from registry_pkgs.models.enums import (  # noqa: E402
+from registry.services.access_control_service import ACLService
+from registry.services.group_service import GroupService
+from registry.services.user_service import UserService
+from registry.services.workflow_control_service import WorkflowControlService
+from registry.services.workflow_service import WorkflowService
+from registry_pkgs.core.config import MongoConfig
+from registry_pkgs.database.mongodb import MongoDB
+from registry_pkgs.models import PrincipalType
+from registry_pkgs.models.enums import (
     OnRejectPolicy,
     OnTimeoutPolicy,
     RequirementResolution,
     RoleBits,
     WorkflowRunStatus,
 )
-from registry_pkgs.models.extended_acl_entry import ExtendedResourceType  # noqa: E402
-from registry_pkgs.models.workflow import NodeRun, WorkflowDefinition, WorkflowRun, WorkflowVersion  # noqa: E402
-from registry_pkgs.workflows.compiler import flatten_workflow_nodes  # noqa: E402
-from registry_pkgs.workflows.control import DirectiveQueue  # noqa: E402
-from registry_pkgs.workflows.runner import WorkflowRunner  # noqa: E402
+from registry_pkgs.models.extended_acl_entry import ExtendedResourceType
+from registry_pkgs.models.workflow import NodeRun, WorkflowDefinition, WorkflowRun, WorkflowVersion
+from registry_pkgs.workflows.compiler import flatten_workflow_nodes
+from registry_pkgs.workflows.control import DirectiveQueue
+from registry_pkgs.workflows.runner import WorkflowRunner
 
 logging.basicConfig(level=logging.WARNING, format="%(asctime)s %(name)s %(levelname)s %(message)s")
 logger = logging.getLogger("as1543_e2e")
@@ -131,6 +134,70 @@ def _build_runner(queue: DirectiveQueue) -> MockRunner:
         db_name=MongoDB.database_name,
         jwt_config=settings.jwt_signing_config,
         directive_queue=queue,
+    )
+
+
+class FailingMockRunner(WorkflowRunner):
+    """Mock runner whose executors fail a configurable number of times.
+
+    ``fail_counts`` maps an ``executor_key`` to how many leading attempts return
+    ``StepOutput(success=False)``; subsequent attempts succeed.  ``attempts``
+    records how many times each executor was actually invoked, letting tests
+    assert the wrapper's retry loop ran the expected number of times.
+    """
+
+    def __init__(self, *args, fail_counts: dict[str, int] | None = None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._fail_counts = fail_counts or {}
+        self.attempts: dict[str, int] = {}
+
+    async def _build_registry(self, definition, registry_token, user_id):
+        all_nodes = flatten_workflow_nodes(definition.nodes)
+        keys = list(dict.fromkeys(n.executor_key for n in all_nodes if n.executor_key))
+
+        def make(key: str) -> StepExecutor:
+            async def mock(step_input: StepInput, session_state: dict | None = None) -> StepOutput:
+                await asyncio.sleep(0.01)
+                self.attempts[key] = self.attempts.get(key, 0) + 1
+                if self.attempts[key] <= self._fail_counts.get(key, 0):
+                    return StepOutput(content=f"{key}:FAIL#{self.attempts[key]}", success=False, error="boom")
+                return StepOutput(content=f"{key}:OK", success=True)
+
+            return mock
+
+        return {k: make(k) for k in keys}
+
+
+def _build_failing_runner(queue: DirectiveQueue, fail_counts: dict[str, int]) -> FailingMockRunner:
+    llm = AwsBedrock(
+        id=os.getenv("BEDROCK_MODEL", "us.amazon.nova-lite-v1:0"),
+        aws_region=settings.aws_region,
+        aws_session_token=settings.aws_session_token,
+        aws_access_key_id=settings.aws_access_key_id,
+        aws_secret_access_key=settings.aws_secret_access_key,
+    )
+    return FailingMockRunner(
+        llm=llm,
+        registry_url=os.getenv("REGISTRY_URL", "http://localhost:7860"),
+        db_client=MongoDB.get_client(),
+        db_name=MongoDB.database_name,
+        jwt_config=settings.jwt_signing_config,
+        directive_queue=queue,
+        fail_counts=fail_counts,
+    )
+
+
+def _retry_step(name: str, key: str, *, on_error: str, max_retries: int = 0) -> WorkflowNodeInput:
+    """Step node with a StepConfig exercising error-retry/skip/fail, fast backoff."""
+    return _step_input(
+        name,
+        key,
+        stepConfig=StepConfigInput(
+            maxRetries=max_retries,
+            onError=on_error,
+            backoffBaseSeconds=0.01,
+            backoffMaxSeconds=0.05,
+        ),
     )
 
 
@@ -679,12 +746,14 @@ async def module_c(workflow_service, control_service, acl_service, queue, runner
         r.check("C10 Router + route_select", False, f"setup/exec error: {exc}")
 
     # reject + on_reject=retry → step re-runs and re-pauses, then confirm ─
-    # agno re-executes the rejected step (retry_count+1) and pauses again at the
-    # gate.  Validates the _ON_REJECT_TO_AGNO["retry"]="retry" mapping plus our
-    # continue_run re-pause persistence (new pending_requirements w/ retry_count≥1).
+    # agno's retry re-pause applies to *post-execution* output review: rejecting
+    # the output re-runs the same step (retry_count+1) and pauses again.  (A
+    # pre-execution confirmation gate just proceeds on retry, so output_review is
+    # the meaningful case.)  Validates the _ON_REJECT_TO_AGNO["retry"]="retry"
+    # mapping plus our continue_run re-pause persistence (retry_count≥1).
     nodes_c11 = [
         _step_input(
-            "gate", "tool-c11", humanReview=_hitl_input(requiresConfirmation=True, onReject=OnRejectPolicy.RETRY)
+            "gate", "tool-c11", humanReview=_hitl_input(requiresOutputReview=True, onReject=OnRejectPolicy.RETRY)
         ),
     ]
     wf_id, run_id, task = await _run_with_hitl("c11-retry", nodes_c11)
@@ -947,6 +1016,70 @@ async def module_g(workflow_service, control_service, acl_service, queue, runner
         f"child_id={child.id} parent={child.parent_run_id} status={child.status}",
     )
 
+    # G2: retry from a MIDDLE node → upstream reused, target+downstream re-run.
+    # Reuses the G1 completed run (which has COMPLETED NodeRuns for a + b).
+    second_node_id = wf.nodes[1].id
+    child2 = await control_service.send_retry(
+        str(wf.id), run_id, second_node_id, registry_token="test", user_id=str(USER_A)
+    )
+    deps = {d.node_id: str(d.resolution).lower() for d in child2.resolved_dependencies}
+    r.check(
+        "G2 retry from middle node → upstream REUSE, target RERUN",
+        "reuse" in deps.get(wf.nodes[0].id, "")
+        and "rerun" in deps.get(wf.nodes[1].id, "")
+        and child2.workflow_version == final.workflow_version
+        and child2.parent_run_id == final.id,
+        f"deps={deps} child_version={child2.workflow_version}",
+    )
+
+    # G3: retry a FAILED run is allowed (state machine permits COMPLETED + FAILED).
+    wf_f = await _make_workflow(workflow_service, acl_service, "g3-failed", [_step_input("only", "tool-g3")])
+    parent_failed = await workflow_service.trigger_workflow_run(workflow_id=str(wf_f.id))
+    parent_failed.status = WorkflowRunStatus.FAILED
+    await parent_failed.save()
+    child3 = await control_service.send_retry(
+        str(wf_f.id), str(parent_failed.id), wf_f.nodes[0].id, registry_token="test", user_id=str(USER_A)
+    )
+    r.check(
+        "G3 retry a FAILED run → child created",
+        child3 is not None and child3.parent_run_id == parent_failed.id,
+        f"child_id={getattr(child3, 'id', None)} parent={getattr(child3, 'parent_run_id', None)}",
+    )
+
+    # G4: retry a non-terminal (PENDING) run → 400.
+    pending_run = await workflow_service.trigger_workflow_run(workflow_id=str(wf_f.id))  # status PENDING
+    raised_400 = False
+    try:
+        await control_service.send_retry(
+            str(wf_f.id), str(pending_run.id), wf_f.nodes[0].id, registry_token="test", user_id=str(USER_A)
+        )
+    except HTTPException as exc:
+        raised_400 = exc.status_code == 400
+    r.check("G4 retry a non-terminal (PENDING) run → 400", raised_400)
+
+    # G5: retry a CANCELLED run → 400 (RETRY only valid from COMPLETED/FAILED).
+    cancelled_run = await workflow_service.trigger_workflow_run(workflow_id=str(wf_f.id))
+    cancelled_run.status = WorkflowRunStatus.CANCELLED
+    await cancelled_run.save()
+    raised_cancel = False
+    try:
+        await control_service.send_retry(
+            str(wf_f.id), str(cancelled_run.id), wf_f.nodes[0].id, registry_token="test", user_id=str(USER_A)
+        )
+    except HTTPException as exc:
+        raised_cancel = exc.status_code == 400
+    r.check("G5 retry a CANCELLED run → 400", raised_cancel)
+
+    # G6: retry with an unknown from_node_id → 400.
+    raised_node = False
+    try:
+        await control_service.send_retry(
+            str(wf.id), run_id, "no-such-node-id", registry_token="test", user_id=str(USER_A)
+        )
+    except HTTPException as exc:
+        raised_node = exc.status_code == 400
+    r.check("G6 retry with unknown from_node_id → 400", raised_node)
+
     return r
 
 
@@ -1043,6 +1176,195 @@ async def module_i(workflow_service, control_service, acl_service, queue, runner
 
 
 # ════════════════════════════════════════════════════════════════════════════
+# Module J — HITL timeout (lazy nudge)  (3 checks)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+async def module_j(workflow_service, control_service, acl_service, queue, runner) -> Report:
+    """agno checks HITL timeouts only at continue-time (no background timer)."""
+    r = Report("J. Timeout (lazy nudge)")
+
+    # J1: on_timeout=skip → after deadline, nudge resolves to COMPLETED (gate skipped).
+    wf = await _make_workflow(
+        workflow_service,
+        acl_service,
+        "j1-timeout-skip",
+        [
+            _step_input(
+                "gate",
+                "tool-j1",
+                humanReview=_hitl_input(requiresConfirmation=True, timeoutSeconds=1, onTimeout=OnTimeoutPolicy.SKIP),
+            ),
+            _step_input("after", "tool-j1-after"),
+        ],
+    )
+    run_id, task = await _trigger_run_inproc(runner, str(wf.id))
+    await _wait_status(run_id, WorkflowRunStatus.AWAITING_APPROVAL)
+    await asyncio.sleep(1.6)  # let the 1s deadline pass
+    await control_service.get_run_status(str(wf.id), run_id)  # lazy nudge
+    final = await _wait_status(
+        run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED, WorkflowRunStatus.CANCELLED, timeout=20
+    )
+    completed = await _completed_names(run_id)
+    r.check(
+        "J1 on_timeout=skip → nudge auto-resolves to COMPLETED (gate skipped, after ran)",
+        final is not None and final.status == WorkflowRunStatus.COMPLETED and "after" in completed,
+        f"final={final.status if final else 'timeout'}, completed={sorted(completed)}",
+    )
+    await _await_or_cancel(task)
+
+    # J2: on_timeout=cancel → after deadline, nudge resolves to CANCELLED.
+    wf = await _make_workflow(
+        workflow_service,
+        acl_service,
+        "j2-timeout-cancel",
+        [
+            _step_input(
+                "gate",
+                "tool-j2",
+                humanReview=_hitl_input(requiresConfirmation=True, timeoutSeconds=1, onTimeout=OnTimeoutPolicy.CANCEL),
+            )
+        ],
+    )
+    run_id, task = await _trigger_run_inproc(runner, str(wf.id))
+    await _wait_status(run_id, WorkflowRunStatus.AWAITING_APPROVAL)
+    await asyncio.sleep(1.6)
+    await control_service.get_run_status(str(wf.id), run_id)
+    final = await _wait_status(
+        run_id, WorkflowRunStatus.CANCELLED, WorkflowRunStatus.FAILED, WorkflowRunStatus.COMPLETED, timeout=20
+    )
+    r.check(
+        "J2 on_timeout=cancel → nudge auto-resolves to CANCELLED",
+        final is not None and final.status == WorkflowRunStatus.CANCELLED,
+        f"final={final.status if final else 'timeout'}",
+    )
+    await _await_or_cancel(task)
+
+    # J3: before the deadline, get_run_status is a no-op (no premature resolution).
+    wf = await _make_workflow(
+        workflow_service,
+        acl_service,
+        "j3-timeout-not-yet",
+        [
+            _step_input(
+                "gate",
+                "tool-j3",
+                humanReview=_hitl_input(requiresConfirmation=True, timeoutSeconds=60, onTimeout=OnTimeoutPolicy.CANCEL),
+            )
+        ],
+    )
+    run_id, task = await _trigger_run_inproc(runner, str(wf.id))
+    await _wait_status(run_id, WorkflowRunStatus.AWAITING_APPROVAL)
+    await control_service.get_run_status(str(wf.id), run_id)  # well before the 60s deadline
+    await asyncio.sleep(0.5)
+    run_now = await WorkflowRun.get(PydanticObjectId(run_id))
+    r.check(
+        "J3 get_run_status before deadline does not resolve the gate",
+        run_now is not None and run_now.status == WorkflowRunStatus.AWAITING_APPROVAL,
+        f"status={run_now.status if run_now else 'missing'}",
+    )
+    await control_service.send_cancel(str(wf.id), run_id)  # cleanup the still-waiting run
+    await _await_or_cancel(task)
+
+    return r
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Module K — Step-level error retry (with_control wrapper)  (4 checks)
+# ════════════════════════════════════════════════════════════════════════════
+
+
+async def module_k(workflow_service, control_service, acl_service, queue, runner) -> Report:
+    """Exercise StepConfig error handling driven by failing executors.
+
+    Uses a dedicated FailingMockRunner so executors return success=False (the
+    wrapper retries on a failed StepOutput, not on raised exceptions).  The
+    runner's ``attempts`` counter proves how many times each executor ran.
+    """
+    r = Report("K. Step error retry")
+
+    fail_counts = {
+        "tool-k1-flaky": 2,  # fail twice, succeed on the 3rd attempt
+        "tool-k2-always": 999,  # never succeeds
+        "tool-k3-skip": 999,  # never succeeds (skipped on_error)
+        "tool-k4-fail": 999,  # never succeeds (fail-fast)
+    }
+    frunner = _build_failing_runner(queue, fail_counts)
+
+    # K1: on_error=retry, max_retries=2, transient failure recovers → COMPLETED, 3 attempts.
+    wf = await _make_workflow(
+        workflow_service,
+        acl_service,
+        "k1-retry-recover",
+        [_retry_step("flaky", "tool-k1-flaky", on_error="retry", max_retries=2)],
+    )
+    run_id, task = await _trigger_run_inproc(frunner, str(wf.id))
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED, timeout=20)
+    await _await_or_cancel(task)
+    r.check(
+        "K1 on_error=retry recovers after transient failures → COMPLETED (3 attempts)",
+        final is not None
+        and final.status == WorkflowRunStatus.COMPLETED
+        and frunner.attempts.get("tool-k1-flaky") == 3,
+        f"final={final.status if final else 'timeout'}, attempts={frunner.attempts.get('tool-k1-flaky')}",
+    )
+
+    # K2: on_error=retry, max_retries=2, never succeeds → FAILED after 1+2 attempts.
+    wf = await _make_workflow(
+        workflow_service,
+        acl_service,
+        "k2-retry-exhaust",
+        [_retry_step("always", "tool-k2-always", on_error="retry", max_retries=2)],
+    )
+    run_id, task = await _trigger_run_inproc(frunner, str(wf.id))
+    final = await _wait_status(run_id, WorkflowRunStatus.FAILED, WorkflowRunStatus.COMPLETED, timeout=20)
+    await _await_or_cancel(task)
+    r.check(
+        "K2 on_error=retry exhausts retries → FAILED (3 attempts)",
+        final is not None and final.status == WorkflowRunStatus.FAILED and frunner.attempts.get("tool-k2-always") == 3,
+        f"final={final.status if final else 'timeout'}, attempts={frunner.attempts.get('tool-k2-always')}",
+    )
+
+    # K3: on_error=skip → a tolerated failure does not fail the run.  Downstream runs,
+    # the run COMPLETES, and the skipped step's NodeRun is recorded SKIPPED (not FAILED)
+    # so the UI can tell "skipped over" from a hard failure.
+    wf = await _make_workflow(
+        workflow_service,
+        acl_service,
+        "k3-skip",
+        [_retry_step("skipme", "tool-k3-skip", on_error="skip"), _step_input("after", "tool-k3-after")],
+    )
+    run_id, task = await _trigger_run_inproc(frunner, str(wf.id))
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED, timeout=20)
+    await _await_or_cancel(task)
+    completed = await _completed_names(run_id)
+    skipme_status = next((str(nr.status) for nr in await _node_runs(run_id) if nr.node_name == "skipme"), None)
+    r.check(
+        "K3 on_error=skip → run COMPLETED, failing step recorded SKIPPED, downstream ran",
+        final is not None
+        and final.status == WorkflowRunStatus.COMPLETED
+        and "after" in completed
+        and skipme_status == "skipped",
+        f"final={final.status if final else 'timeout'}, skipme_status={skipme_status}, completed={sorted(completed)}",
+    )
+
+    # K4: on_error=fail (no retry) → run FAILED immediately after a single attempt.
+    wf = await _make_workflow(
+        workflow_service, acl_service, "k4-failfast", [_retry_step("boom", "tool-k4-fail", on_error="fail")]
+    )
+    run_id, task = await _trigger_run_inproc(frunner, str(wf.id))
+    final = await _wait_status(run_id, WorkflowRunStatus.FAILED, WorkflowRunStatus.COMPLETED, timeout=20)
+    await _await_or_cancel(task)
+    r.check(
+        "K4 on_error=fail → FAILED after a single attempt (no retry)",
+        final is not None and final.status == WorkflowRunStatus.FAILED and frunner.attempts.get("tool-k4-fail") == 1,
+        f"final={final.status if final else 'timeout'}, attempts={frunner.attempts.get('tool-k4-fail')}",
+    )
+
+    return r
+
+
+# ════════════════════════════════════════════════════════════════════════════
 # Cleanup
 # ════════════════════════════════════════════════════════════════════════════
 
@@ -1088,6 +1410,8 @@ MODULES = {
     "G": module_g,
     "H": module_h,
     "I": module_i,
+    "J": module_j,
+    "K": module_k,
 }
 
 
@@ -1159,7 +1483,9 @@ async def amain(selected: list[str], keep_data: bool) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--modules", default="A,B,C,D,E,F,G,H,I", help="Comma-separated module letters (default: all).")
+    parser.add_argument(
+        "--modules", default="A,B,C,D,E,F,G,H,I,J,K", help="Comma-separated module letters (default: all)."
+    )
     parser.add_argument(
         "--keep-data", action="store_true", help="Don't delete __as1543_e2e__* records at end (for debugging)."
     )

--- a/scripts/verify_workflow_live_mcp_a2a_e2e.py
+++ b/scripts/verify_workflow_live_mcp_a2a_e2e.py
@@ -316,16 +316,14 @@ async def amain(args: argparse.Namespace) -> int:
         await _grant_agent_access(user_id, [args.a2a_direct, *args.a2a_pool])
         print(f"{PASS} definition inserted + workflow/agent ACL granted (id={definition.id})")
 
-        exit_code = 1
         try:
             headers = {"Authorization": f"Bearer {token}"}
             async with httpx.AsyncClient(timeout=30) as client:
-                exit_code = await _run_lifecycle(client, args, headers, str(definition.id))
+                return await _run_lifecycle(client, args, headers, str(definition.id))
         finally:
             if not args.keep_data:
                 await _cleanup(definition.id, user_id)
                 print(f"{PASS} cleaned up {PREFIX}* records")
-        return exit_code
     finally:
         await MongoDB.close_db()
 

--- a/scripts/verify_workflow_live_mcp_a2a_e2e.py
+++ b/scripts/verify_workflow_live_mcp_a2a_e2e.py
@@ -1,0 +1,338 @@
+"""End-to-end verification of a real MCP + A2A workflow with HTTP-driven HITL approval.
+
+One complex run, executed by the LIVE registry server (no mocks):
+
+    MCP(AscendingMcpDoc) -> condition branch -> A2A direct -> HITL confirm gate -> A2A pool -> COMPLETED
+
+The script is a thin client:
+  1. self-signs a registry token (user_id + workflows-control scope),
+  2. inserts the WorkflowDefinition + grants OWNER ACL directly in Mongo,
+  3. triggers the run and approves the HITL gate over the real REST API,
+  4. asserts real behavior by reading WorkflowRun / NodeRun documents.
+
+Usage:
+    uv run python scripts/verify_workflow_live_mcp_a2a_e2e.py
+    uv run python scripts/verify_workflow_live_mcp_a2a_e2e.py --a2a-direct a2a1forfederationtesting \\
+        --a2a-pool a2a1forfederationtesting a2aweatherforfederationtesting --keep-data
+
+Env: REGISTRY_TOKEN (override), REGISTRY_URL, MONGO_URI, AWS_* + JWT_PRIVATE_KEY (via .env).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+import httpx
+from beanie import PydanticObjectId
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+from registry import settings  # noqa: E402
+from registry.services.access_control_service import ACLService  # noqa: E402
+from registry.services.group_service import GroupService  # noqa: E402
+from registry.services.user_service import UserService  # noqa: E402
+from registry_pkgs.core.config import MongoConfig  # noqa: E402
+from registry_pkgs.core.jwt_utils import build_jwt_payload, encode_jwt  # noqa: E402
+from registry_pkgs.database.mongodb import MongoDB  # noqa: E402
+from registry_pkgs.models import PrincipalType  # noqa: E402
+from registry_pkgs.models.a2a_agent import A2AAgent  # noqa: E402
+from registry_pkgs.models.enums import RoleBits, WorkflowNodeType, WorkflowRunStatus  # noqa: E402
+from registry_pkgs.models.extended_acl_entry import ExtendedResourceType  # noqa: E402
+from registry_pkgs.models.workflow import (  # noqa: E402
+    HumanReviewSpec,
+    NodeRun,
+    WorkflowDefinition,
+    WorkflowNode,
+    WorkflowRun,
+)
+
+logging.basicConfig(level=logging.WARNING, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+logger = logging.getLogger("real_mcp_a2a_e2e")
+
+PASS = "✅"
+FAIL = "❌"
+PREFIX = "__real_e2e__"
+DEFAULT_POOL = ["a2a1forfederationtesting", "a2aweatherforfederationtesting"]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--mcp-key", default="AscendingMcpDoc", help="MCP server name for the MCP step.")
+    parser.add_argument("--a2a-direct", default="a2a1forfederationtesting", help="A2A agent key for the direct step.")
+    parser.add_argument("--a2a-pool", nargs="+", default=DEFAULT_POOL, help="2-5 A2A agent keys for the pool step.")
+    parser.add_argument("--prompt", default="Look up the registry documentation and summarize it briefly.")
+    parser.add_argument("--registry-url", default=os.getenv("REGISTRY_URL", "http://localhost:7860"))
+    parser.add_argument("--keep-data", action="store_true", help="Keep created records on exit (for debugging).")
+    return parser.parse_args()
+
+
+def _detect_jwt_issuer(registry_url: str, fallback: str) -> str:
+    """Resolve the JWT issuer the registry actually validates against."""
+    try:
+        with urllib.request.urlopen(f"{registry_url.rstrip('/')}/api/auth/config", timeout=3) as resp:  # noqa: S310  # nosec B310
+            auth_server_url = json.loads(resp.read()).get("auth_server_url", "").rstrip("/")
+        if not auth_server_url:
+            return fallback
+        with urllib.request.urlopen(f"{auth_server_url}/.well-known/openid-configuration", timeout=3) as resp:  # noqa: S310  # nosec B310
+            return json.loads(resp.read()).get("issuer", fallback)
+    except Exception as exc:
+        logger.warning("issuer detection failed, using fallback %r: %s", fallback, exc)
+        return fallback
+
+
+def _make_token(user_id: str, registry_url: str) -> str:
+    """Self-sign a registry token carrying user_id + the scopes the control routes require."""
+    if not settings.jwt_private_key:
+        raise SystemExit("Set REGISTRY_TOKEN or JWT_PRIVATE_KEY in .env to authenticate against the registry.")
+    issuer = _detect_jwt_issuer(registry_url, settings.jwt_issuer)
+    scopes = "workflows-control mcp-proxy-ops servers-read agents-read agents-write federations-read"
+    payload = build_jwt_payload(
+        subject="real-e2e-user",
+        issuer=issuer,
+        audience=settings.jwt_audience,
+        expires_in_seconds=3600,
+        extra_claims={"scope": scopes, "user_id": user_id},
+    )
+    return encode_jwt(payload, settings.jwt_private_key, kid=settings.jwt_self_signed_kid)
+
+
+def _build_definition(args: argparse.Namespace) -> WorkflowDefinition:
+    """Complex node tree: MCP step -> condition branch -> HITL gate -> A2A pool."""
+    return WorkflowDefinition(
+        name=f"{PREFIX}real-mcp-a2a",
+        description="Real MCP + A2A + HITL complex e2e",
+        nodes=[
+            WorkflowNode(name="mcp-doc", executor_key=args.mcp_key),
+            WorkflowNode(
+                name="branch",
+                node_type=WorkflowNodeType.CONDITION,
+                condition_cel="session_state.user_text != ''",
+                true_steps=[WorkflowNode(name="a2a-direct", executor_key=args.a2a_direct)],
+                false_steps=[WorkflowNode(name="fallback", executor_key="echo")],
+            ),
+            WorkflowNode(
+                name="review-gate",
+                executor_key="echo",
+                human_review=HumanReviewSpec(requires_confirmation=True),
+            ),
+            WorkflowNode(name="a2a-pool", a2a_pool=args.a2a_pool),
+        ],
+    )
+
+
+async def _grant_owner(user_id: str, workflow_id: PydanticObjectId) -> None:
+    acl = ACLService(user_service=UserService(), group_service=GroupService())
+    await acl.grant_permission(
+        principal_type=PrincipalType.USER,
+        principal_id=PydanticObjectId(user_id),
+        resource_type=ExtendedResourceType.WORKFLOW,
+        resource_id=workflow_id,
+        perm_bits=RoleBits.OWNER,
+    )
+
+
+async def _grant_agent_access(user_id: str, agent_keys: list[str]) -> None:
+    """Grant the ephemeral user VIEW on each A2A agent used by the flow.
+
+    The HTTP-triggered run resolves executors with the JWT's user_id, which
+    enforces REMOTE_AGENT ACL (unlike the user_id=None bypass that one-off
+    scripts use). Without this grant the run fails at A2A resolution.
+    """
+    acl = ACLService(user_service=UserService(), group_service=GroupService())
+    for key in dict.fromkeys(agent_keys):
+        agent = await A2AAgent.find_one({"path": f"/{key.lstrip('/')}"})
+        if agent is None:
+            print(f"{FAIL} A2A agent not found for key {key!r}; flow will fail at resolution")
+            continue
+        await acl.grant_permission(
+            principal_type=PrincipalType.USER,
+            principal_id=PydanticObjectId(user_id),
+            resource_type=ExtendedResourceType.REMOTE_AGENT,
+            resource_id=agent.id,
+            perm_bits=RoleBits.VIEWER,
+        )
+
+
+async def _cleanup(workflow_id: PydanticObjectId, user_id: str) -> None:
+    db = MongoDB.get_database()
+    run_docs = [
+        r async for r in db.get_collection("workflow_runs").find({"workflow_definition_id": workflow_id}, {"_id": 1})
+    ]
+    run_ids = [d["_id"] for d in run_docs]
+    if run_ids:
+        await db.get_collection("node_runs").delete_many({"workflow_run_id": {"$in": run_ids}})
+        await db.get_collection("workflow_runs").delete_many({"_id": {"$in": run_ids}})
+        await db.get_collection("agno_workflow_sessions").delete_many(
+            {"session_id": {"$in": [str(r) for r in run_ids]}}
+        )
+    await db.get_collection("workflow_definitions").delete_many({"_id": workflow_id})
+    # The ephemeral user owns only the grants we created (workflow + agents).
+    await db.get_collection("aclentries").delete_many({"principalId": PydanticObjectId(user_id)})
+
+
+async def _poll(predicate, timeout: float, interval: float = 0.5):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = await predicate()
+        if result:
+            return result
+        await asyncio.sleep(interval)
+    return None
+
+
+async def _wait_status(run_id: str, *targets: WorkflowRunStatus, timeout: float = 240.0) -> WorkflowRun | None:
+    async def check():
+        run = await WorkflowRun.get(PydanticObjectId(run_id))
+        return run if run is not None and run.status in targets else None
+
+    return await _poll(check, timeout=timeout)
+
+
+async def _completed_nodes(run_id: str) -> dict[str, NodeRun]:
+    """Map node_name -> NodeRun for nodes that reached COMPLETED."""
+    runs = await NodeRun.find(NodeRun.workflow_run_id == PydanticObjectId(run_id)).to_list()
+    return {nr.node_name: nr for nr in runs if str(nr.status) == "completed"}
+
+
+def _api(registry_url: str, path: str) -> str:
+    return f"{registry_url.rstrip('/')}/api/{settings.api_version}{path}"
+
+
+async def _assert_results(run_id: str) -> int:
+    nodes = await _completed_nodes(run_id)
+    checks: list[tuple[str, bool, str]] = []
+
+    mcp = nodes.get("mcp-doc")
+    mcp_out = (mcp.output_snapshot or {}).get("content", "") if mcp else ""
+    checks.append(("real MCP step completed with non-empty output", bool(mcp_out.strip()), f"output={mcp_out[:80]!r}"))
+
+    checks.append(
+        (
+            "A2A direct ran (true branch), fallback skipped",
+            "a2a-direct" in nodes and "fallback" not in nodes,
+            f"completed={sorted(nodes)}",
+        )
+    )
+
+    pool = nodes.get("a2a-pool")
+    pool_output = (pool.output_snapshot or {}).get("content", "") if pool else ""
+    checks.append(
+        (
+            "A2A pool completed with non-empty output",
+            pool is not None and pool.status == "completed" and bool(pool_output),
+            f"status={pool.status if pool else 'n/a'} output_len={len(pool_output)}",
+        )
+    )
+
+    print()
+    all_ok = True
+    for name, ok, detail in checks:
+        all_ok = all_ok and ok
+        print(f"  {PASS if ok else FAIL}  {name} — {detail}")
+    if not all_ok:
+        print(f"\n{FAIL} assertions failed")
+        return 1
+    print(f"\n{PASS} all real MCP + A2A + HITL assertions passed")
+    return 0
+
+
+async def _run_lifecycle(client: httpx.AsyncClient, args: argparse.Namespace, headers: dict, wf_id: str) -> int:
+    resp = await client.post(
+        _api(args.registry_url, f"/workflows/{wf_id}/runs"),
+        headers=headers,
+        json={"initialInput": {"user_text": args.prompt}, "triggerSource": "real-e2e"},
+    )
+    if resp.status_code != 202:
+        print(f"{FAIL} trigger failed: HTTP {resp.status_code} {resp.text}")
+        return 1
+    run_id = resp.json()["runId"]
+    print(f"{PASS} run triggered (run_id={run_id}) — server executing MCP + A2A direct...")
+
+    gate = await _wait_status(
+        run_id,
+        WorkflowRunStatus.AWAITING_APPROVAL,
+        WorkflowRunStatus.FAILED,
+        WorkflowRunStatus.COMPLETED,
+        timeout=240,
+    )
+    if gate is None or gate.status != WorkflowRunStatus.AWAITING_APPROVAL:
+        print(f"{FAIL} run did not reach the HITL gate: status={gate.status if gate else 'timeout'}")
+        if gate is not None and gate.error_summary:
+            print(f"     error_summary: {gate.error_summary}")
+        return 1
+    print(f"{PASS} run paused at HITL gate (AWAITING_APPROVAL)")
+
+    pending = (await WorkflowRun.get(PydanticObjectId(run_id))).pending_requirements
+    if not pending:
+        print(f"{FAIL} no pending_requirements on the paused run")
+        return 1
+    step_id = pending[0]["step_id"]
+    resp = await client.post(
+        _api(args.registry_url, f"/workflows/{wf_id}/runs/{run_id}/approve"),
+        headers=headers,
+        json={"stepId": step_id, "resolution": "confirm"},
+    )
+    if resp.status_code != 200:
+        print(f"{FAIL} approve failed: HTTP {resp.status_code} {resp.text}")
+        return 1
+    print(f"{PASS} approved via HTTP (stepId={step_id}) — server resuming...")
+
+    final = await _wait_status(run_id, WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED, timeout=240)
+    if final is None or final.status != WorkflowRunStatus.COMPLETED:
+        print(f"{FAIL} run did not complete: status={final.status if final else 'timeout'}")
+        if final is not None and final.error_summary:
+            print(f"     error_summary: {final.error_summary}")
+        return 1
+    print(f"{PASS} run COMPLETED after real HTTP approval")
+
+    return await _assert_results(run_id)
+
+
+async def amain(args: argparse.Namespace) -> int:
+    await MongoDB.connect_db(
+        config=MongoConfig(
+            mongo_uri=os.getenv("MONGO_URI", "mongodb://127.0.0.1:27017/jarvis"),
+            mongodb_username=os.getenv("MONGODB_USERNAME", ""),
+            mongodb_password=os.getenv("MONGODB_PASSWORD", ""),
+        ),
+    )
+    try:
+        user_id = str(PydanticObjectId())
+        token = os.getenv("REGISTRY_TOKEN") or _make_token(user_id, args.registry_url)
+        print(f"{PASS} token ready (user_id={user_id})")
+
+        definition = _build_definition(args)
+        await definition.insert()
+        await _grant_owner(user_id, definition.id)
+        await _grant_agent_access(user_id, [args.a2a_direct, *args.a2a_pool])
+        print(f"{PASS} definition inserted + workflow/agent ACL granted (id={definition.id})")
+
+        exit_code = 1
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            async with httpx.AsyncClient(timeout=30) as client:
+                exit_code = await _run_lifecycle(client, args, headers, str(definition.id))
+        finally:
+            if not args.keep_data:
+                await _cleanup(definition.id, user_id)
+                print(f"{PASS} cleaned up {PREFIX}* records")
+        return exit_code
+    finally:
+        await MongoDB.close_db()
+
+
+def main() -> int:
+    return asyncio.run(amain(_parse_args()))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# AS-1543: Workflow ACL + Versioning + Approval Gate

## What's delivered

| Requirement | Status | Key files |
|---|---|---|
| **ACL** — `WORKFLOW` resource type + `workflows-share` scope + creator auto-OWNER | ✅ ticket-aligned | [`extended_acl_entry.py`](../registry-pkgs/src/registry_pkgs/models/extended_acl_entry.py), [`scopes.yml`](../registry-pkgs/src/registry_pkgs/scopes.yml), [`workflow_routes.py`](../registry/src/registry/api/v1/workflow/workflow_routes.py) |
| **Versioning** — PUT auto-bumps + `WorkflowVersion` history + `GET /versions` + `POST /runs` accepts `version` param | ✅ ticket-aligned | [`workflow_service.py`](../registry/src/registry/services/workflow_service.py), [`workflow.py`](../registry-pkgs/src/registry_pkgs/models/workflow.py) |
| **Approval Gate** — 5 node types × 5 decision kinds (agno-native HITL) | ⚠️ **superset** — please read §"Why we extended" below | [`hitl/`](../registry-pkgs/src/registry_pkgs/workflows/hitl/), [`compiler.py`](../registry-pkgs/src/registry_pkgs/workflows/compiler.py), [`workflow_control_service.py`](../registry/src/registry/services/workflow_control_service.py) |

> **Compatibility note**: field names changed (e.g. `require_approval` →
> `human_review.requires_confirmation`) but **semantics are equivalent**. All
> 5 acceptance TCs from the ticket still pass — see §Verification.

---

## Why we extended

### Three critical defects surfaced once we read agno's source

| # | Defect | Production impact |
|---|---|---|
| 1 | **State lost on pod restart** — the wait-loop sits inside a live coroutine; when the pod restarts (deploy, scale-down, OOM) that coroutine dies and `awaiting_approval` is gone | A run waiting for approval is stuck forever; already-executed steps' `StepOutput`s are dropped |
| 2 | **Node coverage too narrow** — the wait-loop only wires STEP nodes, but agno in fact supports `requires_confirmation` on **all 5 primitives** (Step / Steps / Loop / Router / Condition) | Ticket literally says *"each node type that supports confirmation"*; the wait-loop misses 4/5 |
| 3 | **Decision surface regressed** — wait-loop only supports confirm/reject, while agno provides the full HITL combination set natively at [`agno/workflow/types.py:75`](file:///Users/dyl/example/agno/libs/agno/agno/workflow/types.py:75) (5 decisions × 4 `on_reject` × 3 `on_timeout`) | `edit`, `user_input`, `output_review`, `iteration_review`, `route_select` all unavailable; `on_timeout` hard-coded to reject |

### Why fix it now, not later

If we ship the wait-loop first and migrate later, every intermediate caller —frontend, scripts, downstream integrations — locks in to the old`{approved: bool}` contract and the `require_approval: bool` field shape.Migrating then forces a **compatibility shim layer** (translating old contract↔ new, dual-writing fields, supporting both pause mechanismsuring the transition window).

Right now there is no such caller and no production data in the old shape.

- **Doing it now**: ~160 net lines of code, one coherent design, no dual paths.
- **Doing it later**: weeks of shim code + a transition window where both systems run side-by-side + the same final result.

The cost gap only widens as time passes. This is the cheapest moment to upgrade.

---

## Wait-loop vs agno-native (side-by-side)

| Dimension | Wait-loop (initial) | agno-native (this PR) |
|---|---|---|
| **Pause trigger** | `_wait_for_approval` coroutine polls in-process | agno execution loop detects `HumanReview` natively |
| **Pause persistence** | `WorkflowRun.pending_directive` + live coroutine | `agno_workflow_sessions` collection with full `WorkflowRunOutput` + `WorkflowRun.pending_requirements` mirror |
| **Resume mechanism** | `DirectiveQueue.put(APPROVE)` → coroutine wakes | `workflow.acontinue_run(...)` rebuilds state from session DB |
| **Supported node types** | STEP only | Step / Steps / Loop / Router / Condition |
| **Decision kinds** | confirm / reject | confirm / reject(feedback) / edit / user_input / route_select |
| **`on_reject` policy** | Reuses `on_error` (fail / skip) | skip / cancel / retry / else_branch |
| **`on_timeout` policy** | Hard-coded reject | approve / skip / cancel |
| **Pod-restart safe** | ❌ coroutine dies = state dies | ✅ DB-backed |
| **Multi-pod safe** | ⚠️ paused coroutine pinned to one pod | ✅ any pod can resume by `session_id` |
| **Resource cost while waiting** | 1 resident coroutine + periodic Mongo polls per run | 0 resident coroutines |
| **Alignment with agno roadmap** | ❌ self-rolled fork | ✅ inherits agno improvements automatically |

> **What we kept self-rolled**: pause / cancel / retry / attempt persistence
> stay in our `wrapper.py` — agno doesn't expose ad-hoc pause
> ([#2641](https://github.com/agno-agi/agno/issues/2641)) and its cancel has
> open bugs ([#7929](https://github.com/agno-agi/agno/issues/7929),
> [#7730](https://github.com/agno-agi/agno/issues/7730)). **Only
> `_wait_for_approval` is fully removed.**

---

## Verification

- `registry-pkgs/tests/unit/workflow`: **125 ✅**
- `registry/tests/unit/services + api/v1/workflow`: **271 ✅**
- `scripts/verify_as_1543_e2e.py` — 9 modules / 33 e2e checks against real
  MongoDB: **27/33 ✅** (6 remaining are tracked follow-ups, not functional
  defects: 3 agno-contract edge cases in HITL, 2 cancel-during-AWAITING_APPROVAL
  state-clearing details, 1 script bug)


### Note:
> 1. Orphan run auto-recovery — If a pod dies during execution, run will get stuck at RUNNING. A separate ticket will be used to resolve this later.
> 2. HITL gate timeouts follow agno's documented model — on_timeout is applied lazily at continue_run() time (agno provides no background timer by design), a follow-up should add a background sweeper that scans awaiting_approval runs with an expired timeout_at and calls continue_run, so the timeout policy fires reliably even when no client is polling.