### PR TITLE
Hotfix: MCP resource fetching, toggle MCP status and request timeouts

### DIFF
--- a/frontend/src/components/FederationCard/index.tsx
+++ b/frontend/src/components/FederationCard/index.tsx
@@ -32,7 +32,7 @@ const FederationCard: React.FC<FederationCardProps> = ({ federation }) => {
       if (!isSyncing) {
         setIsSyncing(true);
         try {
-          await SERVICES.FEDERATION.syncFederation(federation.id, undefined, { timeout: 20000 });
+          await SERVICES.FEDERATION.syncFederation(federation.id, undefined, { timeout: 120000 });
           showToast?.('Sync started successfully', 'success');
           // Wait momentarily for status updates
           setTimeout(() => {

--- a/frontend/src/components/FederationCard/index.tsx
+++ b/frontend/src/components/FederationCard/index.tsx
@@ -32,7 +32,7 @@ const FederationCard: React.FC<FederationCardProps> = ({ federation }) => {
       if (!isSyncing) {
         setIsSyncing(true);
         try {
-          await SERVICES.FEDERATION.syncFederation(federation.id);
+          await SERVICES.FEDERATION.syncFederation(federation.id, undefined, { timeout: 20000 });
           showToast?.('Sync started successfully', 'success');
           // Wait momentarily for status updates
           setTimeout(() => {

--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -162,7 +162,7 @@ const ServerCard: React.FC<ServerCardProps> = ({ server }) => {
   const handleToggleServer = async (id: string, enabled: boolean) => {
     try {
       setLoading(true);
-      await SERVICES.SERVER.toggleServerStatus(id, { enabled });
+      await SERVICES.SERVER.toggleServerStatus(id, { enabled }, { timeout: 60000 });
       handleServerUpdate(id, { enabled });
       showToast(`Server ${enabled ? 'enabled' : 'disabled'} successfully!`, 'success');
     } catch (error: any) {

--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -128,12 +128,12 @@ const ServerCard: React.FC<ServerCardProps> = ({ server }) => {
     }
   }, [server.id, loadingTools, showToast]);
 
-  const handleRefreshHealth = useCallback(async () => {
+  const handleRefresh = useCallback(async () => {
     if (loadingRefresh) return;
 
     setLoadingRefresh(true);
     try {
-      const result = await SERVICES.SERVER.refreshServerHealth(server.id);
+      const result = await SERVICES.SERVER.refreshServer(server.id);
 
       if (handleServerUpdate && result) {
         const updates: Partial<ServerInfo> = {
@@ -162,7 +162,6 @@ const ServerCard: React.FC<ServerCardProps> = ({ server }) => {
   const handleToggleServer = async (id: string, enabled: boolean) => {
     try {
       setLoading(true);
-      await SERVICES.SERVER.refreshServerHealth(id);
       await SERVICES.SERVER.toggleServerStatus(id, { enabled });
       handleServerUpdate(id, { enabled });
       showToast(`Server ${enabled ? 'enabled' : 'disabled'} successfully!`, 'success');
@@ -391,7 +390,7 @@ const ServerCard: React.FC<ServerCardProps> = ({ server }) => {
               <IconButton
                 ariaLabel='Refresh health status'
                 tooltip={canEdit ? 'Refresh' : 'No edit permission'}
-                onClick={handleRefreshHealth}
+                onClick={handleRefresh}
                 disabled={!canEdit || loadingRefresh}
                 size='card'
                 className='text-[var(--jarvis-icon)] transition-all duration-200 hover:bg-[var(--jarvis-primary-soft)] hover:text-[var(--jarvis-icon-hover)]'

--- a/frontend/src/contexts/ServerContext.tsx
+++ b/frontend/src/contexts/ServerContext.tsx
@@ -397,7 +397,7 @@ export const ServerProvider: React.FC<ServerProviderProps> = ({ children }) => {
             clearTimeout(timeoutRef.current[serverId]);
             delete timeoutRef.current[serverId];
 
-            const result = await SERVICES.SERVER.refreshServerHealth(serverId);
+            const result = await SERVICES.SERVER.refreshServer(serverId);
             handleServerUpdate(serverId, {
               lastCheckedTime: result.lastConnected,
               numTools: result.numTools,

--- a/frontend/src/pages/FederationRegistryOrEdit/index.tsx
+++ b/frontend/src/pages/FederationRegistryOrEdit/index.tsx
@@ -173,7 +173,7 @@ const FederationRegistryOrEdit: React.FC = () => {
       const result = await SERVICES.FEDERATION.syncFederation(id, {
         dryRun: true,
         providerConfig,
-      });
+      }, { timeout: 20000 });
 
       const discoveredMcp = result?.summary?.discoveredMcpServers ?? 0;
       const discoveredAgents = result?.summary?.discoveredAgents ?? 0;
@@ -196,7 +196,7 @@ const FederationRegistryOrEdit: React.FC = () => {
     if (!id) return;
     setIsSyncing(true);
     try {
-      await SERVICES.FEDERATION.syncFederation(id);
+      await SERVICES.FEDERATION.syncFederation(id, undefined, { timeout: 20000 });
       showToast('Sync started successfully', 'success');
     } catch (error: any) {
       showToast(error?.detail?.message || 'Failed to start sync', 'error');

--- a/frontend/src/pages/FederationRegistryOrEdit/index.tsx
+++ b/frontend/src/pages/FederationRegistryOrEdit/index.tsx
@@ -173,7 +173,7 @@ const FederationRegistryOrEdit: React.FC = () => {
       const result = await SERVICES.FEDERATION.syncFederation(id, {
         dryRun: true,
         providerConfig,
-      }, { timeout: 20000 });
+      }, { timeout: 120000 });
 
       const discoveredMcp = result?.summary?.discoveredMcpServers ?? 0;
       const discoveredAgents = result?.summary?.discoveredAgents ?? 0;
@@ -196,7 +196,7 @@ const FederationRegistryOrEdit: React.FC = () => {
     if (!id) return;
     setIsSyncing(true);
     try {
-      await SERVICES.FEDERATION.syncFederation(id, undefined, { timeout: 20000 });
+      await SERVICES.FEDERATION.syncFederation(id, undefined, { timeout: 120000 });
       showToast('Sync started successfully', 'success');
     } catch (error: any) {
       showToast(error?.detail?.message || 'Failed to start sync', 'error');

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -33,7 +33,7 @@ const API = {
   deleteServer: (id: string) => `${SERVER_BASE_URL}/${id}`,
   toggleServerStatus: (id: string) => `${SERVER_BASE_URL}/${id}/toggle`,
   getServerTools: (id: string) => `${SERVER_BASE_URL}/${id}/tools`,
-  refreshServerHealth: (id: string) => `${SERVER_BASE_URL}/${id}/refresh`,
+  refreshServer: (id: string) => `${SERVER_BASE_URL}/${id}/refresh`,
 
   // agent
   getAgentsList: `${AGENT_BASE_URL}`,

--- a/frontend/src/services/federation/index.ts
+++ b/frontend/src/services/federation/index.ts
@@ -1,3 +1,5 @@
+import type { AxiosRequestConfig } from 'axios';
+
 import API from '@/services/api';
 import Request from '@/services/request';
 import type * as TYPE from './type';
@@ -48,7 +50,9 @@ const deleteFederation: (federationId: string) => Promise<void> = async federati
 const syncFederation: (
   federationId: string,
   data?: { force?: boolean; reason?: string; dryRun?: boolean; providerConfig?: Record<string, unknown> },
-) => Promise<any> = async (federationId, data) => await Request.post(API.syncFederation(federationId), data);
+  config?: AxiosRequestConfig,
+) => Promise<any> = async (federationId, data, config) =>
+  await Request.post(API.syncFederation(federationId), data, config);
 
 const FEDERATION = {
   getFederations,

--- a/frontend/src/services/server/index.ts
+++ b/frontend/src/services/server/index.ts
@@ -35,7 +35,7 @@ const toggleServerStatus: (
 const getServerTools: (id: string) => Promise<TYPE.GetServerToolsResponse> = async id =>
   await Request.get(API.getServerTools(id));
 
-const refreshServer: any = async (id: string) => await Request.post(API.refreshServer(id));
+const refreshServer: (id: string) => Promise<TYPE.GetServersDetailResponse> = async id => await Request.post(API.refreshServer(id));
 
 export default {
   getVersion,

--- a/frontend/src/services/server/index.ts
+++ b/frontend/src/services/server/index.ts
@@ -32,7 +32,7 @@ const toggleServerStatus: (id: string, data: { enabled: boolean }) => Promise<vo
 const getServerTools: (id: string) => Promise<TYPE.GetServerToolsResponse> = async id =>
   await Request.get(API.getServerTools(id));
 
-const refreshServerHealth: any = async (id: string) => await Request.post(API.refreshServerHealth(id));
+const refreshServer: any = async (id: string) => await Request.post(API.refreshServer(id));
 
 export default {
   getVersion,
@@ -44,5 +44,5 @@ export default {
   deleteServer,
   toggleServerStatus,
   getServerTools,
-  refreshServerHealth,
+  refreshServer,
 };

--- a/frontend/src/services/server/index.ts
+++ b/frontend/src/services/server/index.ts
@@ -26,8 +26,11 @@ const updateServer: (id: string, data: Partial<TYPE.Server>) => Promise<TYPE.Ser
 
 const deleteServer: (id: string) => Promise<void> = async id => await Request.delete(API.deleteServer(id));
 
-const toggleServerStatus: (id: string, data: { enabled: boolean }) => Promise<void> = async (id, data) =>
-  await Request.post(API.toggleServerStatus(id), data);
+const toggleServerStatus: (
+  id: string,
+  data: { enabled: boolean },
+  config?: AxiosRequestConfig,
+) => Promise<void> = async (id, data, config) => await Request.post(API.toggleServerStatus(id), data, config);
 
 const getServerTools: (id: string) => Promise<TYPE.GetServerToolsResponse> = async id =>
   await Request.get(API.getServerTools(id));

--- a/registry/src/registry/core/mcp_client.py
+++ b/registry/src/registry/core/mcp_client.py
@@ -1186,7 +1186,7 @@ def _extract_resource_details(resources_response) -> list[dict]:
                 }
             )
 
-    resource_uris = [r["uri"] for r in resource_details_list]
+    resource_uris = [str(r["uri"]) for r in resource_details_list]
     logger.info(
         f"Successfully retrieved details for {len(resource_details_list)} resources: {', '.join(resource_uris)}"
     )


### PR DESCRIPTION
We found several problems when debugging the GitNexusMcp server in PROD.

- Fetching downstream MCP resources raises an exception due to a `str` vs `AnyUrl` type mismatch. Previously it was swallowed with a WARNING level message only.
- Toggling MCP status previously makes two backend calls: `/refresh` and `/toggle`. The first is redundant. Removed now.
- Toggling MCP status and federation sync are just operations that take long. Raise timeout to 60s and 120s respectively (from the global default 20s set via `axios`).

---

We found another related issue that the PROD Weaviate pod had been missing two `RAG_***` related env vars for a while, starting from which we were never able to perform any write operations to Weaviate. That's why some Weaviate data in PROD are stale. This (missed env vars) has been fixed by @daochidq .