### PR TITLE
Update A2A invoke tool and enhance JSON text parser

### DIFF
--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 import uuid
@@ -221,6 +222,36 @@ def _create_message(text: str) -> Message:
     )
 
 
+def _parse_message_input(text: str) -> Message:
+    """Builds a Message from plain text or a JSON parts-payload; falls back to a TextPart on any parse error."""
+    try:
+        payload = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return _create_message(text)
+
+    if not isinstance(payload, dict) or not payload.get("parts"):
+        return _create_message(text)
+
+    parts: list[Part] = []
+    for raw_part in payload["parts"]:
+        if not isinstance(raw_part, dict):
+            continue
+        try:
+            parts.append(Part.model_validate(raw_part))
+        except Exception as e:
+            logger.warning("Skipping unrecognized message part %s: %s", raw_part, e)
+
+    if not parts:
+        return _create_message(text)
+
+    return Message(
+        kind="message",
+        role=Role.user,
+        parts=parts,
+        message_id=payload.get("messageId") or uuid.uuid4().hex,
+    )
+
+
 async def _maybe_emit_chunk(
     on_chunk: Callable[[str], Awaitable[None]] | None,
     text: str,
@@ -350,7 +381,7 @@ async def _call_with_open_client(
 ) -> A2ACallResult:
     """Run the three-phase consume/poll/build pipeline against an already-open client."""
     # 1. drain the event stream.
-    outcome = await _consume_stream(client, _create_message(text), context=context, on_chunk=on_chunk)
+    outcome = await _consume_stream(client, _parse_message_input(text), context=context, on_chunk=on_chunk)
 
     if isinstance(outcome, Message):
         logger.debug("← A2A agent %r responded with Message", agent_name)

--- a/registry-pkgs/tests/unit/workflow/test_a2a_client.py
+++ b/registry-pkgs/tests/unit/workflow/test_a2a_client.py
@@ -21,7 +21,7 @@ from beanie import PydanticObjectId
 
 from registry_pkgs.core.config import JwtSigningConfig
 from registry_pkgs.models.a2a_agent import A2AAgent, AgentConfig
-from registry_pkgs.workflows.a2a_client import A2ACallResult, call_a2a
+from registry_pkgs.workflows.a2a_client import A2ACallResult, _parse_message_input, call_a2a
 
 
 def _jwt_config() -> JwtSigningConfig:
@@ -657,3 +657,35 @@ async def test_call_a2a_uses_async_with_when_no_shared_httpx_client():
 
     mock_client.__aenter__.assert_awaited_once()
     mock_client.__aexit__.assert_awaited_once()
+
+
+# ── _parse_message_input ─────────────────────────────────────────────────────
+
+
+def test_parse_message_input_plain_text_returns_single_text_part():
+    msg = _parse_message_input("hello world")
+    assert len(msg.parts) == 1
+    assert msg.parts[0].root.kind == "text"
+    assert msg.parts[0].root.text == "hello world"
+
+
+def test_parse_message_input_invalid_json_falls_back_to_text():
+    raw = "{not valid json"
+    msg = _parse_message_input(raw)
+    assert len(msg.parts) == 1
+    assert msg.parts[0].root.text == raw
+
+
+def test_parse_message_input_structured_data_part():
+    raw = '{"parts": [{"kind": "data", "data": {"start_time": "2026-05-15T07:00:00Z", "end_time": "2026-05-15T11:00:00Z"}}]}'
+    msg = _parse_message_input(raw)
+    assert len(msg.parts) == 1
+    assert msg.parts[0].root.kind == "data"
+    assert msg.parts[0].root.data == {"start_time": "2026-05-15T07:00:00Z", "end_time": "2026-05-15T11:00:00Z"}
+
+
+def test_parse_message_input_skips_bad_parts_keeps_valid():
+    raw = '{"parts": [{"kind": "unknown", "foo": "bar"}, {"kind": "text", "text": "keep me"}]}'
+    msg = _parse_message_input(raw)
+    assert len(msg.parts) == 1
+    assert msg.parts[0].root.text == "keep me"

--- a/registry/src/registry/mcpgw/tools/agent.py
+++ b/registry/src/registry/mcpgw/tools/agent.py
@@ -250,7 +250,8 @@ def get_tools() -> list[tuple[str, Callable]]:
                 max_length=8192,
                 description=(
                     "The task or question to send to the agent. "
-                    "Be explicit and complete — the agent has no prior conversation context."
+                    "Accepts plain text or a JSON-serialized payload with typed parts (text, data, file). "
+                    "Check the agent's description from discover_agents — it specifies which format to use."
                 ),
             ),
         ],
@@ -268,9 +269,44 @@ def get_tools() -> list[tuple[str, Callable]]:
           or trying a different agent.
 
         Workflow:
-          1. discover_agents(query='…') → pick agent_id from results
-          2. execute_agent(agent_id='…', message='<full task description>')
-          3. Return the agent's response to the user."""
+        1. discover_agents(query='…') → pick agent_id from results
+        2. Read the agent's description field — it specifies the expected message format
+        3. execute_agent(agent_id='…', message='…') — see Message Format below
+        4. Return the agent's response to the user.
+
+        Message Format:
+        The `message` field accepts plain text (default) or a JSON-serialized payload
+        with typed parts. The agent's description from discover_agents will tell you
+        which format to use.
+
+        PLAIN TEXT (default — use when the agent description gives no special instructions):
+            message='<full task description as natural language>'
+
+        STRUCTURED PAYLOAD (use when the agent description instructs it):
+            Serialize a JSON object as the message string:
+
+            {
+              "messageId": "<uuid>",  (omit to auto-generate; required on the wire per A2A spec)
+              "parts": [...]          (required — one or more Part objects below)
+            }
+
+            Part types:
+
+            kind: "text"  — natural language instruction or context
+            {"kind": "text", "text": "Summarize the results"}
+
+            kind: "data"  — structured parameters matching the agent's input schema
+            {"kind": "data", "data": {"key": "value"}}
+
+            kind: "file"  — file content inline (base64) or by URI reference
+            {"kind": "file", "file": {"name": "report.csv", "mimeType": "text/csv", "bytes": "<base64>"}}
+            {"kind": "file", "file": {"name": "report.json", "mimeType": "application/json", "uri": "s3://bucket/file.json"}}
+
+            Parts can be combined in a single message:
+            message='{"messageId": "uuid", "parts": [
+              {"kind": "data", "data": {"month": "2024-01"}},
+              {"kind": "text", "text": "Summarize spending by category"}
+            ]}'"""
         return await execute_agent_impl(agent_id, message, ctx)
 
     return [("execute_agent", execute_agent)]

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -150,8 +150,12 @@ def get_tools() -> list[tuple[str, Callable]]:
         - skill_name (entity_type='skill'): the specific skill to target
 
         Execution:
-        - call execute_agent(agent_id=<agent_id>, message=<full task description>).
-        - If entity_type='skill', include the skill_name in the message to target that capability.
+        - Read the description field carefully — for skills it includes an Input Schema
+          (if the agent provided one) with exact field names, types, and constraints.
+        - Use the Input Schema to construct the message payload for execute_agent.
+        - call execute_agent(agent_id=<agent_id>, message=<payload>) — see execute_agent
+          for message format details (plain text or JSON with typed parts).
+        - If entity_type='skill', target the specific skill via the message payload.
 
         Evaluating results: read each result's description to confirm the agent's
         domain matches the user's task — do not rely on the score alone. If the top


### PR DESCRIPTION
This pull request adds support for structured message payloads in the agent workflow, allowing messages to be sent as either plain text or as JSON objects with typed parts (`text`, `data`, `file`). It introduces a new parsing function to handle this logic, updates the agent execution documentation to describe the new message format, and adds unit tests to ensure correct parsing behavior.

**Message Parsing Enhancements:**
* Added `_parse_message_input` to `a2a_client.py`, which builds a `Message` from either plain text or a JSON payload with typed parts, falling back to plain text if parsing fails. (`[registry-pkgs/src/registry_pkgs/workflows/a2a_client.pyR225-R254](diffhunk://#diff-edfdabf17ab9c2c762c601b760948e958dfc388a86a18807e886906c80e2b368R225-R254)`)
* Updated `_call_with_open_client` to use `_parse_message_input` instead of always wrapping the input as plain text, enabling support for structured messages. (`[registry-pkgs/src/registry_pkgs/workflows/a2a_client.pyL353-R384](diffhunk://#diff-edfdabf17ab9c2c762c601b760948e958dfc388a86a18807e886906c80e2b368L353-R384)`)

**Documentation and Developer Guidance:**
* Expanded the docstring for `execute_agent` to describe the new message format, including examples of plain text and structured JSON payloads with different part types. (`[registry/src/registry/mcpgw/tools/agent.pyL272-R309](diffhunk://#diff-f597bc9d24017fe9e299c7e5e743ae64a90c340bebeb5185585aafc7bd1c6c95L272-R309)`)
* Clarified the `description` field for the `message` parameter in `execute_agent`, instructing users to check the agent's description for the expected format. (`[registry/src/registry/mcpgw/tools/agent.pyL253-R254](diffhunk://#diff-f597bc9d24017fe9e299c7e5e743ae64a90c340bebeb5185585aafc7bd1c6c95L253-R254)`)
* Updated `discover_agents` documentation to reference the new message format and the importance of using the agent's input schema when constructing messages. (`[registry/src/registry/mcpgw/tools/search.pyL153-R158](diffhunk://#diff-655be6ed748e4cff20c9dbf9cff86299d69ea6118744023751dc488e2ca90813L153-R158)`)

**Testing:**
* Added unit tests for `_parse_message_input` covering plain text, invalid JSON, structured data parts, and mixed/invalid parts. (`[registry-pkgs/tests/unit/workflow/test_a2a_client.pyR660-R691](diffhunk://#diff-682df56ecb39715b5737996b1179265806ef0c6e5a77f8152939189bb34de74cR660-R691)`)…ser for a2a json