### PR TITLE
fix: serialize WorkflowCanvas before MongoDB update to prevent BSON error

### DIFF
--- a/registry/src/registry/services/workflow_service.py
+++ b/registry/src/registry/services/workflow_service.py
@@ -257,7 +257,7 @@ class WorkflowService:
                 update_fields["description"] = data.description
 
             if data.canvas is not None:
-                update_fields["canvas"] = self._convert_api_canvas_to_model(data.canvas)
+                update_fields["canvas"] = self._convert_api_canvas_to_model(data.canvas).model_dump(mode="json")
 
             if data.nodes is not None:
                 update_fields["nodes"] = [


### PR DESCRIPTION
fix: serialize WorkflowCanvas before MongoDB update to prevent BSON error