### PR TITLE
Adjust polling timeout for A2A calls

### DIFF
--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
@@ -34,6 +34,8 @@ logger = logging.getLogger(__name__)
 
 _A2A_JWT_TTL_SECONDS = 300
 _A2A_HTTP_TIMEOUT = 300
+# a2a poll timeout needs to be strictly less than _A2A_JWT_TTL_SECONDS and _A2A_HTTP_TIMEOUT
+_A2A_POLL_TIMEOUT = _A2A_HTTP_TIMEOUT * 0.6
 
 _IN_PROGRESS_STATES: frozenset[TaskState] = frozenset({TaskState.submitted, TaskState.working})
 
@@ -253,11 +255,11 @@ async def _poll_until_terminal(
     `blocking=True` is only a hint; servers may ignore it and return a
     `submitted`/`working` Task immediately. Caller-side polling is the
     documented workaround (see a2a-send-message-1.md, Bug 2). Returns the
-    final Task. Raises TimeoutError if the 60s budget is exceeded.
+    final Task. Raises TimeoutError if the _A2A_POLL_TIMEOUT budget is exceeded.
     """
-    # Exponential backoff capped at 8s; total budget 60s.
+    # Exponential backoff capped at 8s; total budget _A2A_POLL_TIMEOUT.
     back_offs = (0.5, 1.0, 2.0, 4.0, 8.0)
-    deadline = time.monotonic() + 60.0
+    deadline = time.monotonic() + _A2A_POLL_TIMEOUT
     delay_iter = iter(back_offs)
     while True:
         try:
@@ -267,7 +269,7 @@ async def _poll_until_terminal(
 
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            raise TimeoutError(f"polling timed out after 60s for task {task_id!r}")
+            raise TimeoutError(f"polling timed out after {_A2A_POLL_TIMEOUT}s for task {task_id!r}")
         await asyncio.sleep(min(delay, remaining))
 
         task = await client.get_task(TaskQueryParams(id=task_id), context=context)


### PR DESCRIPTION
This pull request updates the polling timeout logic in the `a2a_client.py` workflow client to make the poll timeout configurable and consistent with other timeout settings. The most important changes are:

Timeout configuration improvements:

* Introduced a new constant `_A2A_POLL_TIMEOUT`, set to 60% of `_A2A_HTTP_TIMEOUT`, to ensure the polling timeout is always less than both the JWT and HTTP timeouts.
* Updated the `_poll_until_terminal` function to use `_A2A_POLL_TIMEOUT` instead of a hardcoded 60 seconds for its total polling budget and error messages. [[1]](diffhunk://#diff-edfdabf17ab9c2c762c601b760948e958dfc388a86a18807e886906c80e2b368L256-R262) [[2]](diffhunk://#diff-edfdabf17ab9c2c762c601b760948e958dfc388a86a18807e886906c80e2b368L270-R272)