### PR TITLE
Improve A2A invoke tool and enhance JSON text parser

### DIFF
--- a/docs/macos-setup-guide.md
+++ b/docs/macos-setup-guide.md
@@ -637,7 +637,6 @@ podman compose down
 ---
 
 ## 11. Troubleshooting
->>>>>>> fork-sync
 
 ### Common macOS Issues
 

--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 import asyncio

--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import time
 import uuid
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
@@ -220,24 +219,11 @@ def _create_message(text: str) -> Message:
     )
 
 
-async def _maybe_emit_chunk(
-    on_chunk: Callable[[str], Awaitable[None]] | None,
-    text: str,
-) -> None:
-    if not text or on_chunk is None:
-        return
-    try:
-        await on_chunk(text)
-    except Exception as e:
-        logger.warning("on_chunk callback failed:%s, continuing accumulation", e, exc_info=True)
-
-
 async def _consume_stream(
     client: BaseClient,
     message: Message,
     *,
     context: ClientCallContext,
-    on_chunk: Callable[[str], Awaitable[None]] | None = None,
 ) -> Message | Task | None:
     """Drain client.send_message events. Returns the first Message reply,
     the last seen Task, or None if no events were produced.
@@ -250,10 +236,8 @@ async def _consume_stream(
     latest_task: Task | None = None
     async for event in client.send_message(message, context=context):
         if isinstance(event, Message):
-            await _maybe_emit_chunk(on_chunk, get_message_text(event))
             return event
         task, _ = event
-        await _maybe_emit_chunk(on_chunk, get_artifact_text(task.artifacts[-1]) if task.artifacts else "")
         latest_task = task
     return latest_task
 
@@ -342,12 +326,11 @@ async def _call_with_open_client(
     agent_name: str,
     text: str | Message,
     context: ClientCallContext,
-    on_chunk: Callable[[str], Awaitable[None]] | None = None,
 ) -> A2ACallResult:
     """Run the three-phase consume/poll/build pipeline against an already-open client."""
     # 1. drain the event stream.
     msg = text if isinstance(text, Message) else _create_message(text)
-    outcome = await _consume_stream(client, msg, context=context, on_chunk=on_chunk)
+    outcome = await _consume_stream(client, msg, context=context)
 
     if isinstance(outcome, Message):
         logger.debug("← A2A agent %r responded with Message", agent_name)
@@ -383,7 +366,6 @@ async def call_a2a(
     text: str | Message,
     *,
     jwt_config: JwtSigningConfig,
-    on_chunk: Callable[[str], Awaitable[None]] | None = None,
     httpx_client: httpx.AsyncClient | None = None,
 ) -> A2ACallResult:
     """Invoke an A2A agent via the a2a-sdk ClientFactory.
@@ -443,8 +425,8 @@ async def call_a2a(
         client: BaseClient = ClientFactory(config).create(agent_card)  # type: ignore[assignment]
         if httpx_client is None:
             async with client:
-                return await _call_with_open_client(client, agent_name, text, context, on_chunk)
-        return await _call_with_open_client(client, agent_name, text, context, on_chunk)
+                return await _call_with_open_client(client, agent_name, text, context)
+        return await _call_with_open_client(client, agent_name, text, context)
 
     except Exception as exc:
         logger.exception("A2A call to %r failed", agent_name)

--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
@@ -1,9 +1,11 @@
+
 from __future__ import annotations
 
 import asyncio
 import logging
 import time
 import uuid
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
@@ -219,11 +221,24 @@ def _create_message(text: str) -> Message:
     )
 
 
+async def _maybe_emit_chunk(
+    on_chunk: Callable[[str], Awaitable[None]] | None,
+    text: str,
+) -> None:
+    if not text or on_chunk is None:
+        return
+    try:
+        await on_chunk(text)
+    except Exception as e:
+        logger.warning("on_chunk callback failed:%s, continuing accumulation", e, exc_info=True)
+
+
 async def _consume_stream(
     client: BaseClient,
     message: Message,
     *,
     context: ClientCallContext,
+    on_chunk: Callable[[str], Awaitable[None]] | None = None,
 ) -> Message | Task | None:
     """Drain client.send_message events. Returns the first Message reply,
     the last seen Task, or None if no events were produced.
@@ -236,8 +251,10 @@ async def _consume_stream(
     latest_task: Task | None = None
     async for event in client.send_message(message, context=context):
         if isinstance(event, Message):
+            await _maybe_emit_chunk(on_chunk, get_message_text(event))
             return event
         task, _ = event
+        await _maybe_emit_chunk(on_chunk, get_artifact_text(task.artifacts[-1]) if task.artifacts else "")
         latest_task = task
     return latest_task
 
@@ -324,12 +341,14 @@ def _result_from_task(task: Task) -> A2ACallResult:
 async def _call_with_open_client(
     client: BaseClient,
     agent_name: str,
-    text: str,
+    text: str | Message,
     context: ClientCallContext,
+    on_chunk: Callable[[str], Awaitable[None]] | None = None,
 ) -> A2ACallResult:
     """Run the three-phase consume/poll/build pipeline against an already-open client."""
     # 1. drain the event stream.
-    outcome = await _consume_stream(client, _create_message(text), context=context)
+    msg = text if isinstance(text, Message) else _create_message(text)
+    outcome = await _consume_stream(client, msg, context=context, on_chunk=on_chunk)
 
     if isinstance(outcome, Message):
         logger.debug("← A2A agent %r responded with Message", agent_name)
@@ -362,9 +381,10 @@ async def _call_with_open_client(
 
 async def call_a2a(
     agent: A2AAgent,
-    text: str,
+    text: str | Message,
     *,
     jwt_config: JwtSigningConfig,
+    on_chunk: Callable[[str], Awaitable[None]] | None = None,
     httpx_client: httpx.AsyncClient | None = None,
 ) -> A2ACallResult:
     """Invoke an A2A agent via the a2a-sdk ClientFactory.
@@ -398,7 +418,7 @@ async def call_a2a(
         agent_name,
         transport_type,
         base_url,
-        text[:120],
+        text[:120] if isinstance(text, str) else repr(text)[:120],
     )
 
     agent_card = agent.card.model_copy(deep=True)
@@ -424,8 +444,8 @@ async def call_a2a(
         client: BaseClient = ClientFactory(config).create(agent_card)  # type: ignore[assignment]
         if httpx_client is None:
             async with client:
-                return await _call_with_open_client(client, agent_name, text, context)
-        return await _call_with_open_client(client, agent_name, text, context)
+                return await _call_with_open_client(client, agent_name, text, context, on_chunk)
+        return await _call_with_open_client(client, agent_name, text, context, on_chunk)
 
     except Exception as exc:
         logger.exception("A2A call to %r failed", agent_name)

--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
@@ -394,7 +394,7 @@ async def call_a2a(
 
     Args:
         agent:        A2AAgent document from MongoDB.
-        text:         User message / task description to send.
+        text:         User message string or pre-parsed A2A Message to send.
         jwt_config:   JWT signing config for service-to-agent auth.
         httpx_client: Optional shared httpx client.
 

--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
@@ -399,7 +399,7 @@ async def call_a2a(
         agent_name,
         transport_type,
         base_url,
-        text[:120] if isinstance(text, str) else repr(text)[:120],
+        text[:120] if isinstance(text, str) else f"<Message parts={len(text.parts)}>",
     )
 
     agent_card = agent.card.model_copy(deep=True)

--- a/registry-pkgs/tests/unit/workflow/test_a2a_client.py
+++ b/registry-pkgs/tests/unit/workflow/test_a2a_client.py
@@ -571,3 +571,27 @@ async def test_call_a2a_uses_async_with_when_no_shared_httpx_client():
 
     mock_client.__aenter__.assert_awaited_once()
     mock_client.__aexit__.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_call_a2a_accepts_pre_parsed_message():
+    """When call_a2a receives a pre-built Message, it must pass it directly to
+    _consume_stream without re-wrapping via _create_message."""
+    agent = _make_agent()
+    pre_parsed = Message(
+        kind="message",
+        role=Role.user,
+        parts=[Part(root=TextPart(kind="text", text="pre-parsed"))],
+        message_id="pre-id",
+    )
+    mock_factory, _ = _mock_client([_msg("ok")])
+
+    with (
+        patch("registry_pkgs.workflows.a2a_client.build_headers", return_value={}),
+        patch("registry_pkgs.workflows.a2a_client.ClientFactory", return_value=mock_factory),
+        patch("registry_pkgs.workflows.a2a_client._create_message") as mock_create,
+    ):
+        result = await call_a2a(agent, pre_parsed, jwt_config=_jwt_config())
+
+    assert result.success is True
+    mock_create.assert_not_called()

--- a/registry/src/registry/mcpgw/tools/agent.py
+++ b/registry/src/registry/mcpgw/tools/agent.py
@@ -311,8 +311,34 @@ def get_tools() -> list[tuple[str, Callable]]:
         kind="data"  — structured parameters matching the agent's Input Schema
         kind="file"  — file by URI reference or inline base64
 
-        Example:
-            message={"parts": [{"kind": "text", "text": "Run a full code review of this repo."}]}"""
+        Examples by part type:
+
+        kind="text"  — natural language instruction
+            message={"parts": [{"kind": "text", "text": "Summarize the report."}]}
+
+        kind="data"  — structured parameters matching the agent's Input Schema
+            message={"parts": [{"kind": "data", "data": {"month": "2024-01", "region": "us-east"}}]}
+
+        kind="file"  — URI reference (preferred for large files)
+            message={"parts": [{"kind": "file", "file": {"name": "report.json", "mimeType": "application/json", "uri": "s3://bucket/file.json"}}]}
+
+        kind="file"  — inline base64 (small files only)
+            message={"parts": [{"kind": "file", "file": {"name": "data.csv", "mimeType": "text/csv", "bytes": "<base64>"}}]}
+
+        Combining parts — structured data plus a text instruction:
+            message={"parts": [
+              {"kind": "data", "data": {"month": "2024-01"}},
+              {"kind": "text", "text": "Summarize spending by category"}
+            ]}
+
+        Combining parts — file plus a text instruction:
+            message={"parts": [
+              {"kind": "file", "file": {"uri": "s3://bucket/report.pdf", "mimeType": "application/pdf"}},
+              {"kind": "text", "text": "Summarize the key findings from this report."}
+            ]}
+
+        Targeting a specific skill — include the skill name in a TextPart:
+            message={"parts": [{"kind": "text", "text": "Use the code-review skill to review this PR: <url>"}]}"""
         return await execute_agent_impl(agent_id, message, ctx)
 
     return [("execute_agent", execute_agent)]

--- a/registry/src/registry/mcpgw/tools/agent.py
+++ b/registry/src/registry/mcpgw/tools/agent.py
@@ -31,8 +31,6 @@ from ..core.types import McpAppContext
 
 logger = logging.getLogger(__name__)
 
-_AGENT_INVOKE_LOGGER = "execute_agent"
-
 
 def _file_to_resource(f: FileWithBytes | FileWithUri) -> EmbeddedResource | None:
     """Convert one A2A file payload to an MCP EmbeddedResource. None for unsupported."""
@@ -238,15 +236,11 @@ async def execute_agent_impl(
         parts=[Part(root=p) for p in message.parts],
     )
 
-    async def on_chunk(chunk: str) -> None:
-        await ctx.log("info", chunk, logger_name=_AGENT_INVOKE_LOGGER)
-
     logger.info("execute_agent: invoking agent_id=%s path=%s", agent_id, agent.path)
     result = await call_a2a(
         agent,
         a2a_message,
         jwt_config=lifespan.jwt_signing_config,
-        on_chunk=on_chunk,
         httpx_client=lifespan.a2a_httpx_client,
     )
     if not result.success:
@@ -290,69 +284,35 @@ def get_tools() -> list[tuple[str, Callable]]:
     ) -> CallToolResult:
         """Invoke an A2A agent by its agent_id and receive its response.
 
-                Use this after discover_agents to delegate a complex task to the selected agent.
-                The agent runs autonomously and returns its final result.
+        Use this after discover_agents to delegate a complex task to the selected agent.
+        The agent runs autonomously and returns its final result.
 
-                Streaming: partial responses are sent as MCP log notifications during execution.
+        Error handling:
+        - Invalid or unknown agent_id → isError=True with a retry hint; call discover_agents again.
+        - Agent invocation failure → isError=True with the error message; consider retrying
+          or trying a different agent.
 
-                Error handling:
-                - Invalid or unknown agent_id → isError=True with a retry hint; call discover_agents again.
-                - Agent invocation failure → isError=True with the error message; consider retrying
-                  or trying a different agent.
+        Workflow:
+        1. discover_agents(query='…') → pick agent_id from results
+        2. execute_agent(agent_id='…', message={parts: [...]})
+        3. Return the agent's response to the user.
 
-                Workflow:
-                1. discover_agents(query='…') → pick agent_id from results
-                2. execute_agent(agent_id='…', message={parts: [...]})
-                3. Return the agent's response to the user.
+        Choosing a part type:
+        - Check the agent's description from discover_agents first — if it includes
+          an Input Schema, use DataPart with fields matching that schema.
+        - If no Input Schema is present, use a single TextPart with a natural-language
+          instruction.
+        - Use FilePart to pass file content — URI reference for large files,
+          inline base64 only for small payloads.
 
-        <<<<<<< HEAD
-                Message parts:
-        =======
-                Message Format:
-                The `message` field accepts plain text (default) or a JSON-serialized payload
-                with typed parts. The agent's description from discover_agents will tell you
-                which format to use. The field is capped at 8192 characters — prefer URI file
-                parts over inline base64 for anything beyond a few hundred bytes.
-        >>>>>>> 8257d9b7 (type validation and prompt consideration for larger files and size limits)
+        Message parts:
 
-                kind="text"  — natural language instruction or context (most common)
-                    {"kind": "text", "text": "Summarize the attached data by category"}
+        kind="text"  — natural language instruction or context (most common)
+        kind="data"  — structured parameters matching the agent's Input Schema
+        kind="file"  — file by URI reference or inline base64
 
-                kind="data"  — structured parameters matching the agent's input schema
-                    {"kind": "data", "data": {"month": "2024-01", "region": "us-east"}}
-
-        <<<<<<< HEAD
-                kind="file"  — file by URI reference (preferred for large content)
-        =======
-                    {
-                      "messageId": "<uuid>",  (omit to auto-generate; required on the wire per A2A spec)
-                      "parts": [...]          (required — one or more Part objects below)
-                    }
-
-                    Part types:
-
-                    kind: "text"  — natural language instruction or context
-                    {"kind": "text", "text": "Summarize the results"}
-
-                    kind: "data"  — structured parameters matching the agent's input schema
-                    {"kind": "data", "data": {"key": "value"}}
-
-                    kind: "file"  — file by URI reference (recommended) or inline base64 (small files only)
-        >>>>>>> 8257d9b7 (type validation and prompt consideration for larger files and size limits)
-                    {"kind": "file", "file": {"name": "report.json", "mimeType": "application/json", "uri": "s3://bucket/file.json"}}
-                    {"kind": "file", "file": {"name": "report.csv", "mimeType": "text/csv", "bytes": "<base64>"}}
-
-                kind="file"  — inline base64 (small files only)
-                    {"kind": "file", "file": {"name": "data.csv", "mimeType": "text/csv", "bytes": "<base64>"}}
-
-                Parts can be combined. Example — structured data plus a text instruction:
-                    message={"parts": [
-                      {"kind": "data", "data": {"month": "2024-01"}},
-                      {"kind": "text", "text": "Summarize spending by category"}
-                    ]}
-
-                Default (text only):
-                    message={"parts": [{"kind": "text", "text": "Run a full code review of this PR."}]}"""
+        Example (text only):
+            message={"parts": [{"kind": "text", "text": "Run a full code review of this PR."}]}"""
         return await execute_agent_impl(agent_id, message, ctx)
 
     return [("execute_agent", execute_agent)]

--- a/registry/src/registry/mcpgw/tools/agent.py
+++ b/registry/src/registry/mcpgw/tools/agent.py
@@ -290,69 +290,69 @@ def get_tools() -> list[tuple[str, Callable]]:
     ) -> CallToolResult:
         """Invoke an A2A agent by its agent_id and receive its response.
 
-        Use this after discover_agents to delegate a complex task to the selected agent.
-        The agent runs autonomously and returns its final result.
+                Use this after discover_agents to delegate a complex task to the selected agent.
+                The agent runs autonomously and returns its final result.
 
-        Streaming: partial responses are sent as MCP log notifications during execution.
+                Streaming: partial responses are sent as MCP log notifications during execution.
 
-        Error handling:
-        - Invalid or unknown agent_id → isError=True with a retry hint; call discover_agents again.
-        - Agent invocation failure → isError=True with the error message; consider retrying
-          or trying a different agent.
+                Error handling:
+                - Invalid or unknown agent_id → isError=True with a retry hint; call discover_agents again.
+                - Agent invocation failure → isError=True with the error message; consider retrying
+                  or trying a different agent.
 
-        Workflow:
-        1. discover_agents(query='…') → pick agent_id from results
-        2. execute_agent(agent_id='…', message={parts: [...]})
-        3. Return the agent's response to the user.
+                Workflow:
+                1. discover_agents(query='…') → pick agent_id from results
+                2. execute_agent(agent_id='…', message={parts: [...]})
+                3. Return the agent's response to the user.
 
-<<<<<<< HEAD
-        Message parts:
-=======
-        Message Format:
-        The `message` field accepts plain text (default) or a JSON-serialized payload
-        with typed parts. The agent's description from discover_agents will tell you
-        which format to use. The field is capped at 8192 characters — prefer URI file
-        parts over inline base64 for anything beyond a few hundred bytes.
->>>>>>> 8257d9b7 (type validation and prompt consideration for larger files and size limits)
+        <<<<<<< HEAD
+                Message parts:
+        =======
+                Message Format:
+                The `message` field accepts plain text (default) or a JSON-serialized payload
+                with typed parts. The agent's description from discover_agents will tell you
+                which format to use. The field is capped at 8192 characters — prefer URI file
+                parts over inline base64 for anything beyond a few hundred bytes.
+        >>>>>>> 8257d9b7 (type validation and prompt consideration for larger files and size limits)
 
-        kind="text"  — natural language instruction or context (most common)
-            {"kind": "text", "text": "Summarize the attached data by category"}
+                kind="text"  — natural language instruction or context (most common)
+                    {"kind": "text", "text": "Summarize the attached data by category"}
 
-        kind="data"  — structured parameters matching the agent's input schema
-            {"kind": "data", "data": {"month": "2024-01", "region": "us-east"}}
+                kind="data"  — structured parameters matching the agent's input schema
+                    {"kind": "data", "data": {"month": "2024-01", "region": "us-east"}}
 
-<<<<<<< HEAD
-        kind="file"  — file by URI reference (preferred for large content)
-=======
-            {
-              "messageId": "<uuid>",  (omit to auto-generate; required on the wire per A2A spec)
-              "parts": [...]          (required — one or more Part objects below)
-            }
+        <<<<<<< HEAD
+                kind="file"  — file by URI reference (preferred for large content)
+        =======
+                    {
+                      "messageId": "<uuid>",  (omit to auto-generate; required on the wire per A2A spec)
+                      "parts": [...]          (required — one or more Part objects below)
+                    }
 
-            Part types:
+                    Part types:
 
-            kind: "text"  — natural language instruction or context
-            {"kind": "text", "text": "Summarize the results"}
+                    kind: "text"  — natural language instruction or context
+                    {"kind": "text", "text": "Summarize the results"}
 
-            kind: "data"  — structured parameters matching the agent's input schema
-            {"kind": "data", "data": {"key": "value"}}
+                    kind: "data"  — structured parameters matching the agent's input schema
+                    {"kind": "data", "data": {"key": "value"}}
 
-            kind: "file"  — file by URI reference (recommended) or inline base64 (small files only)
->>>>>>> 8257d9b7 (type validation and prompt consideration for larger files and size limits)
-            {"kind": "file", "file": {"name": "report.json", "mimeType": "application/json", "uri": "s3://bucket/file.json"}}
-            {"kind": "file", "file": {"name": "report.csv", "mimeType": "text/csv", "bytes": "<base64>"}}
+                    kind: "file"  — file by URI reference (recommended) or inline base64 (small files only)
+        >>>>>>> 8257d9b7 (type validation and prompt consideration for larger files and size limits)
+                    {"kind": "file", "file": {"name": "report.json", "mimeType": "application/json", "uri": "s3://bucket/file.json"}}
+                    {"kind": "file", "file": {"name": "report.csv", "mimeType": "text/csv", "bytes": "<base64>"}}
 
-        kind="file"  — inline base64 (small files only)
-            {"kind": "file", "file": {"name": "data.csv", "mimeType": "text/csv", "bytes": "<base64>"}}
+                kind="file"  — inline base64 (small files only)
+                    {"kind": "file", "file": {"name": "data.csv", "mimeType": "text/csv", "bytes": "<base64>"}}
 
-        Parts can be combined. Example — structured data plus a text instruction:
-            message={"parts": [
-              {"kind": "data", "data": {"month": "2024-01"}},
-              {"kind": "text", "text": "Summarize spending by category"}
-            ]}
+                Parts can be combined. Example — structured data plus a text instruction:
+                    message={"parts": [
+                      {"kind": "data", "data": {"month": "2024-01"}},
+                      {"kind": "text", "text": "Summarize spending by category"}
+                    ]}
 
-        Default (text only):
-            message={"parts": [{"kind": "text", "text": "Run a full code review of this PR."}]}"""
+                Default (text only):
+                    message={"parts": [{"kind": "text", "text": "Run a full code review of this PR."}]}"""
         return await execute_agent_impl(agent_id, message, ctx)
 
     return [("execute_agent", execute_agent)]

--- a/registry/src/registry/mcpgw/tools/agent.py
+++ b/registry/src/registry/mcpgw/tools/agent.py
@@ -297,45 +297,45 @@ def get_tools() -> list[tuple[str, Callable]]:
         2. execute_agent(agent_id='…', message={parts: [...]})
         3. Return the agent's response to the user.
 
-        Choosing a part type:
-        - Check the agent's description from discover_agents first — if it includes
-          an Input Schema, use DataPart with fields matching that schema.
-        - If no Input Schema is present, use a single TextPart with a natural-language
-          instruction.
-        - Use FilePart to pass file content — URI reference for large files,
-          inline base64 only for small payloads.
+        Message parts (combinable, include as many as the agent needs based on the requirements and functions of the agent):
 
-        Message parts:
+        kind="text":
+            Natural language instruction or context. Use for task descriptions,
+            prompts, and any free-text input. Always valid.
 
-        kind="text"  — natural language instruction or context (most common)
-        kind="data"  — structured parameters matching the agent's Input Schema
-        kind="file"  — file by URI reference or inline base64
+        kind="data":
+            Structured JSON parameters. Use when your input is structured data such as:
+            named fields, key-value pairs, or objects, rather than a natural-language
+            description. If the agent's description (from discover_agents) explicitly
+            defines expected fields or a parameter schema, use those field names and
+            types exactly as described.
 
-        Examples by part type:
+        kind="file":
+            A file by URI reference (preferred for large content) or inline
+            base64 (small payloads only).
 
-        kind="text"  — natural language instruction
-            message={"parts": [{"kind": "text", "text": "Summarize the report."}]}
+        Parts combine freely in a single message. Lead with DataPart or FilePart when
+        relevant, and add a TextPart for any additional instruction or context.
 
-        kind="data"  — structured parameters matching the agent's Input Schema
-            message={"parts": [{"kind": "data", "data": {"month": "2024-01", "region": "us-east"}}]}
+        Examples:
 
-        kind="file"  — URI reference (preferred for large files)
-            message={"parts": [{"kind": "file", "file": {"name": "report.json", "mimeType": "application/json", "uri": "s3://bucket/file.json"}}]}
+        Text only (default):
+            message={"parts": [{"kind": "text", "text": "Summarize Q1 sales trends."}]}
 
-        kind="file"  — inline base64 (small files only)
+        Structured data with a text instruction:
+            message={"parts": [
+              {"kind": "data", "data": {"month": "2024-01", "region": "us-east"}},
+              {"kind": "text", "text": "Summarize spending by category."}
+            ]}
+
+        File by URI with a text instruction:
+            message={"parts": [
+              {"kind": "file", "file": {"name": "report.json", "mimeType": "application/json", "uri": "s3://bucket/report.json"}},
+              {"kind": "text", "text": "Analyze this report and highlight anomalies."}
+            ]}
+
+        File inline base64 (small files only):
             message={"parts": [{"kind": "file", "file": {"name": "data.csv", "mimeType": "text/csv", "bytes": "<base64>"}}]}
-
-        Combining parts — structured data plus a text instruction:
-            message={"parts": [
-              {"kind": "data", "data": {"month": "2024-01"}},
-              {"kind": "text", "text": "Summarize spending by category"}
-            ]}
-
-        Combining parts — file plus a text instruction:
-            message={"parts": [
-              {"kind": "file", "file": {"uri": "s3://bucket/report.pdf", "mimeType": "application/pdf"}},
-              {"kind": "text", "text": "Summarize the key findings from this report."}
-            ]}
 
         Targeting a specific skill — include the skill name in a TextPart:
             message={"parts": [{"kind": "text", "text": "Use the code-review skill to review this PR: <url>"}]}"""

--- a/registry/src/registry/mcpgw/tools/agent.py
+++ b/registry/src/registry/mcpgw/tools/agent.py
@@ -311,8 +311,8 @@ def get_tools() -> list[tuple[str, Callable]]:
         kind="data"  — structured parameters matching the agent's Input Schema
         kind="file"  — file by URI reference or inline base64
 
-        Example (text only):
-            message={"parts": [{"kind": "text", "text": "Run a full code review of this PR."}]}"""
+        Example:
+            message={"parts": [{"kind": "text", "text": "Run a full code review of this repo."}]}"""
         return await execute_agent_impl(agent_id, message, ctx)
 
     return [("execute_agent", execute_agent)]

--- a/registry/src/registry/mcpgw/tools/agent.py
+++ b/registry/src/registry/mcpgw/tools/agent.py
@@ -305,7 +305,15 @@ def get_tools() -> list[tuple[str, Callable]]:
         2. execute_agent(agent_id='…', message={parts: [...]})
         3. Return the agent's response to the user.
 
+<<<<<<< HEAD
         Message parts:
+=======
+        Message Format:
+        The `message` field accepts plain text (default) or a JSON-serialized payload
+        with typed parts. The agent's description from discover_agents will tell you
+        which format to use. The field is capped at 8192 characters — prefer URI file
+        parts over inline base64 for anything beyond a few hundred bytes.
+>>>>>>> 8257d9b7 (type validation and prompt consideration for larger files and size limits)
 
         kind="text"  — natural language instruction or context (most common)
             {"kind": "text", "text": "Summarize the attached data by category"}
@@ -313,8 +321,26 @@ def get_tools() -> list[tuple[str, Callable]]:
         kind="data"  — structured parameters matching the agent's input schema
             {"kind": "data", "data": {"month": "2024-01", "region": "us-east"}}
 
+<<<<<<< HEAD
         kind="file"  — file by URI reference (preferred for large content)
+=======
+            {
+              "messageId": "<uuid>",  (omit to auto-generate; required on the wire per A2A spec)
+              "parts": [...]          (required — one or more Part objects below)
+            }
+
+            Part types:
+
+            kind: "text"  — natural language instruction or context
+            {"kind": "text", "text": "Summarize the results"}
+
+            kind: "data"  — structured parameters matching the agent's input schema
+            {"kind": "data", "data": {"key": "value"}}
+
+            kind: "file"  — file by URI reference (recommended) or inline base64 (small files only)
+>>>>>>> 8257d9b7 (type validation and prompt consideration for larger files and size limits)
             {"kind": "file", "file": {"name": "report.json", "mimeType": "application/json", "uri": "s3://bucket/file.json"}}
+            {"kind": "file", "file": {"name": "report.csv", "mimeType": "text/csv", "bytes": "<base64>"}}
 
         kind="file"  — inline base64 (small files only)
             {"kind": "file", "file": {"name": "data.csv", "mimeType": "text/csv", "bytes": "<base64>"}}

--- a/registry/src/registry/mcpgw/tools/agent.py
+++ b/registry/src/registry/mcpgw/tools/agent.py
@@ -6,7 +6,7 @@ import uuid
 from collections.abc import Callable
 from typing import Annotated
 
-from a2a.types import Artifact, FileWithBytes, FileWithUri, Message, Task
+from a2a.types import Artifact, DataPart, FilePart, FileWithBytes, FileWithUri, Message, Part, Role, Task, TextPart
 from a2a.utils.artifact import get_artifact_text
 from a2a.utils.message import get_message_text
 from a2a.utils.parts import get_data_parts, get_file_parts
@@ -20,7 +20,7 @@ from mcp.types import (
     TextContent,
     TextResourceContents,
 )
-from pydantic import AnyUrl, Field
+from pydantic import AnyUrl, BaseModel, Field
 
 from registry_pkgs.models import ResourceType
 from registry_pkgs.models.a2a_agent import A2AAgent
@@ -30,6 +30,8 @@ from ...services.access_control_service import ACLService
 from ..core.types import McpAppContext
 
 logger = logging.getLogger(__name__)
+
+_AGENT_INVOKE_LOGGER = "execute_agent"
 
 
 def _file_to_resource(f: FileWithBytes | FileWithUri) -> EmbeddedResource | None:
@@ -165,9 +167,33 @@ async def _resolve_active_agent(agent_id: str) -> tuple[A2AAgent | None, CallToo
     return agent, None
 
 
+AgentPart = Annotated[TextPart | FilePart | DataPart, Field(discriminator="kind")]
+
+
+class AgentMessageInput(BaseModel):
+    """Content to send to the A2A agent.
+
+    Each element of `parts` is one of:
+      - TextPart  (kind="text")  — natural language instruction or context
+      - DataPart  (kind="data")  — structured parameters as a JSON object
+      - FilePart  (kind="file")  — a file by URI reference or inline base64
+
+    Parts can be combined in a single message.
+    """
+
+    parts: list[AgentPart] = Field(
+        min_length=1,
+        description=(
+            "One or more content parts that form the message body. "
+            "Use TextPart for plain instructions, DataPart for structured input, "
+            "FilePart for file references or inline content."
+        ),
+    )
+
+
 async def execute_agent_impl(
     agent_id: str,
-    message: str,
+    message: AgentMessageInput,
     ctx: Context[ServerSession, McpAppContext],
 ) -> CallToolResult:
     """
@@ -203,11 +229,24 @@ async def execute_agent_impl(
         return _error_result(str(exc))
 
     # 5. Invoke
+    # AgentPart is TextPart | FilePart | DataPart — bare concrete types from a2a-sdk.
+    # a2a.types.Part is RootModel[...] — the SDK wrapper call_a2a expects.
+    a2a_message = Message(
+        kind="message",
+        role=Role.user,
+        message_id=uuid.uuid4().hex,
+        parts=[Part(root=p) for p in message.parts],
+    )
+
+    async def on_chunk(chunk: str) -> None:
+        await ctx.log("info", chunk, logger_name=_AGENT_INVOKE_LOGGER)
+
     logger.info("execute_agent: invoking agent_id=%s path=%s", agent_id, agent.path)
     result = await call_a2a(
         agent,
-        message,
+        a2a_message,
         jwt_config=lifespan.jwt_signing_config,
+        on_chunk=on_chunk,
         httpx_client=lifespan.a2a_httpx_client,
     )
     if not result.success:
@@ -238,13 +277,13 @@ def get_tools() -> list[tuple[str, Callable]]:
             ),
         ],
         message: Annotated[
-            str,
+            AgentMessageInput,
             Field(
-                min_length=1,
-                max_length=8192,
                 description=(
-                    "The task or question to send to the agent. "
-                    "Be explicit and complete — the agent has no prior conversation context."
+                    "The message to send to the agent. "
+                    "Must contain at least one part. "
+                    "Use TextPart for plain task descriptions (most common). "
+                    "Use DataPart to pass structured parameters, FilePart to pass files."
                 ),
             ),
         ],
@@ -254,15 +293,40 @@ def get_tools() -> list[tuple[str, Callable]]:
         Use this after discover_agents to delegate a complex task to the selected agent.
         The agent runs autonomously and returns its final result.
 
+        Streaming: partial responses are sent as MCP log notifications during execution.
+
         Error handling:
         - Invalid or unknown agent_id → isError=True with a retry hint; call discover_agents again.
         - Agent invocation failure → isError=True with the error message; consider retrying
           or trying a different agent.
 
         Workflow:
-          1. discover_agents(query='…') → pick agent_id from results
-          2. execute_agent(agent_id='…', message='<full task description>')
-          3. Return the agent's response to the user."""
+        1. discover_agents(query='…') → pick agent_id from results
+        2. execute_agent(agent_id='…', message={parts: [...]})
+        3. Return the agent's response to the user.
+
+        Message parts:
+
+        kind="text"  — natural language instruction or context (most common)
+            {"kind": "text", "text": "Summarize the attached data by category"}
+
+        kind="data"  — structured parameters matching the agent's input schema
+            {"kind": "data", "data": {"month": "2024-01", "region": "us-east"}}
+
+        kind="file"  — file by URI reference (preferred for large content)
+            {"kind": "file", "file": {"name": "report.json", "mimeType": "application/json", "uri": "s3://bucket/file.json"}}
+
+        kind="file"  — inline base64 (small files only)
+            {"kind": "file", "file": {"name": "data.csv", "mimeType": "text/csv", "bytes": "<base64>"}}
+
+        Parts can be combined. Example — structured data plus a text instruction:
+            message={"parts": [
+              {"kind": "data", "data": {"month": "2024-01"}},
+              {"kind": "text", "text": "Summarize spending by category"}
+            ]}
+
+        Default (text only):
+            message={"parts": [{"kind": "text", "text": "Run a full code review of this PR."}]}"""
         return await execute_agent_impl(agent_id, message, ctx)
 
     return [("execute_agent", execute_agent)]

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -150,8 +150,9 @@ def get_tools() -> list[tuple[str, Callable]]:
         - skill_name (entity_type='skill'): the specific skill to target
 
         Execution:
-        - call execute_agent(agent_id=<agent_id>, message=<full task description>).
-        - If entity_type='skill', include the skill_name in the message to target that capability.
+        - call execute_agent(agent_id=<agent_id>, message=<payload>) — see execute_agent's
+          inputSchema for the message structure (parts array with typed content).
+        - If entity_type='skill', target the specific skill via the message payload.
 
         Evaluating results: read each result's description to confirm the agent's
         domain matches the user's task — do not rely on the score alone. If the top

--- a/registry/tests/unit/mcpgw/test_agent.py
+++ b/registry/tests/unit/mcpgw/test_agent.py
@@ -20,7 +20,7 @@ from beanie import PydanticObjectId
 from mcp.types import BlobResourceContents, EmbeddedResource, TextContent, TextResourceContents
 
 from registry.mcpgw.tools import agent
-from registry.mcpgw.tools.agent import _convert_response, execute_agent_impl
+from registry.mcpgw.tools.agent import AgentMessageInput, _convert_response, execute_agent_impl
 from registry_pkgs.workflows.a2a_client import A2ACallResult
 
 
@@ -101,10 +101,14 @@ def _result_with_task(*artifacts: Artifact) -> A2ACallResult:
     return A2ACallResult(task=_completed_task(*artifacts), success=True)
 
 
+def _msg(text: str) -> AgentMessageInput:
+    return AgentMessageInput(parts=[TextPart(kind="text", text=text)])
+
+
 @pytest.mark.asyncio
 async def test_execute_agent_invalid_id_returns_error():
     ctx = _make_ctx()
-    result = await execute_agent_impl("not-a-valid-objectid", "hello", ctx)
+    result = await execute_agent_impl("not-a-valid-objectid", _msg("hello"), ctx)
 
     assert result.isError is True
     assert len(result.content) == 1
@@ -123,7 +127,7 @@ async def test_execute_agent_not_found_returns_error():
         mock_model.status = MagicMock()
         mock_model.find_one = AsyncMock(return_value=None)
 
-        result = await execute_agent_impl(valid_id, "hello", ctx)
+        result = await execute_agent_impl(valid_id, _msg("hello"), ctx)
 
     assert result.isError is True
     text = result.content[0].text
@@ -145,7 +149,7 @@ async def test_execute_agent_happy_path_returns_text():
         mock_model.find_one = AsyncMock(return_value=agent)
         mock_call.return_value = _result_with_message("Agent response text")
 
-        result = await execute_agent_impl(valid_id, "Do something", ctx)
+        result = await execute_agent_impl(valid_id, _msg("Do something"), ctx)
 
     assert result.isError is not True
     assert any(isinstance(c, TextContent) and "Agent response text" in c.text for c in result.content)
@@ -166,7 +170,7 @@ async def test_execute_agent_denied_when_agent_not_in_user_acl():
     ):
         mock_model.id = MagicMock()
         mock_model.find_one = AsyncMock(return_value=agent)
-        result = await execute_agent_impl(valid_id, "Do something", ctx)
+        result = await execute_agent_impl(valid_id, _msg("Do something"), ctx)
 
     assert result.isError is True
     assert "Access denied" in result.content[0].text
@@ -186,7 +190,7 @@ async def test_execute_agent_rejects_missing_user_context():
     ):
         mock_model.id = MagicMock()
         mock_model.find_one = AsyncMock(return_value=agent)
-        result = await execute_agent_impl(valid_id, "Do something", ctx)
+        result = await execute_agent_impl(valid_id, _msg("Do something"), ctx)
 
     assert result.isError is True
     assert "Authentication required" in result.content[0].text
@@ -216,7 +220,7 @@ async def test_execute_agent_forwards_a2a_httpx_client_to_call_a2a():
         ):
             mock_model.id = MagicMock()
             mock_model.find_one = AsyncMock(return_value=agent)
-            await execute_agent_impl(valid_id, "test", ctx)
+            await execute_agent_impl(valid_id, _msg("test"), ctx)
 
         assert captured.get("httpx_client") is shared
     finally:
@@ -237,7 +241,7 @@ async def test_execute_agent_a2a_failure_returns_error():
         mock_model.find_one = AsyncMock(return_value=agent)
         mock_call.return_value = A2ACallResult(success=False, error="connection refused")
 
-        result = await execute_agent_impl(valid_id, "Do something", ctx)
+        result = await execute_agent_impl(valid_id, _msg("Do something"), ctx)
 
     assert result.isError is True
     assert "connection refused" in result.content[0].text
@@ -431,7 +435,54 @@ async def test_execute_agent_iam_unsupported_returns_error():
         mock_model.status = MagicMock()
         mock_model.find_one = AsyncMock(return_value=agent)
 
-        result = await execute_agent_impl(valid_id, "hello", ctx)
+        result = await execute_agent_impl(valid_id, _msg("hello"), ctx)
 
     assert result.isError is True
     assert "IAM" in result.content[0].text
+
+
+# ── AgentMessageInput validation ─────────────────────────────────────────────
+
+
+def test_agent_message_input_single_text_part():
+    msg = AgentMessageInput(parts=[TextPart(kind="text", text="hello")])
+    assert len(msg.parts) == 1
+    assert msg.parts[0].kind == "text"
+    assert msg.parts[0].text == "hello"
+
+
+def test_agent_message_input_multi_part_data_and_text():
+    msg = AgentMessageInput(
+        parts=[
+            DataPart(kind="data", data={"month": "2024-01"}),
+            TextPart(kind="text", text="Summarize spending by category"),
+        ]
+    )
+    assert len(msg.parts) == 2
+    assert msg.parts[0].kind == "data"
+    assert msg.parts[1].kind == "text"
+
+
+def test_agent_message_input_file_uri_part():
+    from a2a.types import FileWithUri
+
+    msg = AgentMessageInput(
+        parts=[FilePart(kind="file", file=FileWithUri(uri="s3://bucket/report.json", mimeType="application/json"))]
+    )
+    assert len(msg.parts) == 1
+    assert msg.parts[0].kind == "file"
+    assert "bucket" in str(msg.parts[0].file.uri)
+
+
+def test_agent_message_input_empty_parts_rejected():
+    from pydantic import ValidationError as PydanticValidationError
+
+    with pytest.raises(PydanticValidationError):
+        AgentMessageInput(parts=[])
+
+
+def test_agent_message_input_from_dict_text_part():
+    msg = AgentMessageInput.model_validate({"parts": [{"kind": "text", "text": "run the analysis"}]})
+    assert len(msg.parts) == 1
+    assert msg.parts[0].kind == "text"
+    assert msg.parts[0].text == "run the analysis"

--- a/registry/tests/unit/mcpgw/test_agent.py
+++ b/registry/tests/unit/mcpgw/test_agent.py
@@ -464,8 +464,6 @@ def test_agent_message_input_multi_part_data_and_text():
 
 
 def test_agent_message_input_file_uri_part():
-    from a2a.types import FileWithUri
-
     msg = AgentMessageInput(
         parts=[FilePart(kind="file", file=FileWithUri(uri="s3://bucket/report.json", mimeType="application/json"))]
     )
@@ -479,6 +477,13 @@ def test_agent_message_input_empty_parts_rejected():
 
     with pytest.raises(PydanticValidationError):
         AgentMessageInput(parts=[])
+
+
+def test_agent_message_input_invalid_kind_rejected():
+    from pydantic import ValidationError as PydanticValidationError
+
+    with pytest.raises(PydanticValidationError):
+        AgentMessageInput.model_validate({"parts": [{"kind": "unknown", "text": "x"}]})
 
 
 def test_agent_message_input_from_dict_text_part():


### PR DESCRIPTION
This pull request introduces a new structured input model for sending messages to A2A agents, replacing the previous plain string input with a validated, multi-part message format. The changes affect both the implementation and the API schema, enabling richer interactions (such as sending structured data and files) and improving input validation. Test coverage is expanded to ensure correct behavior and validation of the new input type.

**API and Input Model Improvements:**

* Introduced `AgentMessageInput`, a Pydantic model that allows messages to be composed of multiple typed parts (`TextPart`, `DataPart`, `FilePart`). This replaces the previous string-based message input for agent execution. The model enforces at least one part per message and provides clear schema for API consumers. [[1]](diffhunk://#diff-f597bc9d24017fe9e299c7e5e743ae64a90c340bebeb5185585aafc7bd1c6c95R168-R194) [[2]](diffhunk://#diff-f597bc9d24017fe9e299c7e5e743ae64a90c340bebeb5185585aafc7bd1c6c95L241-R280)
* Updated the `execute_agent_impl` and `execute_agent` functions to accept and handle `AgentMessageInput` instead of a plain string, constructing the appropriate A2A `Message` object for downstream calls. [[1]](diffhunk://#diff-f597bc9d24017fe9e299c7e5e743ae64a90c340bebeb5185585aafc7bd1c6c95R230-R242) [[2]](diffhunk://#diff-f597bc9d24017fe9e299c7e5e743ae64a90c340bebeb5185585aafc7bd1c6c95L241-R280)
* Enhanced API documentation and docstrings to guide users on how to construct messages using the new parts-based format, including usage examples and recommendations based on agent schemas. [[1]](diffhunk://#diff-f597bc9d24017fe9e299c7e5e743ae64a90c340bebeb5185585aafc7bd1c6c95L264-R315) [[2]](diffhunk://#diff-655be6ed748e4cff20c9dbf9cff86299d69ea6118744023751dc488e2ca90813L153-R155)

**A2A Client and Message Handling:**

* Modified the A2A client (`call_a2a` and related functions) to accept either a string or a pre-parsed `Message` object, ensuring that pre-built messages are passed through directly without unnecessary re-wrapping. [[1]](diffhunk://#diff-edfdabf17ab9c2c762c601b760948e958dfc388a86a18807e886906c80e2b368L327-R333) [[2]](diffhunk://#diff-edfdabf17ab9c2c762c601b760948e958dfc388a86a18807e886906c80e2b368L365-R366) [[3]](diffhunk://#diff-edfdabf17ab9c2c762c601b760948e958dfc388a86a18807e886906c80e2b368L377-R378) [[4]](diffhunk://#diff-edfdabf17ab9c2c762c601b760948e958dfc388a86a18807e886906c80e2b368L401-R402)
* Added a new test to verify that `call_a2a` correctly accepts and processes pre-parsed `Message` objects.

**Testing and Validation:**

* Updated all relevant tests to use the new `AgentMessageInput` format, ensuring compatibility and correctness of the new API. [[1]](diffhunk://#diff-71d066f2d1e4e61dd3035c20c4a18a8755faeb17e21408f3edfda2dc2f1ac21dR104-R111) [[2]](diffhunk://#diff-71d066f2d1e4e61dd3035c20c4a18a8755faeb17e21408f3edfda2dc2f1ac21dL126-R130) [[3]](diffhunk://#diff-71d066f2d1e4e61dd3035c20c4a18a8755faeb17e21408f3edfda2dc2f1ac21dL148-R152) [[4]](diffhunk://#diff-71d066f2d1e4e61dd3035c20c4a18a8755faeb17e21408f3edfda2dc2f1ac21dL169-R173) [[5]](diffhunk://#diff-71d066f2d1e4e61dd3035c20c4a18a8755faeb17e21408f3edfda2dc2f1ac21dL189-R193) [[6]](diffhunk://#diff-71d066f2d1e4e61dd3035c20c4a18a8755faeb17e21408f3edfda2dc2f1ac21dL219-R223) [[7]](diffhunk://#diff-71d066f2d1e4e61dd3035c20c4a18a8755faeb17e21408f3edfda2dc2f1ac21dL240-R244) [[8]](diffhunk://#diff-71d066f2d1e4e61dd3035c20c4a18a8755faeb17e21408f3edfda2dc2f1ac21dL434-R493)
* Added comprehensive unit tests for `AgentMessageInput` to validate correct construction, multi-part handling, and enforcement of required fields and types.

These changes provide a more flexible, extensible, and robust way to interact with A2A agents, supporting a broader range of use cases and improving input validation for downstream processing.