### PR TITLE
feat(registry-pkgs): introduce managed-agent vs crud-session token cl…

### DIFF
--- a/auth-server/src/auth_server/routes/oauth_flow.py
+++ b/auth-server/src/auth_server/routes/oauth_flow.py
@@ -18,7 +18,8 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from pydantic import BaseModel
 
-from registry_pkgs.core.jwt_utils import build_jwt_payload, decode_jwt_unverified, encode_jwt, get_token_kid
+from registry_pkgs.core.jwt_tokens import mint_managed_agent_token
+from registry_pkgs.core.jwt_utils import decode_jwt_unverified, get_token_kid
 from registry_pkgs.core.scopes import map_groups_to_scopes
 
 from ..core.config import settings
@@ -51,10 +52,10 @@ router = APIRouter()
 
 
 # JWT / signer configuration (use settings)
-PRIVATE_KEY = settings.jwt_private_key
 JWT_ISSUER = settings.jwt_issuer
-JWT_AUDIENCE = settings.jwt_audience
 JWT_SELF_SIGNED_KID = settings.jwt_self_signed_kid
+# All access tokens issued by /oauth2/token (+ device flow) are managed-agent (proxy) tokens.
+JWT_TOKEN_CONFIG = settings.jwt_token_config
 
 # Refresh token expiry (14 days in seconds)
 REFRESH_TOKEN_EXPIRY_SECONDS = 1209600
@@ -295,21 +296,19 @@ async def approve_device(request: DeviceApprovalRequest):
     if device_data["status"] == "approved":
         return {"status": "already_approved", "message": "Device already approved"}
 
-    # Generate token
-    token_payload = build_jwt_payload(
+    # Generate token (managed-agent / proxy class)
+    access_token = mint_managed_agent_token(
+        JWT_TOKEN_CONFIG,
         subject="device_user",
-        issuer=JWT_ISSUER,
-        audience=JWT_AUDIENCE,
+        client_id=device_data["client_id"],
         expires_in_seconds=3600,
         iat=current_time,
         extra_claims={
-            "client_id": device_data["client_id"],
             "scope": device_data["scope"],
             "token_use": "access",
             "auth_provider": settings.auth_provider,
         },
     )
-    access_token = encode_jwt(token_payload, PRIVATE_KEY, kid=JWT_SELF_SIGNED_KID)
     device_data["status"] = "approved"
     device_data["token"] = access_token
     device_data["approved_at"] = current_time
@@ -471,31 +470,30 @@ async def device_token(request: Request, user_service: UserService = Depends(get
         # Resolve user_id from MongoDB
         user_id = await user_service.resolve_user_id(user_info)
 
-        token_payload = build_jwt_payload(
+        scope_claim = " ".join(resolved_scopes) if isinstance(resolved_scopes, list) else resolved_scopes
+        access_token = mint_managed_agent_token(
+            JWT_TOKEN_CONFIG,
             subject=user_info["username"],
-            issuer=JWT_ISSUER,
-            audience=JWT_AUDIENCE,
+            client_id=client_id,
             expires_in_seconds=3600,
             iat=current_time,
             extra_claims={
                 "name": user_info.get("name"),
                 "idp_id": user_info.get("idp_id"),
                 "user_id": user_id,
-                "client_id": client_id,
-                "scope": " ".join(resolved_scopes) if isinstance(resolved_scopes, list) else resolved_scopes,
+                "scope": scope_claim,
                 "groups": user_info.get("groups", []),
                 "token_use": "access",
                 "auth_provider": settings.auth_provider,
             },
         )
-        access_token = encode_jwt(token_payload, PRIVATE_KEY, kid=JWT_SELF_SIGNED_KID)
 
         rt = secrets.token_urlsafe(32)
         refresh_expires_at = current_time + REFRESH_TOKEN_EXPIRY_SECONDS
         refresh_tokens_storage[rt] = {
             "client_id": client_id,
             "user_info": user_info,
-            "scope": token_payload["scope"],
+            "scope": scope_claim,
             "expires_at": refresh_expires_at,
         }
 
@@ -505,7 +503,7 @@ async def device_token(request: Request, user_service: UserService = Depends(get
             access_token=access_token,
             token_type="Bearer",
             expires_in=3600,
-            scope=token_payload["scope"],
+            scope=scope_claim,
             refresh_token=rt,
         )
 
@@ -549,23 +547,20 @@ async def device_token(request: Request, user_service: UserService = Depends(get
         # Resolve user_id from MongoDB
         user_id = await user_service.resolve_user_id(user_info)
 
-        token_payload = build_jwt_payload(
+        access_token = mint_managed_agent_token(
+            JWT_TOKEN_CONFIG,
             subject=user_info["username"],
-            issuer=JWT_ISSUER,
-            audience=JWT_AUDIENCE,
+            client_id=client_id,
             expires_in_seconds=3600,
             iat=now,
             extra_claims={
                 "user_id": user_id,
-                "client_id": client_id,
                 "scope": rt_data.get("scope", ""),
                 "groups": user_info.get("groups", []),
                 "token_use": "access",
                 "auth_provider": settings.auth_provider,
             },
         )
-
-        access_token = encode_jwt(token_payload, PRIVATE_KEY, kid=JWT_SELF_SIGNED_KID)
 
         # Atomically remove old refresh token to prevent reuse and handle concurrent requests
         # IMPORTANT: popping of the old token must be BEFORE storing a new token.

--- a/auth-server/src/auth_server/server.py
+++ b/auth-server/src/auth_server/server.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 
 # Configuration for token generation (from settings)
 JWT_ISSUER = settings.jwt_issuer
-JWT_AUDIENCE = settings.jwt_audience
 JWT_SELF_SIGNED_KID = settings.jwt_self_signed_kid
 MAX_TOKEN_LIFETIME_HOURS = settings.max_token_lifetime_hours
 DEFAULT_TOKEN_LIFETIME_HOURS = settings.default_token_lifetime_hours

--- a/auth-server/src/auth_server/services/cognito_validator_service.py
+++ b/auth-server/src/auth_server/services/cognito_validator_service.py
@@ -8,10 +8,10 @@ import boto3
 import httpx
 from botocore.exceptions import ClientError
 
+from registry_pkgs.core.jwt_tokens import verify_managed_agent_token
 from registry_pkgs.core.jwt_utils import (
     ExpiredSignatureError,
     InvalidTokenError,
-    decode_jwt,
     decode_jwt_unverified,
     decode_jwt_with_jwk,
     get_token_unverified_header,
@@ -147,12 +147,7 @@ class SimplifiedCognitoValidator:
 
     def validate_self_signed_token(self, access_token: str) -> dict:
         try:
-            claims = decode_jwt(
-                access_token,
-                settings.jwt_public_key,
-                issuer=settings.jwt_issuer,
-                audience=settings.jwt_audience,
-            )
+            claims = verify_managed_agent_token(settings.jwt_token_config, access_token)
 
             token_use = claims.get("token_use")
             if token_use != "access":

--- a/auth-server/tests/integration/test_oauth_callback_token_flow.py
+++ b/auth-server/tests/integration/test_oauth_callback_token_flow.py
@@ -430,6 +430,7 @@ class TestOAuth2TokenEndpoint:
             "expires_at": current_time + 600,
             "used": False,
             "redirect_uri": "http://localhost/callback",
+            "resolved_scope": ["servers-read", "agents-read"],
             "resource": None,
             "created_at": current_time,
         }
@@ -442,8 +443,8 @@ class TestOAuth2TokenEndpoint:
         }
 
         # Exchange code for token
-        with patch("auth_server.routes.oauth_flow.encode_jwt") as mock_jwt_encode:
-            mock_jwt_encode.return_value = "mock-jwt-token-with-user-id"
+        with patch("auth_server.routes.oauth_flow.mint_managed_agent_token") as mock_mint_token:
+            mock_mint_token.return_value = "mock-jwt-token-with-user-id"
 
             app.dependency_overrides = {}
 
@@ -462,12 +463,15 @@ class TestOAuth2TokenEndpoint:
             assert "expires_in" in token_data
             assert "refresh_token" in token_data
 
-            # Verify JWT was encoded with user_id
-            call_args = mock_jwt_encode.call_args[0]
-            token_payload = call_args[0]
-            assert token_payload["user_id"] == "507f1f77bcf86cd799439011"
-            assert token_payload["sub"] == "testuser"
-            assert token_payload["groups"] == ["user-group"]
+            # Verify managed-agent token was minted with resolved user identity
+            assert mock_mint_token.call_args.kwargs["subject"] == "testuser"
+            assert mock_mint_token.call_args.kwargs["client_id"] == "test-client"
+            token_claims = mock_mint_token.call_args.kwargs["extra_claims"]
+            assert token_claims["user_id"] == "507f1f77bcf86cd799439011"
+            assert token_claims["groups"] == ["user-group"]
+            assert token_claims["scope"] == "servers-read agents-read"
+            assert token_claims["token_use"] == "access"
+            assert token_claims["auth_provider"] is not None
 
             # Code should be deleted after successful exchange
             assert auth_code not in authorization_codes_storage
@@ -509,8 +513,8 @@ class TestOAuth2TokenEndpoint:
 
         basic_auth = base64.b64encode(b"test-client:test-secret").decode("ascii")
 
-        with patch("auth_server.routes.oauth_flow.encode_jwt") as mock_jwt_encode:
-            mock_jwt_encode.return_value = "mock-jwt-token-with-user-id"
+        with patch("auth_server.routes.oauth_flow.mint_managed_agent_token") as mock_mint_token:
+            mock_mint_token.return_value = "mock-jwt-token-with-user-id"
 
             app.dependency_overrides = {}
             app.dependency_overrides[get_user_service] = lambda: mock_user_service
@@ -530,9 +534,10 @@ class TestOAuth2TokenEndpoint:
             token_data = response.json()
             assert token_data["access_token"] == "mock-jwt-token-with-user-id"
 
-            call_args = mock_jwt_encode.call_args[0]
-            token_payload = call_args[0]
-            assert token_payload["client_id"] == "test-client"
+            assert mock_mint_token.call_args.kwargs["client_id"] == "test-client"
+            token_claims = mock_mint_token.call_args.kwargs["extra_claims"]
+            assert token_claims["user_id"] == "507f1f77bcf86cd799439011"
+            assert token_claims["token_use"] == "access"
 
             assert auth_code not in authorization_codes_storage
 
@@ -573,7 +578,7 @@ class TestOAuth2TokenEndpoint:
 
         basic_auth = base64.b64encode(b"test-client:test-secret").decode("ascii")
 
-        with patch("auth_server.routes.oauth_flow.encode_jwt") as mock_jwt_encode:
+        with patch("auth_server.routes.oauth_flow.mint_managed_agent_token") as mock_mint_token:
             app.dependency_overrides = {}
             app.dependency_overrides[get_user_service] = lambda: mock_user_service
 
@@ -591,7 +596,7 @@ class TestOAuth2TokenEndpoint:
             assert response.status_code == 400
             assert response.json()["error"] == "invalid_request"
             assert response.json()["error_description"] == "client_id is required"
-            mock_jwt_encode.assert_not_called()
+            mock_mint_token.assert_not_called()
 
             # Request should fail before code exchange, so code remains stored.
             assert auth_code in authorization_codes_storage

--- a/auth-server/tests/integration/test_oauth_flow_routes.py
+++ b/auth-server/tests/integration/test_oauth_flow_routes.py
@@ -632,10 +632,10 @@ class TestDeviceFlowRoutes:
 class TestDeviceFlowWithMocking:
     """Integration tests for device flow with JWT mocking."""
 
-    @patch("auth_server.routes.oauth_flow.encode_jwt")
-    def test_approve_device_success_with_token(self, mock_jwt_encode, test_client: TestClient, clear_device_storage):
+    @patch("auth_server.routes.oauth_flow.mint_managed_agent_token")
+    def test_approve_device_success_with_token(self, mock_mint_token, test_client: TestClient, clear_device_storage):
         """Test device approval generates access token."""
-        mock_jwt_encode.return_value = "mock-access-token"
+        mock_mint_token.return_value = "mock-access-token"
 
         # Create device code
         device_response = test_client.post(
@@ -652,13 +652,16 @@ class TestDeviceFlowWithMocking:
         assert data["status"] == "approved"
         assert "successfully" in data["message"].lower()
 
-        # Verify JWT token generated
-        mock_jwt_encode.assert_called_once()
+        # Verify access token generated
+        mock_mint_token.assert_called_once()
+        assert mock_mint_token.call_args.kwargs["subject"] == "device_user"
+        assert mock_mint_token.call_args.kwargs["client_id"] == "test-client"
+        assert mock_mint_token.call_args.kwargs["extra_claims"]["scope"] == "test-scope"
 
-    @patch("auth_server.routes.oauth_flow.encode_jwt")
-    def test_approve_device_already_approved(self, mock_jwt_encode, test_client: TestClient, clear_device_storage):
+    @patch("auth_server.routes.oauth_flow.mint_managed_agent_token")
+    def test_approve_device_already_approved(self, mock_mint_token, test_client: TestClient, clear_device_storage):
         """Test approving already-approved device returns success."""
-        mock_jwt_encode.return_value = "mock-access-token"
+        mock_mint_token.return_value = "mock-access-token"
 
         # Create and approve device
         device_response = test_client.post(f"{API_PREFIX}/oauth2/device/code", data={"client_id": "test-client"})
@@ -672,11 +675,12 @@ class TestDeviceFlowWithMocking:
 
         assert response.status_code == 200
         assert "already" in response.json()["message"].lower()
+        mock_mint_token.assert_called_once()
 
-    @patch("auth_server.routes.oauth_flow.encode_jwt")
-    def test_device_token_success_with_mocked_jwt(self, mock_jwt_encode, test_client: TestClient, clear_device_storage):
+    @patch("auth_server.routes.oauth_flow.mint_managed_agent_token")
+    def test_device_token_success_with_mocked_jwt(self, mock_mint_token, test_client: TestClient, clear_device_storage):
         """Test token endpoint returns mocked access token after approval."""
-        mock_jwt_encode.return_value = "mock-access-token"
+        mock_mint_token.return_value = "mock-access-token"
 
         # Create device code
         device_response = test_client.post(
@@ -709,8 +713,8 @@ class TestDeviceFlowWithMocking:
         assert token_data["scope"] == "test-scope"
         assert token_data["access_token"] == "mock-access-token"
 
-    @patch("auth_server.routes.oauth_flow.encode_jwt")
-    def test_device_token_expired_code(self, mock_jwt_encode, test_client: TestClient, clear_device_storage):
+    @patch("auth_server.routes.oauth_flow.mint_managed_agent_token")
+    def test_device_token_expired_code(self, mock_mint_token, test_client: TestClient, clear_device_storage):
         """Test token endpoint rejects expired device codes."""
         # Create device code
         device_response = test_client.post(f"{API_PREFIX}/oauth2/device/code", data={"client_id": "test-client"})
@@ -732,6 +736,7 @@ class TestDeviceFlowWithMocking:
         assert response.status_code == 400
         # After cleanup, expired codes may return invalid_grant or expired_token
         assert response.json()["error"] in ["expired_token", "invalid_grant"]
+        mock_mint_token.assert_not_called()
 
 
 @pytest.mark.integration
@@ -739,12 +744,12 @@ class TestDeviceFlowWithMocking:
 class TestEndToEndIntegration:
     """End-to-end integration tests combining client registration and device flow."""
 
-    @patch("auth_server.routes.oauth_flow.encode_jwt")
+    @patch("auth_server.routes.oauth_flow.mint_managed_agent_token")
     def test_full_device_flow_with_registered_client(
-        self, mock_jwt_encode, test_client: TestClient, clear_device_storage
+        self, mock_mint_token, test_client: TestClient, clear_device_storage
     ):
         """Test complete device flow with dynamically registered client."""
-        mock_jwt_encode.return_value = "integration-test-token"
+        mock_mint_token.return_value = "integration-test-token"
 
         # Step 1: Register client
         reg_response = test_client.post(
@@ -769,6 +774,7 @@ class TestEndToEndIntegration:
         # Step 3: User approves device
         approve_response = test_client.post(f"{API_PREFIX}/oauth2/device/approve", json={"user_code": user_code})
         assert approve_response.status_code == 200
+        mock_mint_token.assert_called_once()
 
         # Step 4: Client polls for token
         token_response = test_client.post(

--- a/auth-server/tests/unit/test_jwt_audience.py
+++ b/auth-server/tests/unit/test_jwt_audience.py
@@ -1,130 +1,74 @@
-"""
-Unit tests for JWT audience validation with RFC 8707 Resource Indicators.
-
-Tests verify that:
-1. Self-signed tokens (kid='self-signed-key-v1') skip audience validation
-2. Resource URLs are accepted as audience claims
-3. Provider tokens still validate audience properly
-
-JWT operations are fully mocked — crypto logic is tested in
-registry-pkgs/tests/unit/test_jwt_utils.py.
-"""
-
-from unittest.mock import patch
-
 import pytest
+
+from auth_server.core.config import settings
+from auth_server.services.cognito_validator_service import SimplifiedCognitoValidator
+from registry_pkgs.core.jwt_tokens import mint_crud_session_token, mint_managed_agent_token
+
+
+@pytest.fixture
+def validator() -> SimplifiedCognitoValidator:
+    return SimplifiedCognitoValidator()
+
+
+@pytest.fixture
+def cfg():
+    return settings.jwt_token_config
 
 
 @pytest.mark.unit
 @pytest.mark.auth
-class TestJWTAudienceValidation:
-    """Test JWT audience validation for RFC 8707 compliance."""
+class TestSelfSignedTokenValidation:
+    def test_accepts_managed_agent_token(self, validator, cfg):
+        token = mint_managed_agent_token(
+            cfg,
+            subject="alice",
+            client_id="mcp-client-abc",
+            expires_in_seconds=3600,
+            extra_claims={"token_use": "access", "scope": "a b"},
+        )
 
-    def test_self_signed_token_skips_audience_validation(self):
-        """Self-signed tokens should skip audience validation (aud == resource URL)."""
-        from auth_server.server import JWT_ISSUER, JWT_SELF_SIGNED_KID
+        result = validator.validate_self_signed_token(token)
 
-        resource_url = "http://localhost/proxy/mcpgw"
+        assert result["valid"] is True
+        assert result["method"] == "self_signed"
+        assert result["client_id"] == "mcp-client-abc"
+        assert result["username"] == "alice"
+        assert result["scopes"] == ["a", "b"]
 
-        fake_claims = {
-            "iss": JWT_ISSUER,
-            "aud": resource_url,
-            "sub": "test-user",
-            "scope": "test-scope",
-        }
-        fake_token = "header.payload.sig"
+    def test_rejects_crud_session_token(self, validator, cfg):
+        # A dashboard cookie token must never validate as a managed-agent token.
+        token = mint_crud_session_token(
+            cfg,
+            subject="bob",
+            token_type="access_token",
+            expires_in_seconds=3600,
+            extra_claims={"token_use": "access"},
+        )
 
-        with (
-            patch("registry_pkgs.core.jwt_utils.encode_jwt", return_value=fake_token),
-            patch("registry_pkgs.core.jwt_utils.decode_jwt", return_value=fake_claims),
-        ):
-            # Simulate encoding a self-signed token with a resource URL as audience
-            from registry_pkgs.core.jwt_utils import decode_jwt, encode_jwt
+        with pytest.raises(ValueError):
+            validator.validate_self_signed_token(token)
 
-            payload = {
-                "iss": JWT_ISSUER,
-                "aud": resource_url,
-                "sub": "test-user",
-                "scope": "test-scope",
-            }
-            token = encode_jwt(payload, "dummy-private-key", kid=JWT_SELF_SIGNED_KID)
-            assert token == fake_token
+    def test_rejects_registry_self_token(self, validator, cfg):
+        # Registry's own-login token (client_id == registry) is inert on the proxy path.
+        token = mint_managed_agent_token(
+            cfg,
+            subject="self",
+            client_id=cfg.registry_client_id,
+            expires_in_seconds=3600,
+            extra_claims={"token_use": "access"},
+        )
 
-            # Decode skipping audience verification (audience=None)
-            claims = decode_jwt(token, "dummy-public-key", issuer=JWT_ISSUER, audience=None)
-            assert claims["aud"] == resource_url
-            assert claims["sub"] == "test-user"
+        with pytest.raises(ValueError):
+            validator.validate_self_signed_token(token)
 
-    def test_provider_token_validates_audience(self):
-        """Provider tokens should validate audience strictly."""
-        from auth_server.server import JWT_AUDIENCE, JWT_ISSUER
+    def test_rejects_non_access_token_use(self, validator, cfg):
+        token = mint_managed_agent_token(
+            cfg,
+            subject="alice",
+            client_id="mcp-client-abc",
+            expires_in_seconds=3600,
+            extra_claims={"token_use": "id"},
+        )
 
-        fake_claims = {
-            "iss": JWT_ISSUER,
-            "aud": JWT_AUDIENCE,
-            "sub": "test-user",
-            "scope": "test-scope",
-        }
-        fake_token = "header.payload.sig"
-
-        with (
-            patch("registry_pkgs.core.jwt_utils.encode_jwt", return_value=fake_token),
-            patch("registry_pkgs.core.jwt_utils.decode_jwt", return_value=fake_claims),
-        ):
-            from registry_pkgs.core.jwt_utils import decode_jwt, encode_jwt
-
-            payload = {"iss": JWT_ISSUER, "aud": JWT_AUDIENCE, "sub": "test-user", "scope": "test-scope"}
-            token = encode_jwt(payload, "dummy-private-key", kid="provider-key-id")
-            claims = decode_jwt(token, "dummy-public-key", issuer=JWT_ISSUER, audience=JWT_AUDIENCE)
-            assert claims["aud"] == JWT_AUDIENCE
-
-    def test_provider_token_rejects_wrong_audience(self):
-        """Provider tokens should reject mismatched audience."""
-        from auth_server.server import JWT_AUDIENCE, JWT_ISSUER
-        from registry_pkgs.core.jwt_utils import InvalidAudienceError
-
-        fake_token = "header.payload.sig"
-
-        with (
-            patch("registry_pkgs.core.jwt_utils.encode_jwt", return_value=fake_token),
-            patch("registry_pkgs.core.jwt_utils.decode_jwt", side_effect=InvalidAudienceError("wrong audience")),
-        ):
-            from registry_pkgs.core.jwt_utils import decode_jwt, encode_jwt
-
-            payload = {"iss": JWT_ISSUER, "aud": "wrong-audience", "sub": "test-user"}
-            token = encode_jwt(payload, "dummy-private-key", kid="provider-key-id")
-
-            with pytest.raises(InvalidAudienceError):
-                decode_jwt(token, "dummy-public-key", issuer=JWT_ISSUER, audience=JWT_AUDIENCE)
-
-    def test_resource_url_in_token_payload(self):
-        """Token with resource URL should contain correct aud claim."""
-        from auth_server.server import JWT_ISSUER, JWT_SELF_SIGNED_KID
-
-        resource_url = "http://localhost/proxy/server123"
-
-        fake_claims = {
-            "iss": JWT_ISSUER,
-            "aud": resource_url,
-            "sub": "test-user",
-            "scope": "server123:read server123:write",
-        }
-        fake_token = "header.payload.sig"
-
-        with (
-            patch("registry_pkgs.core.jwt_utils.encode_jwt", return_value=fake_token),
-            patch("registry_pkgs.core.jwt_utils.decode_jwt", return_value=fake_claims),
-        ):
-            from registry_pkgs.core.jwt_utils import decode_jwt, encode_jwt
-
-            payload = {
-                "iss": JWT_ISSUER,
-                "aud": resource_url,
-                "sub": "test-user",
-                "scope": "server123:read server123:write",
-            }
-            token = encode_jwt(payload, "dummy-private-key", kid=JWT_SELF_SIGNED_KID)
-            claims = decode_jwt(token, "dummy-public-key", issuer=JWT_ISSUER, audience=None)
-
-            assert claims["aud"] == resource_url
-            assert "server123:read" in claims["scope"]
+        with pytest.raises(ValueError):
+            validator.validate_self_signed_token(token)

--- a/registry-pkgs/src/registry_pkgs/core/config.py
+++ b/registry-pkgs/src/registry_pkgs/core/config.py
@@ -68,6 +68,19 @@ class JwtSigningConfig(BaseModel):
     jwt_audience: str = Field(description="Default audience (`aud`) claim")
 
 
+class JwtTokenConfig(BaseModel):
+    """Everything the token-class layer (``core.jwt_tokens``) needs to mint and verify
+    the two mutually-exclusive classes of self-signed JWT."""
+
+    jwt_private_key: str = Field(description="PEM-encoded RSA private key used to sign tokens")
+    jwt_public_key: str = Field(description="PEM-encoded RSA public key used to verify tokens")
+    jwt_issuer: str = Field(description="Issuer (`iss`) claim — the registry's public URL")
+    jwt_self_signed_kid: str = Field(description="`kid` header for self-signed JWKS lookup")
+    managed_agents_audience: str = Field(description="`aud` for managed-agent (proxy / Bearer) tokens")
+    crud_services_audience: str = Field(description="`aud` for CRUD session (cookie) tokens")
+    registry_client_id: str = Field(description="`client_id` of the registry backend (the first-party CRUD principal)")
+
+
 class TelemetryConfig(BaseModel):
     otel_metrics_config_path: str = Field(default="", description="Metrics config file path")
     otel_exporter_otlp_endpoint: str = Field(
@@ -105,7 +118,13 @@ class JarvisBaseSettings(BaseSettings):
     # ==================== JWT ====================
     jwt_private_key: str = ""  # PEM-encoded RSA private key (JWT_PRIVATE_KEY env var)
     jwt_public_key: str = ""  # PEM-encoded RSA public key (JWT_PUBLIC_KEY env var)
+    # Outbound / service-to-service audience (registry -> external MCP / AgentCore Runtime).
+    # Coupled to AgentCore-side config; do NOT reuse for inbound managed-agent / CRUD tokens.
     jwt_audience: str = "jarvis-services"
+    # Inbound token-class audiences (AS-1523): managed-agent tokens (Bearer -> /proxy) vs
+    # CRUD session tokens (jarvis_registry_session cookie -> non-proxy CRUD routes).
+    jwt_audience_managed_agents: str = "jarvis-managed-agents"
+    jwt_audience_crud_services: str = "jarvis-crud-services"
     jwt_self_signed_kid: str = "self-signed-key-v1"
 
     # ==================== RFC 9110 realm ====================
@@ -233,6 +252,18 @@ class JarvisBaseSettings(BaseSettings):
             jwt_issuer=self.jwt_issuer,
             jwt_self_signed_kid=self.jwt_self_signed_kid,
             jwt_audience=self.jwt_audience,
+        )
+
+    @cached_property
+    def jwt_token_config(self) -> JwtTokenConfig:
+        return JwtTokenConfig(
+            jwt_private_key=self.jwt_private_key,
+            jwt_public_key=self.jwt_public_key,
+            jwt_issuer=self.jwt_issuer,
+            jwt_self_signed_kid=self.jwt_self_signed_kid,
+            managed_agents_audience=self.jwt_audience_managed_agents,
+            crud_services_audience=self.jwt_audience_crud_services,
+            registry_client_id=self.registry_app_name,
         )
 
     @cached_property

--- a/registry-pkgs/src/registry_pkgs/core/jwt_tokens.py
+++ b/registry-pkgs/src/registry_pkgs/core/jwt_tokens.py
@@ -39,8 +39,8 @@ __all__ = [
 def _merge_class_claims(extra_claims: dict[str, Any] | None, token_class: str, client_id: str) -> dict[str, Any]:
     reserved_claims = _RESERVED_EXTRA_CLAIMS.intersection(extra_claims or {})
     if reserved_claims:
-        claims = ", ".join(sorted(reserved_claims))
-        raise ValueError(f"extra_claims cannot override reserved JWT claims: {claims}")
+        bad_keys = ", ".join(sorted(reserved_claims))
+        raise ValueError(f"extra_claims cannot override reserved JWT claims: {bad_keys}")
 
     claims: dict[str, Any] = dict(extra_claims or {})
     claims["client_id"] = client_id

--- a/registry-pkgs/src/registry_pkgs/core/jwt_tokens.py
+++ b/registry-pkgs/src/registry_pkgs/core/jwt_tokens.py
@@ -1,0 +1,154 @@
+import logging
+from typing import Any
+
+from .config import JwtTokenConfig
+from .jwt_utils import (
+    InvalidTokenError,
+    build_jwt_payload,
+    decode_jwt,
+    encode_jwt,
+    get_token_kid,
+)
+
+logger = logging.getLogger(__name__)
+
+TOKEN_CLASS_CLAIM = "token_class"
+TOKEN_CLASS_MANAGED_AGENT = "managed_agent"
+TOKEN_CLASS_CRUD_SESSION = "crud_session"
+
+__all__ = [
+    "TOKEN_CLASS_CLAIM",
+    "TOKEN_CLASS_MANAGED_AGENT",
+    "TOKEN_CLASS_CRUD_SESSION",
+    "mint_managed_agent_token",
+    "mint_crud_session_token",
+    "verify_managed_agent_token",
+    "verify_crud_session_token",
+]
+
+
+def _merge_class_claims(extra_claims: dict[str, Any] | None, token_class: str, client_id: str) -> dict[str, Any]:
+    claims: dict[str, Any] = dict(extra_claims or {})
+    claims["client_id"] = client_id
+    claims[TOKEN_CLASS_CLAIM] = token_class
+    return claims
+
+
+def mint_managed_agent_token(
+    config: JwtTokenConfig,
+    *,
+    subject: str,
+    client_id: str,
+    expires_in_seconds: int,
+    iat: int | None = None,
+    extra_claims: dict[str, Any] | None = None,
+) -> str:
+    """Mint a managed-agent (proxy / Bearer) self-signed JWT.
+
+    ``client_id`` is the requesting client's id (DCR-registered client, the literal
+    ``"user-generated"`` for token vending, or a device-flow client). It is recorded
+    as-is; the proxy verifier later rejects tokens whose ``client_id`` equals the
+    registry backend's own id.
+    """
+    payload = build_jwt_payload(
+        subject=subject,
+        issuer=config.jwt_issuer,
+        audience=config.managed_agents_audience,
+        expires_in_seconds=expires_in_seconds,
+        iat=iat,
+        extra_claims=_merge_class_claims(extra_claims, TOKEN_CLASS_MANAGED_AGENT, client_id),
+    )
+    return encode_jwt(payload, config.jwt_private_key, kid=config.jwt_self_signed_kid)
+
+
+def mint_crud_session_token(
+    config: JwtTokenConfig,
+    *,
+    subject: str,
+    token_type: str,
+    expires_in_seconds: int,
+    iat: int | None = None,
+    extra_claims: dict[str, Any] | None = None,
+) -> str:
+    """Mint a CRUD-session (cookie) self-signed JWT.
+
+    ``client_id`` is fixed to the registry backend's own id — CRUD session tokens are
+    always issued by the registry acting as the first-party principal. ``token_type``
+    distinguishes ``"access_token"`` from ``"refresh_token"``.
+    """
+    payload = build_jwt_payload(
+        subject=subject,
+        issuer=config.jwt_issuer,
+        audience=config.crud_services_audience,
+        expires_in_seconds=expires_in_seconds,
+        token_type=token_type,
+        iat=iat,
+        extra_claims=_merge_class_claims(extra_claims, TOKEN_CLASS_CRUD_SESSION, config.registry_client_id),
+    )
+    return encode_jwt(payload, config.jwt_private_key, kid=config.jwt_self_signed_kid)
+
+
+def _decode_self_signed(config: JwtTokenConfig, token: str, audience: str) -> dict[str, Any]:
+    """Reject foreign-kid tokens early, then verify signature + iss + aud."""
+    kid = get_token_kid(token)
+    if kid != config.jwt_self_signed_kid:
+        raise InvalidTokenError(f"unexpected kid: {kid!r}")
+    return decode_jwt(
+        token,
+        config.jwt_public_key,
+        issuer=config.jwt_issuer,
+        audience=audience,
+    )
+
+
+def verify_managed_agent_token(config: JwtTokenConfig, token: str) -> dict[str, Any]:
+    """Verify a managed-agent (proxy) token and return its claims.
+
+    Positive judgement is ``token_class == "managed_agent"``; ``aud`` and the
+    ``client_id != registry`` exclusion are defense-in-depth. Raises
+    :class:`InvalidTokenError` on any failure.
+    """
+    claims = _decode_self_signed(config, token, config.managed_agents_audience)
+
+    if claims.get(TOKEN_CLASS_CLAIM) != TOKEN_CLASS_MANAGED_AGENT:
+        raise InvalidTokenError(f"wrong token_class for managed-agent: {claims.get(TOKEN_CLASS_CLAIM)!r}")
+
+    # client_id is required on managed-agent tokens (the token endpoint mandates it).
+    # Require it positively rather than relying on "!= registry" treating a missing
+    # value as acceptable.
+    client_id = claims.get("client_id")
+    if not client_id:
+        raise InvalidTokenError("managed-agent token is missing the required client_id claim")
+
+    # First-party CRUD principal must never act as a managed agent over /proxy.
+    if client_id == config.registry_client_id:
+        raise InvalidTokenError("registry client_id is not permitted on managed-agent (proxy) tokens")
+
+    return claims
+
+
+def verify_crud_session_token(
+    config: JwtTokenConfig,
+    token: str,
+    *,
+    expected_token_type: str | None = None,
+) -> dict[str, Any]:
+    """Verify a CRUD-session (cookie) token and return its claims.
+
+    Positive judgement is ``token_class == "crud_session"``; ``aud`` and the
+    ``client_id == registry`` requirement are defense-in-depth. When
+    ``expected_token_type`` is given, ``token_type`` must match (access vs refresh).
+    Raises :class:`InvalidTokenError` on any failure.
+    """
+    claims = _decode_self_signed(config, token, config.crud_services_audience)
+
+    if claims.get(TOKEN_CLASS_CLAIM) != TOKEN_CLASS_CRUD_SESSION:
+        raise InvalidTokenError(f"wrong token_class for crud-session: {claims.get(TOKEN_CLASS_CLAIM)!r}")
+
+    if claims.get("client_id") != config.registry_client_id:
+        raise InvalidTokenError("crud-session tokens must carry the registry client_id")
+
+    if expected_token_type is not None and claims.get("token_type") != expected_token_type:
+        raise InvalidTokenError(f"wrong token_type: {claims.get('token_type')!r}, expected {expected_token_type!r}")
+
+    return claims

--- a/registry-pkgs/src/registry_pkgs/core/jwt_tokens.py
+++ b/registry-pkgs/src/registry_pkgs/core/jwt_tokens.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any
 
 from .config import JwtTokenConfig
@@ -9,8 +8,6 @@ from .jwt_utils import (
     encode_jwt,
     get_token_kid,
 )
-
-logger = logging.getLogger(__name__)
 
 TOKEN_CLASS_CLAIM = "token_class"
 TOKEN_CLASS_MANAGED_AGENT = "managed_agent"

--- a/registry-pkgs/src/registry_pkgs/core/jwt_tokens.py
+++ b/registry-pkgs/src/registry_pkgs/core/jwt_tokens.py
@@ -12,6 +12,18 @@ from .jwt_utils import (
 TOKEN_CLASS_CLAIM = "token_class"
 TOKEN_CLASS_MANAGED_AGENT = "managed_agent"
 TOKEN_CLASS_CRUD_SESSION = "crud_session"
+_RESERVED_EXTRA_CLAIMS = frozenset(
+    {
+        "sub",
+        "iss",
+        "aud",
+        "iat",
+        "exp",
+        "token_type",
+        "client_id",
+        TOKEN_CLASS_CLAIM,
+    }
+)
 
 __all__ = [
     "TOKEN_CLASS_CLAIM",
@@ -25,6 +37,11 @@ __all__ = [
 
 
 def _merge_class_claims(extra_claims: dict[str, Any] | None, token_class: str, client_id: str) -> dict[str, Any]:
+    reserved_claims = _RESERVED_EXTRA_CLAIMS.intersection(extra_claims or {})
+    if reserved_claims:
+        claims = ", ".join(sorted(reserved_claims))
+        raise ValueError(f"extra_claims cannot override reserved JWT claims: {claims}")
+
     claims: dict[str, Any] = dict(extra_claims or {})
     claims["client_id"] = client_id
     claims[TOKEN_CLASS_CLAIM] = token_class

--- a/registry-pkgs/tests/unit/core/test_jwt_tokens.py
+++ b/registry-pkgs/tests/unit/core/test_jwt_tokens.py
@@ -46,11 +46,6 @@ def cfg() -> JwtTokenConfig:
     )
 
 
-# --------------------------------------------------------------------------- #
-# Happy paths
-# --------------------------------------------------------------------------- #
-
-
 def test_managed_agent_roundtrip(cfg):
     token = mint_managed_agent_token(
         cfg, subject="alice", client_id="mcp-client-abc", expires_in_seconds=3600, extra_claims={"scope": "x"}

--- a/registry-pkgs/tests/unit/core/test_jwt_tokens.py
+++ b/registry-pkgs/tests/unit/core/test_jwt_tokens.py
@@ -68,13 +68,26 @@ def test_crud_session_roundtrip(cfg):
     assert claims["token_type"] == "access_token"
 
 
-def test_crud_session_client_id_is_forced(cfg):
-    # Even if a caller tries to override client_id, the class-defining value wins.
-    token = mint_crud_session_token(
-        cfg, subject="bob", token_type="access_token", expires_in_seconds=3600, extra_claims={"client_id": "evil"}
-    )
-    claims = verify_crud_session_token(cfg, token)
-    assert claims["client_id"] == _REGISTRY_CLIENT_ID
+def test_crud_session_rejects_reserved_client_id_claim(cfg):
+    with pytest.raises(ValueError, match="client_id"):
+        mint_crud_session_token(
+            cfg,
+            subject="bob",
+            token_type="access_token",
+            expires_in_seconds=3600,
+            extra_claims={"client_id": "evil"},
+        )
+
+
+def test_managed_agent_rejects_reserved_standard_claims(cfg):
+    with pytest.raises(ValueError, match="aud"):
+        mint_managed_agent_token(
+            cfg,
+            subject="alice",
+            client_id="mcp-client-abc",
+            expires_in_seconds=3600,
+            extra_claims={"aud": "wrong-audience"},
+        )
 
 
 # --------------------------------------------------------------------------- #

--- a/registry-pkgs/tests/unit/core/test_jwt_tokens.py
+++ b/registry-pkgs/tests/unit/core/test_jwt_tokens.py
@@ -167,3 +167,33 @@ def test_missing_client_id_rejected(cfg):
     token = encode_jwt(payload, _PRIVATE_KEY, kid=_KID)
     with pytest.raises(InvalidTokenError):
         verify_managed_agent_token(cfg, token)
+
+
+def test_crud_session_missing_token_class_rejected(cfg):
+    from registry_pkgs.core.jwt_utils import build_jwt_payload
+
+    payload = build_jwt_payload(
+        subject="b",
+        issuer=cfg.jwt_issuer,
+        audience=cfg.crud_services_audience,
+        expires_in_seconds=3600,
+        extra_claims={"client_id": cfg.registry_client_id},  # no token_class
+    )
+    token = encode_jwt(payload, _PRIVATE_KEY, kid=_KID)
+    with pytest.raises(InvalidTokenError):
+        verify_crud_session_token(cfg, token)
+
+
+def test_crud_session_wrong_client_id_rejected(cfg):
+    from registry_pkgs.core.jwt_utils import build_jwt_payload
+
+    payload = build_jwt_payload(
+        subject="b",
+        issuer=cfg.jwt_issuer,
+        audience=cfg.crud_services_audience,
+        expires_in_seconds=3600,
+        extra_claims={TOKEN_CLASS_CLAIM: TOKEN_CLASS_CRUD_SESSION, "client_id": "some-other-client"},
+    )
+    token = encode_jwt(payload, _PRIVATE_KEY, kid=_KID)
+    with pytest.raises(InvalidTokenError):
+        verify_crud_session_token(cfg, token)

--- a/registry-pkgs/tests/unit/core/test_jwt_tokens.py
+++ b/registry-pkgs/tests/unit/core/test_jwt_tokens.py
@@ -1,0 +1,161 @@
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from registry_pkgs.core.config import JwtTokenConfig
+from registry_pkgs.core.jwt_tokens import (
+    TOKEN_CLASS_CLAIM,
+    TOKEN_CLASS_CRUD_SESSION,
+    TOKEN_CLASS_MANAGED_AGENT,
+    mint_crud_session_token,
+    mint_managed_agent_token,
+    verify_crud_session_token,
+    verify_managed_agent_token,
+)
+from registry_pkgs.core.jwt_utils import InvalidTokenError, encode_jwt
+
+_RSA_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PRIVATE_KEY = _RSA_KEY.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.TraditionalOpenSSL,
+    encryption_algorithm=serialization.NoEncryption(),
+).decode("utf-8")
+_PUBLIC_KEY = (
+    _RSA_KEY.public_key()
+    .public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    .decode("utf-8")
+)
+
+_REGISTRY_CLIENT_ID = "jarvis-registry-client"
+_KID = "self-signed-key-v1"
+
+
+@pytest.fixture
+def cfg() -> JwtTokenConfig:
+    return JwtTokenConfig(
+        jwt_private_key=_PRIVATE_KEY,
+        jwt_public_key=_PUBLIC_KEY,
+        jwt_issuer="https://jarvis.test",
+        jwt_self_signed_kid=_KID,
+        managed_agents_audience="jarvis-managed-agents",
+        crud_services_audience="jarvis-crud-services",
+        registry_client_id=_REGISTRY_CLIENT_ID,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Happy paths
+# --------------------------------------------------------------------------- #
+
+
+def test_managed_agent_roundtrip(cfg):
+    token = mint_managed_agent_token(
+        cfg, subject="alice", client_id="mcp-client-abc", expires_in_seconds=3600, extra_claims={"scope": "x"}
+    )
+    claims = verify_managed_agent_token(cfg, token)
+    assert claims["sub"] == "alice"
+    assert claims["aud"] == "jarvis-managed-agents"
+    assert claims["client_id"] == "mcp-client-abc"
+    assert claims[TOKEN_CLASS_CLAIM] == TOKEN_CLASS_MANAGED_AGENT
+    assert claims["scope"] == "x"
+
+
+def test_crud_session_roundtrip(cfg):
+    token = mint_crud_session_token(cfg, subject="bob", token_type="access_token", expires_in_seconds=3600)
+    claims = verify_crud_session_token(cfg, token, expected_token_type="access_token")
+    assert claims["sub"] == "bob"
+    assert claims["aud"] == "jarvis-crud-services"
+    assert claims["client_id"] == _REGISTRY_CLIENT_ID
+    assert claims[TOKEN_CLASS_CLAIM] == TOKEN_CLASS_CRUD_SESSION
+    assert claims["token_type"] == "access_token"
+
+
+def test_crud_session_client_id_is_forced(cfg):
+    # Even if a caller tries to override client_id, the class-defining value wins.
+    token = mint_crud_session_token(
+        cfg, subject="bob", token_type="access_token", expires_in_seconds=3600, extra_claims={"client_id": "evil"}
+    )
+    claims = verify_crud_session_token(cfg, token)
+    assert claims["client_id"] == _REGISTRY_CLIENT_ID
+
+
+# --------------------------------------------------------------------------- #
+# Cross-class rejection matrix (the security invariant)
+# --------------------------------------------------------------------------- #
+
+
+def test_managed_agent_token_rejected_by_crud_verifier(cfg):
+    token = mint_managed_agent_token(cfg, subject="a", client_id="mcp-client-abc", expires_in_seconds=3600)
+    with pytest.raises(InvalidTokenError):
+        verify_crud_session_token(cfg, token)
+
+
+def test_crud_token_rejected_by_managed_agent_verifier(cfg):
+    token = mint_crud_session_token(cfg, subject="b", token_type="access_token", expires_in_seconds=3600)
+    with pytest.raises(InvalidTokenError):
+        verify_managed_agent_token(cfg, token)
+
+
+def test_registry_client_id_managed_agent_token_is_inert(cfg):
+    # Registry's own login mints a managed_agent token with client_id == registry.
+    # It must be rejected by the proxy verifier (and also by CRUD verifier via aud).
+    token = mint_managed_agent_token(cfg, subject="self", client_id=_REGISTRY_CLIENT_ID, expires_in_seconds=3600)
+    with pytest.raises(InvalidTokenError):
+        verify_managed_agent_token(cfg, token)
+    with pytest.raises(InvalidTokenError):
+        verify_crud_session_token(cfg, token)
+
+
+def test_wrong_token_type_rejected(cfg):
+    token = mint_crud_session_token(cfg, subject="b", token_type="refresh_token", expires_in_seconds=3600)
+    with pytest.raises(InvalidTokenError):
+        verify_crud_session_token(cfg, token, expected_token_type="access_token")
+
+
+def test_foreign_kid_rejected(cfg):
+    # A token signed with the right key but a foreign kid must be rejected early.
+    from registry_pkgs.core.jwt_utils import build_jwt_payload
+
+    payload = build_jwt_payload(
+        subject="a",
+        issuer=cfg.jwt_issuer,
+        audience=cfg.managed_agents_audience,
+        expires_in_seconds=3600,
+        extra_claims={"client_id": "mcp-client-abc", TOKEN_CLASS_CLAIM: TOKEN_CLASS_MANAGED_AGENT},
+    )
+    token = encode_jwt(payload, _PRIVATE_KEY, kid="some-other-kid")
+    with pytest.raises(InvalidTokenError):
+        verify_managed_agent_token(cfg, token)
+
+
+def test_missing_token_class_rejected(cfg):
+    from registry_pkgs.core.jwt_utils import build_jwt_payload
+
+    payload = build_jwt_payload(
+        subject="a",
+        issuer=cfg.jwt_issuer,
+        audience=cfg.managed_agents_audience,
+        expires_in_seconds=3600,
+        extra_claims={"client_id": "mcp-client-abc"},  # no token_class
+    )
+    token = encode_jwt(payload, _PRIVATE_KEY, kid=_KID)
+    with pytest.raises(InvalidTokenError):
+        verify_managed_agent_token(cfg, token)
+
+
+def test_missing_client_id_rejected(cfg):
+    from registry_pkgs.core.jwt_utils import build_jwt_payload
+
+    payload = build_jwt_payload(
+        subject="a",
+        issuer=cfg.jwt_issuer,
+        audience=cfg.managed_agents_audience,
+        expires_in_seconds=3600,
+        extra_claims={TOKEN_CLASS_CLAIM: TOKEN_CLASS_MANAGED_AGENT},  # no client_id
+    )
+    token = encode_jwt(payload, _PRIVATE_KEY, kid=_KID)
+    with pytest.raises(InvalidTokenError):
+        verify_managed_agent_token(cfg, token)

--- a/registry/src/registry/api/v1/token_routes.py
+++ b/registry/src/registry/api/v1/token_routes.py
@@ -5,7 +5,7 @@ import uuid
 from fastapi import APIRouter, HTTPException
 from pydantic import ValidationError
 
-from registry_pkgs.core.jwt_utils import build_jwt_payload, encode_jwt
+from registry_pkgs.core.jwt_tokens import mint_managed_agent_token
 
 from ...auth.dependencies import CurrentUser
 from ...core.config import settings
@@ -78,22 +78,21 @@ async def generate_user_token(
             "groups": user_groups,
             "jti": str(uuid.uuid4()),
             "token_use": "access",
-            "client_id": "user-generated",
         }
 
         if description:
             extra_claims["description"] = description
 
-        access_payload = build_jwt_payload(
+        # User-vended tokens are managed-agent (proxy / Bearer) class. client_id is the
+        # sentinel "user-generated" (never the registry backend's id).
+        access_token = mint_managed_agent_token(
+            settings.jwt_token_config,
             subject=username,
-            issuer=settings.jwt_issuer,
-            audience=settings.jwt_audience,
+            client_id="user-generated",
             expires_in_seconds=expires_in_seconds,
             iat=current_time,
             extra_claims=extra_claims,
         )
-
-        access_token = encode_jwt(access_payload, settings.jwt_private_key, kid=settings.jwt_self_signed_kid)
 
         logger.info(f"Successfully generated token for user '{username}' with expiry {expires_in_hours}h")
 

--- a/registry/src/registry/middleware/auth.py
+++ b/registry/src/registry/middleware/auth.py
@@ -198,7 +198,11 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
                 return None
 
             parts = auth_header.split(" ", 1)
-            access_token = parts[1].strip() if len(parts) == 2 else ""
+            if len(parts) != 2 or parts[0].lower() != "bearer":
+                logger.debug("Authorization header is not a Bearer scheme")
+                return None
+
+            access_token = parts[1].strip()
             if not access_token:
                 logger.debug("Empty Bearer token after split")
                 return None

--- a/registry/src/registry/middleware/auth.py
+++ b/registry/src/registry/middleware/auth.py
@@ -5,7 +5,8 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.routing import compile_path, get_route_path
 
-from registry_pkgs.core.jwt_utils import ExpiredSignatureError, InvalidTokenError, decode_jwt, get_token_kid
+from registry_pkgs.core.jwt_tokens import verify_managed_agent_token
+from registry_pkgs.core.jwt_utils import ExpiredSignatureError, InvalidTokenError
 from registry_pkgs.core.scopes import map_groups_to_scopes
 
 from ..auth.dependencies import UserContextDict
@@ -76,6 +77,10 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
         self.scopes_config = settings.scopes_config
         logger.info(f"Scopes config loaded with {len(self.scopes_config.get('group_mappings', {}))} group mappings")
 
+    def _is_proxy_route(self, path: str) -> bool:
+        """Single source of truth for the proxy/non-proxy split."""
+        return path.startswith("/proxy/")
+
     def _compile_patterns(self, patterns: list[str]) -> list[tuple]:
         """
         Compile path patterns into Starlette route matchers
@@ -108,7 +113,7 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
         # Use context manager for clean metrics tracking
         async with AuthMetricsContext() as auth_ctx:
             try:
-                user_context = await self._authenticate(request)
+                user_context = await self._authenticate(request, path)
                 request.state.user = user_context
                 request.state.is_authenticated = True
                 auth_source = user_context.get("auth_source", "unknown")
@@ -127,18 +132,19 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
 
                 headers = {"Connection": "close"}
 
-                if path.startswith("/proxy/"):
-                    # Add WWW-Authenticate header for MCP related routes (both `mcpgw` and dynamic catch-all),
-                    # so that AI agents can perform Dynamic Client Registration.
+                if self._is_proxy_route(path):
+                    # Proxy routes are Bearer-authenticated (managed-agent tokens). Advertise a
+                    # Bearer challenge with resource metadata so AI agents can perform Dynamic
+                    # Client Registration.
                     headers["WWW-Authenticate"] = (
                         f'Bearer realm="{settings.jarvis_realm}", '
                         f'resource_metadata="{settings.jwt_issuer}/.well-known/oauth-protected-resource{settings.service_base_path}{path}", '
                         'scope="mcp-proxy-ops"'
                     )
-                else:
-                    # For non-MCP related routes, the only caller is our frontend, which knows the auth-server routes.
-                    # Therefore we don't include resource_metadata here.
-                    headers["WWW-Authenticate"] = f'Bearer realm="{settings.jarvis_realm}"'
+                # Non-proxy routes are cookie-authenticated (CRUD-session cookie). Cookie/session
+                # auth has no RFC 7235 challenge scheme, and the only caller is our frontend, which
+                # handles a bare 401 by redirecting to login — so we deliberately advertise no
+                # (misleading) Bearer challenge here.
 
                 return JSONResponse(status_code=401, content={"detail": str(e)}, headers=headers)
 
@@ -160,73 +166,56 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
                 return True
         return False
 
-    async def _authenticate(self, request: Request) -> UserContextDict:
-        """
-        Unified authentication logic (simple and efficient)
+    async def _authenticate(self, request: Request, path: str) -> UserContextDict:
+        """Route-based authentication dispatch.
 
-        1. Authenticated paths (including /api/auth/me, /api/servers/*, /proxy/*, /api/mcp/*) → JWT or Session Auth
-        2. Other paths → Session Auth
+        - Proxy routes (``/proxy/*``): the ONLY accepted credential is a managed-agent
+          Bearer token in the Authorization header. The session cookie is never consulted.
+        - Every other authenticated route: the ONLY accepted credential is the
+          CRUD-session cookie. The Authorization header is never consulted.
+
+        This hard split is what stops a leaked managed-agent token (e.g. via the DCR-CSRF
+        path) from being replayed as a dashboard session cookie, and vice versa.
         """
-        # Try JWT first, then fall back to session auth
-        user_context = self._try_jwt_auth(request)
-        if user_context:
-            return user_context
+        if self._is_proxy_route(path):
+            user_context = self._try_jwt_auth(request)
+            if user_context:
+                return user_context
+            raise AuthenticationError("Managed-agent Bearer token required for proxy routes")
+
         user_context = await self._try_session_auth(request)
         if user_context:
             return user_context
-        raise AuthenticationError("JWT or session authentication required")
+        raise AuthenticationError("Session authentication required")
 
     def _try_jwt_auth(self, request: Request) -> UserContextDict | None:
-        """JWT token authentication for /api/servers endpoints"""
+        """Managed-agent Bearer-token authentication for proxy routes"""
         try:
             # Get Authorization header
             auth_header = request.headers.get("Authorization")
             if not auth_header:
-                logger.debug("Missing Authorization header for JWT auth")
+                logger.debug("Missing Authorization header for managed-agent auth")
                 return None
 
-            access_token = auth_header.split(" ")[1]
+            parts = auth_header.split(" ", 1)
+            access_token = parts[1].strip() if len(parts) == 2 else ""
             if not access_token:
-                logger.debug("Empty JWT token after split")
+                logger.debug("Empty Bearer token after split")
                 return None
 
-            # Extract kid from header first
+            # Validate as a managed-agent (proxy) token. Wrong class/audience/kid/client_id
+            # all raise InvalidTokenError.
             try:
-                kid = get_token_kid(access_token)
-            except Exception as e:
-                logger.debug(f"Failed to decode JWT header: {e}")
-                return None
-
-            # Check if this is our self-signed token; reject tokens with an unrecognised explicit kid
-            if kid and kid != settings.jwt_self_signed_kid:
-                logger.debug(f"JWT token has wrong kid: {kid}, expected: {settings.jwt_self_signed_kid}")
-                return None
-
-            # Validate and decode token
-            try:
-                # For self-signed tokens (kid='mcp-self-signed'), skip audience validation
-                # because the audience is now the resource URL (RFC 8707 Resource Indicators)
-                # which varies per endpoint (/proxy/mcpgw, /proxy/server2, etc.)
-                # Issuer validation provides sufficient security for self-signed tokens.
-                is_self_signed_token = kid == settings.jwt_self_signed_kid
-
-                if is_self_signed_token:
-                    logger.info("Skipping audience validation for self-signed token (RFC 8707 Resource Indicators)")
-
-                claims = decode_jwt(
-                    access_token,
-                    settings.jwt_public_key,
-                    issuer=settings.jwt_issuer,
-                    audience=None if is_self_signed_token else settings.jwt_audience,
-                )
+                claims = verify_managed_agent_token(settings.jwt_token_config, access_token)
                 logger.info(
-                    f"JWT claims validated: sub={claims.get('sub')}, aud={claims.get('aud')}, scope={claims.get('scope')}"
+                    f"Managed-agent token validated: sub={claims.get('sub')}, "
+                    f"aud={claims.get('aud')}, client_id={claims.get('client_id')}"
                 )
             except ExpiredSignatureError:
-                logger.debug("JWT token has expired")
+                logger.debug("Managed-agent token has expired")
                 return None
             except InvalidTokenError as e:
-                logger.debug(f"Invalid JWT token: {e}")
+                logger.debug(f"Invalid managed-agent token: {e}")
                 return None
 
             # Extract user information from claims

--- a/registry/src/registry/middleware/auth.py
+++ b/registry/src/registry/middleware/auth.py
@@ -246,9 +246,9 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
                 return None
 
             # Log token validation success with additional details
-            token_type = claims.get("token_type", "unknown")
+            token_class = claims.get("token_class", "unknown")
             description = claims.get("description", "")
-            logger.info(f"JWT token validated for user: {username}, type: {token_type}, scopes: {scopes}")
+            logger.info(f"Managed-agent token validated for user: {username}, class: {token_class}, scopes: {scopes}")
             if description:
                 logger.debug(f"Token description: {description}")
             user_id = claims.get("user_id")

--- a/registry/src/registry/utils/crypto_utils.py
+++ b/registry/src/registry/utils/crypto_utils.py
@@ -20,13 +20,12 @@ from typing import Any
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
+from registry_pkgs.core.jwt_tokens import mint_crud_session_token, verify_crud_session_token
 from registry_pkgs.core.jwt_utils import (
     ExpiredSignatureError,
     InvalidTokenError,
     build_jwt_payload,
-    decode_jwt,
     encode_jwt,
-    get_token_kid,
 )
 
 from ..core.config import settings
@@ -451,19 +450,15 @@ def generate_access_token(
     if idp_id:
         extra_claims["idp_id"] = idp_id
 
-    # Build JWT payload using centralized helper
-    payload = build_jwt_payload(
+    # CRUD-session (cookie) class: audience, client_id and token_class are set by the layer.
+    token = mint_crud_session_token(
+        settings.jwt_token_config,
         subject=username,
-        issuer=settings.jwt_issuer,
-        audience=settings.jwt_audience,
-        expires_in_seconds=expires_in_seconds,
         token_type="access_token",
+        expires_in_seconds=expires_in_seconds,
         iat=iat,
         extra_claims=extra_claims,
     )
-
-    # Generate JWT
-    token = encode_jwt(payload, settings.jwt_private_key, kid=settings.jwt_self_signed_kid)
 
     logger.debug(f"Generated access token for user {username}, expires in {expires_hours}h")
     return token
@@ -513,17 +508,14 @@ def generate_refresh_token(
         "email": email,
     }
 
-    # Build JWT payload using centralized helper
-    payload = build_jwt_payload(
+    # CRUD-session (cookie) class: audience, client_id and token_class are set by the layer.
+    token = mint_crud_session_token(
+        settings.jwt_token_config,
         subject=username,
-        issuer=settings.jwt_issuer,
-        audience=settings.jwt_audience,
-        expires_in_seconds=expires_in_seconds,
         token_type="refresh_token",
+        expires_in_seconds=expires_in_seconds,
         extra_claims=extra_claims,
     )
-
-    token = encode_jwt(payload, settings.jwt_private_key, kid=settings.jwt_self_signed_kid)
 
     logger.debug(f"Generated refresh token for user {username}, expires in {expires_days} days")
     return token
@@ -540,27 +532,7 @@ def verify_access_token(token: str) -> dict[str, Any] | None:
         Decoded token claims if valid, None otherwise
     """
     try:
-        # Verify kid in header
-        kid = get_token_kid(token)
-
-        if kid != settings.jwt_self_signed_kid:
-            logger.debug(f"Invalid kid in token: {kid}")
-            return None
-
-        # Decode and verify token
-        claims = decode_jwt(
-            token,
-            settings.jwt_public_key,
-            issuer=settings.jwt_issuer,
-            audience=settings.jwt_audience,
-            leeway=30,
-        )
-
-        # Verify token type
-        if claims.get("token_type") != "access_token":
-            logger.warning(f"Wrong token type: {claims.get('token_type')}")
-            return None
-
+        claims = verify_crud_session_token(settings.jwt_token_config, token, expected_token_type="access_token")
         logger.debug(f"Access token verified for user: {claims.get('sub')}")
         return claims
 
@@ -586,27 +558,7 @@ def verify_refresh_token(token: str) -> dict[str, Any] | None:
         Decoded token claims if valid, None otherwise
     """
     try:
-        # Verify kid in header
-        kid = get_token_kid(token)
-
-        if kid != settings.jwt_self_signed_kid:
-            logger.debug(f"Invalid kid in refresh token: {kid}")
-            return None
-
-        # Decode and verify token
-        claims = decode_jwt(
-            token,
-            settings.jwt_public_key,
-            issuer=settings.jwt_issuer,
-            audience=settings.jwt_audience,
-            leeway=30,
-        )
-
-        # Verify token type
-        if claims.get("token_type") != "refresh_token":
-            logger.warning(f"Wrong token type in refresh: {claims.get('token_type')}")
-            return None
-
+        claims = verify_crud_session_token(settings.jwt_token_config, token, expected_token_type="refresh_token")
         logger.debug(f"Refresh token verified for user: {claims.get('sub')}")
         return claims
 

--- a/registry/tests/conftest.py
+++ b/registry/tests/conftest.py
@@ -237,7 +237,7 @@ def mock_auth_middleware():
         "provider": "test",
     }
 
-    async def mock_authenticate(self, request):
+    async def mock_authenticate(self, request, _path):
         """Mock authenticate method that always returns admin user."""
         return test_user_context
 

--- a/registry/tests/unit/middleware/test_auth_dispatch.py
+++ b/registry/tests/unit/middleware/test_auth_dispatch.py
@@ -1,0 +1,127 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from starlette.testclient import TestClient
+
+from registry.core.config import settings
+from registry.middleware.auth import UnifiedAuthMiddleware
+from registry.utils.crypto_utils import generate_access_token
+from registry_pkgs.core.jwt_tokens import mint_managed_agent_token
+
+_COOKIE = settings.session_cookie_name
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(UnifiedAuthMiddleware)
+
+    @app.get("/proxy/mcpgw/mcp")
+    async def proxy_ep():  # pragma: no cover - body trivial
+        return JSONResponse({"ok": "proxy"})
+
+    @app.get("/api/v1/servers")
+    async def crud_ep():  # pragma: no cover - body trivial
+        return JSONResponse({"ok": "crud"})
+
+    return app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(_build_app())
+
+
+def _managed_agent_token(client_id: str = "mcp-client-abc") -> str:
+    return mint_managed_agent_token(
+        settings.jwt_token_config,
+        subject="alice",
+        client_id=client_id,
+        expires_in_seconds=3600,
+        extra_claims={"scope": "mcp-proxy-ops"},
+    )
+
+
+def _crud_cookie_token() -> str:
+    return generate_access_token(
+        user_id="u1",
+        username="alice",
+        email="alice@example.com",
+        groups=["g1"],
+        scopes=["servers-read"],
+        role="user",
+        auth_method="oauth2",
+        provider="entra",
+    )
+
+
+def test_proxy_accepts_managed_agent_bearer(client):
+    resp = client.get("/proxy/mcpgw/mcp", headers={"Authorization": f"Bearer {_managed_agent_token()}"})
+    assert resp.status_code == 200
+
+
+def test_proxy_rejects_crud_token_as_bearer(client):
+    # CRUD-session token presented as a Bearer must not work on proxy routes.
+    resp = client.get("/proxy/mcpgw/mcp", headers={"Authorization": f"Bearer {_crud_cookie_token()}"})
+    assert resp.status_code == 401
+
+
+def test_proxy_ignores_cookie(client):
+    # A valid CRUD cookie must not authenticate a proxy route.
+    client.cookies.set(_COOKIE, _crud_cookie_token())
+    resp = client.get("/proxy/mcpgw/mcp")
+    assert resp.status_code == 401
+
+
+def test_proxy_rejects_registry_client_id_token(client):
+    token = _managed_agent_token(client_id=settings.registry_app_name)
+    resp = client.get("/proxy/mcpgw/mcp", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_crud_accepts_session_cookie(client):
+    client.cookies.set(_COOKIE, _crud_cookie_token())
+    resp = client.get("/api/v1/servers")
+    assert resp.status_code == 200
+
+
+def test_crud_rejects_managed_agent_token_in_cookie(client):
+    # Epic regression: leaked managed-agent token replayed as session cookie must fail.
+    client.cookies.set(_COOKIE, _managed_agent_token())
+    resp = client.get("/api/v1/servers")
+    assert resp.status_code == 401
+
+
+def test_crud_ignores_bearer_header(client):
+    resp = client.get("/api/v1/servers", headers={"Authorization": f"Bearer {_managed_agent_token()}"})
+    assert resp.status_code == 401
+
+
+def test_crud_401_advertises_no_bearer_challenge(client):
+    resp = client.get("/api/v1/servers")
+    assert resp.status_code == 401
+    assert "WWW-Authenticate" not in resp.headers
+
+
+def test_proxy_401_advertises_bearer_challenge(client):
+    resp = client.get("/proxy/mcpgw/mcp")
+    assert resp.status_code == 401
+    assert resp.headers.get("WWW-Authenticate", "").startswith("Bearer")
+
+
+def test_all_proxy_router_paths_classify_as_proxy():
+    from registry.api.proxy_routes import router as proxy_router
+
+    mw = UnifiedAuthMiddleware(FastAPI())
+    proxy_paths = [r.path for r in proxy_router.routes if getattr(r, "path", None) is not None]
+    assert proxy_paths, "expected proxy_router to expose routes"
+    for path in proxy_paths:
+        assert mw._is_proxy_route(f"/proxy{path}") is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/api/v1/servers", "/api/v1/agents", "/api/auth/me", "/api/v1/tokens/generate", "/api/health/status"],
+)
+def test_crud_paths_classify_as_non_proxy(path):
+    mw = UnifiedAuthMiddleware(FastAPI())
+    assert mw._is_proxy_route(path) is False

--- a/registry/tests/unit/middleware/test_auth_dispatch.py
+++ b/registry/tests/unit/middleware/test_auth_dispatch.py
@@ -78,6 +78,16 @@ def test_proxy_rejects_registry_client_id_token(client):
     assert resp.status_code == 401
 
 
+def test_proxy_rejects_non_bearer_scheme(client):
+    resp = client.get("/proxy/mcpgw/mcp", headers={"Authorization": f"Basic {_managed_agent_token()}"})
+    assert resp.status_code == 401
+
+
+def test_proxy_accepts_bearer_scheme_case_insensitively(client):
+    resp = client.get("/proxy/mcpgw/mcp", headers={"Authorization": f"bearer {_managed_agent_token()}"})
+    assert resp.status_code == 200
+
+
 def test_crud_accepts_session_cookie(client):
     client.cookies.set(_COOKIE, _crud_cookie_token())
     resp = client.get("/api/v1/servers")

--- a/registry/tests/unit/utils/test_crypto_utils.py
+++ b/registry/tests/unit/utils/test_crypto_utils.py
@@ -2,13 +2,89 @@
 
 from unittest.mock import patch
 
+from registry.core.config import settings
 from registry.utils.crypto_utils import (
     ENCRYPTED_VALUE_PATTERN,
     decrypt_auth_fields,
     encrypt_auth_fields,
+    generate_access_token,
+    generate_refresh_token,
     generate_service_jwt,
     is_encrypted,
+    verify_access_token,
+    verify_refresh_token,
 )
+from registry_pkgs.core.jwt_tokens import (
+    TOKEN_CLASS_CLAIM,
+    TOKEN_CLASS_CRUD_SESSION,
+    mint_managed_agent_token,
+)
+
+
+class TestCrudSessionTokens:
+    """Cookie (CRUD-session) token round-trips and cross-class rejection (AS-1523)."""
+
+    @staticmethod
+    def _gen_access() -> str:
+        return generate_access_token(
+            user_id="u1",
+            username="alice",
+            email="alice@example.com",
+            groups=["g1"],
+            scopes=["servers-read"],
+            role="user",
+            auth_method="oauth2",
+            provider="entra",
+        )
+
+    def test_access_token_roundtrip_and_class(self):
+        token = self._gen_access()
+        claims = verify_access_token(token)
+        assert claims is not None
+        assert claims["sub"] == "alice"
+        assert claims["aud"] == settings.jwt_audience_crud_services
+        assert claims["client_id"] == settings.registry_app_name
+        assert claims[TOKEN_CLASS_CLAIM] == TOKEN_CLASS_CRUD_SESSION
+        assert claims["token_type"] == "access_token"
+
+    def test_refresh_token_roundtrip(self):
+        token = generate_refresh_token(
+            user_id="u1",
+            username="alice",
+            auth_method="oauth2",
+            provider="entra",
+            groups=["g1"],
+            scopes=["servers-read"],
+            role="user",
+            email="alice@example.com",
+        )
+        claims = verify_refresh_token(token)
+        assert claims is not None
+        assert claims["token_type"] == "refresh_token"
+        assert claims["client_id"] == settings.registry_app_name
+
+    def test_access_verifier_rejects_refresh_token(self):
+        token = generate_refresh_token(
+            user_id="u1",
+            username="alice",
+            auth_method="oauth2",
+            provider="entra",
+            groups=[],
+            scopes=["servers-read"],
+            role="user",
+            email="alice@example.com",
+        )
+        assert verify_access_token(token) is None
+
+    def test_access_verifier_rejects_managed_agent_token(self):
+        # A leaked managed-agent (proxy) token must never validate as a CRUD session cookie.
+        managed = mint_managed_agent_token(
+            settings.jwt_token_config,
+            subject="alice",
+            client_id="mcp-client-abc",
+            expires_in_seconds=3600,
+        )
+        assert verify_access_token(managed) is None
 
 
 class TestIsEncrypted:


### PR DESCRIPTION
This change splits self-signed JWTs into two mutually-exclusive classes. `UnifiedAuthMiddleware` dispatches by route, so neither class works on the other's routes — closing the DCR-CSRF replay path where an `/oauth2/token` JWT could be reused as a `jarvis_registry_session` cookie.

| | CRUD token | Proxy token |
|---|---|---|
| Audience (`aud`) | `jarvis-crud-services` | `jarvis-managed-agents` |
| Transport | `jarvis_registry_session` cookie | `Authorization: Bearer` |
| `client_id` | registry backend (`registry_app_name`) | caller's id (never registry's) |
| Issued by | `/redirect`, `/redirect/refresh` | `/oauth2/token`, `/tokens/generate` |
| Accepted on | non-proxy routes only | `/proxy/*` only |