### PR TITLE
Fix/as 1545

### DIFF
--- a/auth-server/src/auth_server/container.py
+++ b/auth-server/src/auth_server/container.py
@@ -6,6 +6,7 @@ from .core.config import AuthSettings
 from .core.types import AllowedProvider
 from .providers.factory import get_auth_provider
 from .services.cognito_validator_service import SimplifiedCognitoValidator
+from .services.downstream_token_service import DownstreamTokenCheckService
 from .services.user_service import UserService
 from .utils.config_loader import AuthProviderConfig, EntraConfig, OAuth2Config, OAuth2ConfigLoader
 
@@ -26,6 +27,10 @@ class AuthContainer:
     @cached_property
     def user_service(self) -> UserService:
         return UserService()
+
+    @cached_property
+    def downstream_token_check(self) -> DownstreamTokenCheckService:
+        return DownstreamTokenCheckService()
 
     @cached_property
     def validator(self) -> SimplifiedCognitoValidator:

--- a/auth-server/src/auth_server/deps.py
+++ b/auth-server/src/auth_server/deps.py
@@ -5,6 +5,7 @@ from .container import AuthContainer
 from .core.types import AllowedProvider
 from .providers.base import AuthProvider
 from .services.cognito_validator_service import SimplifiedCognitoValidator
+from .services.downstream_token_service import DownstreamTokenCheckService
 from .services.user_service import UserService
 from .utils.config_loader import OAuth2Config
 
@@ -15,6 +16,10 @@ def get_container(request: Request) -> AuthContainer:
 
 def get_user_service(container: AuthContainer = Depends(get_container)) -> UserService:
     return container.user_service
+
+
+def get_downstream_token_check(container: AuthContainer = Depends(get_container)) -> DownstreamTokenCheckService:
+    return container.downstream_token_check
 
 
 def get_validator(container: AuthContainer = Depends(get_container)) -> SimplifiedCognitoValidator:

--- a/auth-server/src/auth_server/routes/well_known.py
+++ b/auth-server/src/auth_server/routes/well_known.py
@@ -7,15 +7,13 @@ Also implements RFC 9728 Protected Resource Metadata.
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, HTTPException
 
 from registry_pkgs.core.downstream_oauth import DOWNSTREAM_OAUTH_NAMESPACE, downstream_mcp_issuer
 from registry_pkgs.core.jwt_utils import build_jwks
 
 # Import settings
 from ..core.config import settings
-from ..deps import get_downstream_token_check
-from ..services.downstream_token_service import DownstreamTokenCheckService
 
 logger = logging.getLogger(__name__)
 
@@ -161,10 +159,7 @@ async def jwks_endpoint():
 
 
 @router.get(f"/.well-known/oauth-protected-resource{settings.service_base_path}/proxy/{{server_path:path}}")
-async def protected_resource_metadata(
-    server_path: str,
-    downstream_token_check: DownstreamTokenCheckService = Depends(get_downstream_token_check),
-):
+async def protected_resource_metadata(server_path: str):
     """
     `resource` lives on the registry backend, so we use `settings.registry_url`.
     `authorization_servers` includes our auth-server, so we use `settings.jwt_issuer`,
@@ -175,12 +170,11 @@ async def protected_resource_metadata(
     where registry backend and auth-server live on different ports of localhost.
 
     Direct-connect resources have the shape ``server/{user_id}/{actual_server_path}``. For those, the
-    advertised authorization server depends on whether the user already holds valid downstream tokens:
-    the standard registry issuer when they do, the per-server downstream issuer (which the MCP client
-    follows into the new /authorize + /token flow) when they don't.
+    advertised authorization server is always the per-server downstream issuer, so that MCP clients
+    (e.g. VS Code) always go through the downstream OAuth flow and receive a managed-agent token
+    bound to that specific (user_id, server_path) pair.
+    **MCP client such as VS Code caches the discovered AS metadata URL, so it only uses the first-time discovered URL no matter what.**
     """
-    # Default: advertise the standard registry issuer. Direct-connect resources without valid
-    # downstream tokens override this with the per-server downstream issuer below.
     authorization_servers = [settings.jwt_issuer]
 
     if server_path.startswith("server/"):
@@ -188,16 +182,7 @@ async def protected_resource_metadata(
         parts = rest.split("/", 1)
         if len(parts) == 2 and parts[0] and parts[1]:
             user_id, actual_server_path = parts[0], parts[1]
-            try:
-                has_tokens = await downstream_token_check.has_valid_downstream_token(
-                    user_id=user_id, server_path=actual_server_path
-                )
-            except Exception as e:
-                logger.warning(f"downstream token check failed for {server_path}: {e}")
-                has_tokens = False
-
-            if not has_tokens:
-                authorization_servers = [downstream_mcp_issuer(settings.jwt_issuer, user_id, actual_server_path)]
+            authorization_servers = [downstream_mcp_issuer(settings.jwt_issuer, user_id, actual_server_path)]
 
     return {
         "resource": f"{settings.registry_url}/proxy/{server_path}",

--- a/auth-server/src/auth_server/routes/well_known.py
+++ b/auth-server/src/auth_server/routes/well_known.py
@@ -79,10 +79,12 @@ async def downstream_authorization_server_metadata(user_id: str, server_path: st
     """
     issuer = downstream_mcp_issuer(settings.jwt_issuer, user_id, server_path)
     registry_url = settings.registry_url.rstrip("/")
+    auth_server_url = settings.auth_server_external_url.rstrip("/")
     return {
         "issuer": issuer,
         "authorization_endpoint": f"{registry_url}/api/v1/mcp/downstream/oauth/authorize/{user_id}/{server_path}",
         "token_endpoint": f"{registry_url}/api/v1/mcp/downstream/oauth/token/{user_id}/{server_path}",
+        "registration_endpoint": f"{auth_server_url}/oauth2/register",
         "jwks_uri": f"{settings.jwt_issuer}/.well-known/jwks.json",
         "response_types_supported": ["code"],
         "code_challenge_methods_supported": ["S256"],

--- a/auth-server/src/auth_server/routes/well_known.py
+++ b/auth-server/src/auth_server/routes/well_known.py
@@ -7,12 +7,15 @@ Also implements RFC 9728 Protected Resource Metadata.
 
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
+from registry_pkgs.core.downstream_oauth import DOWNSTREAM_OAUTH_NAMESPACE, downstream_mcp_issuer
 from registry_pkgs.core.jwt_utils import build_jwks
 
 # Import settings
 from ..core.config import settings
+from ..deps import get_downstream_token_check
+from ..services.downstream_token_service import DownstreamTokenCheckService
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +62,30 @@ async def oauth_authorization_server_metadata():
         "code_challenge_methods_supported": ["S256"],
         "scopes_supported": scope_names,
         "service_documentation": f"{auth_server_url}/docs",
+    }
+
+
+@router.get(f"/.well-known/oauth-authorization-server/{DOWNSTREAM_OAUTH_NAMESPACE}/{{user_id}}/{{server_path:path}}")
+async def downstream_authorization_server_metadata(user_id: str, server_path: str):
+    """Per-user, per-server downstream OAuth authorization server metadata (RFC 8414).
+
+    The MCP client reaches this by RFC 8414 path-insertion from the issuer identifier
+    ``{jwt_issuer}/proxy/server/oauth/{user_id}/{server_path}`` advertised in the protected
+    resource metadata. The ``issuer`` MUST exactly equal that identifier (RFC 8414 §3.3).
+
+    No ``service_base_path`` prefix here: the issuer is rooted at ``jwt_issuer`` (origin-only),
+    so the well-known path is ``/proxy/server/oauth/...`` directly after ``/.well-known/``.
+    The functional ``authorization_endpoint`` / ``token_endpoint`` live on the registry backend.
+    """
+    issuer = downstream_mcp_issuer(settings.jwt_issuer, user_id, server_path)
+    registry_url = settings.registry_url.rstrip("/")
+    return {
+        "issuer": issuer,
+        "authorization_endpoint": f"{registry_url}/api/v1/mcp/downstream/oauth/authorize/{user_id}/{server_path}",
+        "token_endpoint": f"{registry_url}/api/v1/mcp/downstream/oauth/token/{user_id}/{server_path}",
+        "jwks_uri": f"{settings.jwt_issuer}/.well-known/jwks.json",
+        "response_types_supported": ["code"],
+        "code_challenge_methods_supported": ["S256"],
     }
 
 
@@ -132,7 +159,10 @@ async def jwks_endpoint():
 
 
 @router.get(f"/.well-known/oauth-protected-resource{settings.service_base_path}/proxy/{{server_path:path}}")
-async def protected_resource_metadata(server_path: str):
+async def protected_resource_metadata(
+    server_path: str,
+    downstream_token_check: DownstreamTokenCheckService = Depends(get_downstream_token_check),
+):
     """
     `resource` lives on the registry backend, so we use `settings.registry_url`.
     `authorization_servers` includes our auth-server, so we use `settings.jwt_issuer`,
@@ -141,11 +171,35 @@ async def protected_resource_metadata(server_path: str):
     In EKS all URLs use the same domain name and traffic is handled by k8s Ingress.
     The current way of writing it only makes a difference when running services locally in Docker Compose,
     where registry backend and auth-server live on different ports of localhost.
+
+    Direct-connect resources have the shape ``server/{user_id}/{actual_server_path}``. For those, the
+    advertised authorization server depends on whether the user already holds valid downstream tokens:
+    the standard registry issuer when they do, the per-server downstream issuer (which the MCP client
+    follows into the new /authorize + /token flow) when they don't.
     """
+    # Default: advertise the standard registry issuer. Direct-connect resources without valid
+    # downstream tokens override this with the per-server downstream issuer below.
+    authorization_servers = [settings.jwt_issuer]
+
+    if server_path.startswith("server/"):
+        rest = server_path.removeprefix("server/")
+        parts = rest.split("/", 1)
+        if len(parts) == 2 and parts[0] and parts[1]:
+            user_id, actual_server_path = parts[0], parts[1]
+            try:
+                has_tokens = await downstream_token_check.has_valid_downstream_token(
+                    user_id=user_id, server_path=actual_server_path
+                )
+            except Exception as e:
+                logger.warning(f"downstream token check failed for {server_path}: {e}")
+                has_tokens = False
+
+            if not has_tokens:
+                authorization_servers = [downstream_mcp_issuer(settings.jwt_issuer, user_id, actual_server_path)]
 
     return {
         "resource": f"{settings.registry_url}/proxy/{server_path}",
-        "authorization_servers": [settings.jwt_issuer],
+        "authorization_servers": authorization_servers,
         "scopes_supported": settings.scopes_list,
         "bearer_methods_supported": ["header"],
     }

--- a/auth-server/src/auth_server/services/downstream_token_service.py
+++ b/auth-server/src/auth_server/services/downstream_token_service.py
@@ -1,0 +1,47 @@
+"""Downstream token check service for the auth server.
+
+Decides whether a user already holds usable downstream MCP tokens for a given server, so the
+protected resource metadata can point the MCP client at the right authorization server: the
+standard registry issuer when tokens exist, or the per-server downstream issuer when they don't.
+
+``ExtendedMCPServer``, ``Token``, and ``TokenType`` are imported from ``registry-pkgs`` — within
+the allowed dependency direction (``auth-server`` → ``registry-pkgs``).
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from beanie import PydanticObjectId
+
+from registry_pkgs.models import ExtendedMCPServer, Token, TokenType
+
+logger = logging.getLogger(__name__)
+
+_EXPIRY_BUFFER = timedelta(seconds=3)
+
+
+class DownstreamTokenCheckService:
+    """Checks MongoDB for valid downstream MCP access/refresh tokens."""
+
+    async def has_valid_downstream_token(self, user_id: str, server_path: str) -> bool:
+        """Return True if the user has a non-expired access or refresh token for the server."""
+        server = await ExtendedMCPServer.find_one({"path": f"/{server_path}"})
+        if not server:
+            return False
+
+        service_name = server.serverName
+        user_obj_id = PydanticObjectId(user_id)
+        cutoff = datetime.now(UTC) + _EXPIRY_BUFFER
+
+        # Single round-trip: a non-expired access OR refresh token for this user/server.
+        token = await Token.find_one(
+            {
+                "userId": user_obj_id,
+                "expiresAt": {"$gt": cutoff},
+                "$or": [
+                    {"type": TokenType.MCP_OAUTH_ACCESS.value, "identifier": f"mcp:{service_name}"},
+                    {"type": TokenType.MCP_OAUTH_REFRESH.value, "identifier": f"mcp:{service_name}:refresh"},
+                ],
+            }
+        )
+        return token is not None

--- a/auth-server/tests/integration/test_downstream_well_known.py
+++ b/auth-server/tests/integration/test_downstream_well_known.py
@@ -3,38 +3,16 @@
 - per-server authorization server metadata (RFC 8414)
 """
 
-from collections.abc import Generator
-from unittest.mock import AsyncMock
-
-import pytest
 from fastapi.testclient import TestClient
 
 from auth_server.core.config import settings
-from auth_server.deps import get_downstream_token_check
 from registry_pkgs.core.downstream_oauth import downstream_mcp_issuer
 
 USER_ID = "507f1f77bcf86cd799439011"
 _PRM_BASE = f"/.well-known/oauth-protected-resource{settings.service_base_path}/proxy"
 
 
-@pytest.fixture
-def token_check_override(auth_server_app) -> Generator[AsyncMock, None, None]:
-    """Override the downstream token check with a controllable async mock."""
-    mock = AsyncMock()
-    auth_server_app.dependency_overrides[get_downstream_token_check] = lambda: _Holder(mock)
-    yield mock
-    auth_server_app.dependency_overrides.pop(get_downstream_token_check, None)
-
-
-class _Holder:
-    """Wraps the mock so .has_valid_downstream_token resolves to it."""
-
-    def __init__(self, mock: AsyncMock):
-        self.has_valid_downstream_token = mock
-
-
-def test_prm_direct_connect_without_tokens_points_to_downstream_issuer(test_client: TestClient, token_check_override):
-    token_check_override.return_value = False
+def test_prm_direct_connect_points_to_downstream_issuer(test_client: TestClient):
     resp = test_client.get(f"{_PRM_BASE}/server/{USER_ID}/github")
     assert resp.status_code == 200
     body = resp.json()
@@ -42,19 +20,11 @@ def test_prm_direct_connect_without_tokens_points_to_downstream_issuer(test_clie
     assert body["authorization_servers"] == [expected_issuer]
 
 
-def test_prm_direct_connect_with_tokens_points_to_registry_issuer(test_client: TestClient, token_check_override):
-    token_check_override.return_value = True
-    resp = test_client.get(f"{_PRM_BASE}/server/{USER_ID}/github")
-    assert resp.status_code == 200
-    assert resp.json()["authorization_servers"] == [settings.jwt_issuer]
-
-
-def test_prm_non_direct_connect_unchanged(test_client: TestClient, token_check_override):
+def test_prm_non_direct_connect_unchanged(test_client: TestClient):
     # mcpgw/mcp (and any non server/ path) always points to the standard registry issuer.
     resp = test_client.get(f"{_PRM_BASE}/mcpgw/mcp")
     assert resp.status_code == 200
     assert resp.json()["authorization_servers"] == [settings.jwt_issuer]
-    token_check_override.assert_not_awaited()
 
 
 def test_downstream_as_metadata_issuer_and_endpoints(test_client: TestClient):

--- a/auth-server/tests/integration/test_downstream_well_known.py
+++ b/auth-server/tests/integration/test_downstream_well_known.py
@@ -1,0 +1,68 @@
+"""Integration tests for the downstream OAuth discovery documents:
+- protected resource metadata branching (RFC 9728)
+- per-server authorization server metadata (RFC 8414)
+"""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from auth_server.core.config import settings
+from auth_server.deps import get_downstream_token_check
+from registry_pkgs.core.downstream_oauth import downstream_mcp_issuer
+
+USER_ID = "507f1f77bcf86cd799439011"
+_PRM_BASE = f"/.well-known/oauth-protected-resource{settings.service_base_path}/proxy"
+
+
+@pytest.fixture
+def token_check_override(auth_server_app) -> Generator[AsyncMock, None, None]:
+    """Override the downstream token check with a controllable async mock."""
+    mock = AsyncMock()
+    auth_server_app.dependency_overrides[get_downstream_token_check] = lambda: _Holder(mock)
+    yield mock
+    auth_server_app.dependency_overrides.pop(get_downstream_token_check, None)
+
+
+class _Holder:
+    """Wraps the mock so .has_valid_downstream_token resolves to it."""
+
+    def __init__(self, mock: AsyncMock):
+        self.has_valid_downstream_token = mock
+
+
+def test_prm_direct_connect_without_tokens_points_to_downstream_issuer(test_client: TestClient, token_check_override):
+    token_check_override.return_value = False
+    resp = test_client.get(f"{_PRM_BASE}/server/{USER_ID}/github")
+    assert resp.status_code == 200
+    body = resp.json()
+    expected_issuer = downstream_mcp_issuer(settings.jwt_issuer, USER_ID, "github")
+    assert body["authorization_servers"] == [expected_issuer]
+
+
+def test_prm_direct_connect_with_tokens_points_to_registry_issuer(test_client: TestClient, token_check_override):
+    token_check_override.return_value = True
+    resp = test_client.get(f"{_PRM_BASE}/server/{USER_ID}/github")
+    assert resp.status_code == 200
+    assert resp.json()["authorization_servers"] == [settings.jwt_issuer]
+
+
+def test_prm_non_direct_connect_unchanged(test_client: TestClient, token_check_override):
+    # mcpgw/mcp (and any non server/ path) always points to the standard registry issuer.
+    resp = test_client.get(f"{_PRM_BASE}/mcpgw/mcp")
+    assert resp.status_code == 200
+    assert resp.json()["authorization_servers"] == [settings.jwt_issuer]
+    token_check_override.assert_not_awaited()
+
+
+def test_downstream_as_metadata_issuer_and_endpoints(test_client: TestClient):
+    resp = test_client.get(f"/.well-known/oauth-authorization-server/proxy/server/oauth/{USER_ID}/github")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["issuer"] == downstream_mcp_issuer(settings.jwt_issuer, USER_ID, "github")
+    assert body["authorization_endpoint"].endswith(f"/downstream/oauth/authorize/{USER_ID}/github")
+    assert body["token_endpoint"].endswith(f"/downstream/oauth/token/{USER_ID}/github")
+    assert body["jwks_uri"] == f"{settings.jwt_issuer}/.well-known/jwks.json"
+    assert body["code_challenge_methods_supported"] == ["S256"]

--- a/auth-server/tests/unit/test_downstream_token_service.py
+++ b/auth-server/tests/unit/test_downstream_token_service.py
@@ -1,0 +1,69 @@
+"""Unit tests for DownstreamTokenCheckService (single $or token lookup)."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from auth_server.services.downstream_token_service import DownstreamTokenCheckService
+
+USER_ID = "507f1f77bcf86cd799439011"
+
+
+@pytest.fixture
+def service() -> DownstreamTokenCheckService:
+    return DownstreamTokenCheckService()
+
+
+def _server() -> Mock:
+    s = Mock()
+    s.serverName = "github"
+    return s
+
+
+async def test_returns_false_when_server_unknown(service):
+    with patch(
+        "auth_server.services.downstream_token_service.ExtendedMCPServer.find_one",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        assert await service.has_valid_downstream_token(USER_ID, "github") is False
+
+
+async def test_returns_true_when_token_exists(service):
+    token = Mock()
+    token.expiresAt = datetime.now(UTC) + timedelta(hours=1)
+    with (
+        patch(
+            "auth_server.services.downstream_token_service.ExtendedMCPServer.find_one",
+            new_callable=AsyncMock,
+            return_value=_server(),
+        ),
+        patch(
+            "auth_server.services.downstream_token_service.Token.find_one",
+            new_callable=AsyncMock,
+            return_value=token,
+        ) as mock_find,
+    ):
+        assert await service.has_valid_downstream_token(USER_ID, "github") is True
+        # Single round-trip with an $or over access/refresh shapes.
+        mock_find.assert_awaited_once()
+        query = mock_find.await_args.args[0]
+        assert "$or" in query
+        assert len(query["$or"]) == 2
+
+
+async def test_returns_false_when_no_token(service):
+    with (
+        patch(
+            "auth_server.services.downstream_token_service.ExtendedMCPServer.find_one",
+            new_callable=AsyncMock,
+            return_value=_server(),
+        ),
+        patch(
+            "auth_server.services.downstream_token_service.Token.find_one",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        assert await service.has_valid_downstream_token(USER_ID, "github") is False

--- a/frontend/src/components/ServerConfigModal.tsx
+++ b/frontend/src/components/ServerConfigModal.tsx
@@ -65,7 +65,7 @@ const joinUrlPath = (...segments: string[]) =>
 
 const ServerConfigModal: React.FC<ServerConfigModalProps> = ({ server, isOpen, onClose, configScope = 'server' }) => {
   const { showToast } = useGlobal();
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const [selectedIDE, setSelectedIDE] = useState<IDE>('vscode');
 
   useEffect(() => {
@@ -95,13 +95,14 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({ server, isOpen, o
       ? 'Connect to Jarvis Registry from your preferred Copilot environment.'
       : `Connect to ${serverName} from your preferred Copilot environment.`;
 
+  const userId = user?.userId || '';
+  const isDirectConnect = configScope !== 'registry';
+  const configReady = !isDirectConnect || userId !== '';
+
   const generateMCPConfig = useCallback(() => {
     const currentUrl = new URL(window.location.origin);
     const basePath = getBasePath();
     const normalizedPath = server?.path || '';
-    // The direct-connect URL embeds the connecting user's id so the downstream OAuth discovery
-    // chain can thread user identity through URLs alone (see proxy_routes.dynamic_mcp_post_proxy).
-    const userId = user?.userId || '';
     const url =
       configScope === 'registry'
         ? REGISTRY_SERVER_URL
@@ -115,11 +116,17 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({ server, isOpen, o
         },
       },
     };
-  }, [configScope, selectedOption.rootKey, server?.path, serverName, user?.userId]);
+  }, [configScope, selectedOption.rootKey, server?.path, serverName, userId]);
 
-  const configText = useMemo(() => JSON.stringify(generateMCPConfig(), null, 2), [generateMCPConfig]);
+  const configText = useMemo(
+    () => (configReady ? JSON.stringify(generateMCPConfig(), null, 2) : ''),
+    [configReady, generateMCPConfig],
+  );
 
   const copyConfigToClipboard = useCallback(async () => {
+    if (!configReady) {
+      return;
+    }
     try {
       await navigator.clipboard.writeText(configText);
       showToast?.('Configuration copied to clipboard', 'success');
@@ -127,7 +134,7 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({ server, isOpen, o
       console.error('Failed to copy to clipboard:', error);
       showToast?.('Failed to copy configuration', 'error');
     }
-  }, [configText, showToast]);
+  }, [configReady, configText, showToast]);
 
   if (!isOpen) {
     return null;
@@ -205,16 +212,25 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({ server, isOpen, o
           <button
             type='button'
             onClick={copyConfigToClipboard}
-            className='inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border border-[color:var(--jarvis-border)] bg-white/[0.04] px-3 py-1.5 text-xs font-medium text-[var(--jarvis-text)] transition hover:border-[var(--jarvis-primary)] hover:bg-[var(--jarvis-primary-soft)] hover:text-[var(--jarvis-primary-text-hover)]'
+            disabled={!configReady}
+            className='inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border border-[color:var(--jarvis-border)] bg-white/[0.04] px-3 py-1.5 text-xs font-medium text-[var(--jarvis-text)] transition hover:border-[var(--jarvis-primary)] hover:bg-[var(--jarvis-primary-soft)] hover:text-[var(--jarvis-primary-text-hover)] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-[color:var(--jarvis-border)] disabled:hover:bg-white/[0.04] disabled:hover:text-[var(--jarvis-text)]'
           >
             <ClipboardDocumentIcon className='h-4 w-4' />
             Copy
           </button>
         </div>
 
-        <pre className='overflow-x-auto rounded-lg border border-white/5 bg-[#0d1117] px-4 py-4 text-xs leading-6 text-[#c9d1d9]'>
-          <code>{configText}</code>
-        </pre>
+        {configReady ? (
+          <pre className='overflow-x-auto rounded-lg border border-white/5 bg-[#0d1117] px-4 py-4 text-xs leading-6 text-[#c9d1d9]'>
+            <code>{configText}</code>
+          </pre>
+        ) : (
+          <div className='rounded-lg border border-white/5 bg-[#0d1117] px-4 py-6 text-xs leading-6 text-[var(--jarvis-muted)]'>
+            {loading
+              ? 'Loading your account…'
+              : 'Your account isn’t fully set up, so a direct-connect configuration can’t be generated. Please sign out and sign in again.'}
+          </div>
+        )}
 
         <div className='mt-4 rounded-lg border border-[rgba(124,58,237,0.15)] bg-[rgba(124,58,237,0.06)] p-3'>
           <div className='mb-1 flex items-center gap-2 text-xs font-semibold text-[var(--jarvis-primary-text)]'>

--- a/frontend/src/components/ServerConfigModal.tsx
+++ b/frontend/src/components/ServerConfigModal.tsx
@@ -3,6 +3,7 @@ import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import IconButton from '@/components/IconButton';
 import { getBasePath } from '@/config';
+import { useAuth } from '@/contexts/AuthContext';
 import { useGlobal } from '@/contexts/GlobalContext';
 import type { ServerInfo } from '@/contexts/ServerContext';
 
@@ -64,6 +65,7 @@ const joinUrlPath = (...segments: string[]) =>
 
 const ServerConfigModal: React.FC<ServerConfigModalProps> = ({ server, isOpen, onClose, configScope = 'server' }) => {
   const { showToast } = useGlobal();
+  const { user } = useAuth();
   const [selectedIDE, setSelectedIDE] = useState<IDE>('vscode');
 
   useEffect(() => {
@@ -97,10 +99,13 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({ server, isOpen, o
     const currentUrl = new URL(window.location.origin);
     const basePath = getBasePath();
     const normalizedPath = server?.path || '';
+    // The direct-connect URL embeds the connecting user's id so the downstream OAuth discovery
+    // chain can thread user identity through URLs alone (see proxy_routes.dynamic_mcp_post_proxy).
+    const userId = user?.userId || '';
     const url =
       configScope === 'registry'
         ? REGISTRY_SERVER_URL
-        : `${currentUrl.protocol}//${currentUrl.host}/${joinUrlPath(basePath, 'proxy/server', normalizedPath)}`;
+        : `${currentUrl.protocol}//${currentUrl.host}/${joinUrlPath(basePath, 'proxy/server', userId, normalizedPath)}`;
 
     return {
       [selectedOption.rootKey]: {
@@ -110,7 +115,7 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({ server, isOpen, o
         },
       },
     };
-  }, [configScope, selectedOption.rootKey, server?.path, serverName]);
+  }, [configScope, selectedOption.rootKey, server?.path, serverName, user?.userId]);
 
   const configText = useMemo(() => JSON.stringify(generateMCPConfig(), null, 2), [generateMCPConfig]);
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -6,6 +6,7 @@ import SERVICES from '@/services';
 
 interface User {
   username: string;
+  userId?: string;
   email?: string;
   scopes?: string[];
   groups?: string[];
@@ -54,6 +55,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       const userData = await SERVICES.AUTH.getAuthMe();
       setUser({
         username: userData.username,
+        userId: userData.userId,
         email: userData.email,
         scopes: userData.scopes || [],
         groups: userData.groups || [],

--- a/frontend/src/services/auth/type.ts
+++ b/frontend/src/services/auth/type.ts
@@ -1,5 +1,6 @@
 export type GetAuthMeResponse = {
   username: string;
+  userId?: string;
   email: string;
   scopes: string[];
   groups: string[];

--- a/registry-pkgs/src/registry_pkgs/core/downstream_oauth.py
+++ b/registry-pkgs/src/registry_pkgs/core/downstream_oauth.py
@@ -1,0 +1,27 @@
+"""Shared identifiers for the downstream MCP OAuth flow (Layer B: registry-as-AS).
+
+The downstream issuer string is an exact-match security contract: the registry mints and verifies
+it, and the auth-server advertises it via RFC 9728 / RFC 8414. It must stay byte-identical across
+both workspaces, so the single source of truth lives here in ``registry-pkgs`` where both
+``registry`` and ``auth-server`` can import it.
+"""
+
+DOWNSTREAM_OAUTH_NAMESPACE = "proxy/server/oauth"
+
+# Redis key prefix for a Layer B authorization code's stashed PKCE / binding context.
+DOWNSTREAM_OAUTH_CODE_PREFIX = "downstream_mcp_code:"
+
+
+def downstream_mcp_issuer(jwt_issuer: str, user_id: str, server_path: str) -> str:
+    """Build the issuer identifier for a downstream confirmation token.
+
+    ``jwt_issuer`` is origin-only (no path); the result is
+    ``{jwt_issuer}/proxy/server/oauth/{user_id}/{server_path}``.
+    """
+    return f"{jwt_issuer}/{DOWNSTREAM_OAUTH_NAMESPACE}/{user_id}/{server_path}"
+
+
+def downstream_mcp_code_key(code: str) -> str:
+    """Redis key under which a Layer B authorization code's context is stashed between the
+    OAuth callback and the ``/token`` exchange."""
+    return f"{DOWNSTREAM_OAUTH_CODE_PREFIX}{code}"

--- a/registry-pkgs/src/registry_pkgs/models/__init__.py
+++ b/registry-pkgs/src/registry_pkgs/models/__init__.py
@@ -21,6 +21,7 @@ from .extended_acl_entry import RegistryAclEntry
 from .extended_mcp_server import ExtendedMCPServer
 from .federation import Federation
 from .federation_sync_job import FederationSyncJob
+from .token_type import TokenType
 from .workflow import NodeRun, WorkflowDefinition, WorkflowRun, WorkflowVersion
 
 __all__ = [
@@ -38,6 +39,7 @@ __all__ = [
     "User",
     "Key",
     "Token",
+    "TokenType",
     "PrincipalType",
     "ResourceType",
 ]

--- a/registry-pkgs/src/registry_pkgs/models/token_type.py
+++ b/registry-pkgs/src/registry_pkgs/models/token_type.py
@@ -1,0 +1,18 @@
+"""Token type enumeration.
+
+Lives in ``registry-pkgs`` (alongside the ``Token`` Beanie document) so both the registry and
+the auth-server can reference it within the allowed dependency direction
+(``registry`` → ``registry-pkgs`` ← ``auth-server``). ``registry.schemas.enums`` re-exports it
+for backward compatibility.
+"""
+
+from enum import StrEnum
+
+
+class TokenType(StrEnum):
+    """Token type enumeration"""
+
+    MCP_OAUTH_ACCESS = "mcp_oauth"  # Access token (canonical name, value unchanged for DB compatibility)
+    MCP_OAUTH = MCP_OAUTH_ACCESS
+    MCP_OAUTH_REFRESH = "mcp_oauth_refresh"  # Refresh token
+    MCP_OAUTH_CLIENT = "mcp_oauth_client"  # Client credentials (client_id, client_secret)

--- a/registry-pkgs/src/registry_pkgs/models/token_type.py
+++ b/registry-pkgs/src/registry_pkgs/models/token_type.py
@@ -2,8 +2,7 @@
 
 Lives in ``registry-pkgs`` (alongside the ``Token`` Beanie document) so both the registry and
 the auth-server can reference it within the allowed dependency direction
-(``registry`` → ``registry-pkgs`` ← ``auth-server``). ``registry.schemas.enums`` re-exports it
-for backward compatibility.
+(``registry`` → ``registry-pkgs`` ← ``auth-server``). Import it from ``registry_pkgs.models``.
 """
 
 from enum import StrEnum

--- a/registry-pkgs/src/registry_pkgs/scopes.yml
+++ b/registry-pkgs/src/registry_pkgs/scopes.yml
@@ -235,6 +235,9 @@ user-read:
   - action: oauth_initiate
     method: GET
     endpoint: /mcp/{server_id}/oauth/initiate
+  - action: downstream_oauth_authorize
+    method: GET
+    endpoint: /mcp/downstream/oauth/authorize/{user_id}/{path}
   - action: oauth_callback
     method: GET
     endpoint: /mcp/{server_path}/oauth/callback

--- a/registry/src/registry/api/proxy_routes.py
+++ b/registry/src/registry/api/proxy_routes.py
@@ -817,7 +817,9 @@ async def dynamic_mcp_get_proxy(
     if not ObjectId.is_valid(user_id):
         return JSONResponse(
             status_code=400,
-            content={"detail": "The URL contains an invalid user ID. Ensure the user ID segment matches your account identifier."},
+            content={
+                "detail": "The URL contains an invalid user ID. Ensure the user ID segment matches your account identifier."
+            },
         )
 
     # Extract registered server path from request URL. The `user_id` prefix is never part of a
@@ -835,7 +837,9 @@ async def dynamic_mcp_get_proxy(
     if server is None:
         return JSONResponse(
             status_code=404,
-            content={"detail": f"No MCP server is registered at path '{server_path}'. Verify the server path and try again."},
+            content={
+                "detail": f"No MCP server is registered at path '{server_path}'. Verify the server path and try again."
+            },
         )
 
     # Check if server is enabled
@@ -843,12 +847,16 @@ async def dynamic_mcp_get_proxy(
     if not config.get("enabled", False):
         return JSONResponse(
             status_code=404,
-            content={"detail": f"The MCP server at '{server_path}' is currently disabled. Contact the server owner to enable it."},
+            content={
+                "detail": f"The MCP server at '{server_path}' is currently disabled. Contact the server owner to enable it."
+            },
         )
     elif config.get("type", "") != "streamable-http":
         return JSONResponse(
             status_code=404,
-            content={"detail": f"The MCP server at '{server_path}' does not support the streamable-http transport required for direct connections."},
+            content={
+                "detail": f"The MCP server at '{server_path}' does not support the streamable-http transport required for direct connections."
+            },
         )
 
     # Get target URL
@@ -858,7 +866,9 @@ async def dynamic_mcp_get_proxy(
         # GET requests doesn't use JSON-RPC, so use HTTP status code 500.
         return JSONResponse(
             status_code=500,
-            content={"detail": "The MCP server's backend URL is not configured and cannot be reached. Contact the administrator."},
+            content={
+                "detail": "The MCP server's backend URL is not configured and cannot be reached. Contact the administrator."
+            },
         )
 
     # Proxy the request. At this point, auth_context must exist as UserContextDict. Otherwise the UnifiedAuthMiddleware
@@ -908,7 +918,12 @@ async def dynamic_mcp_get_proxy(
     except InternalServerException:
         logger.exception("Internal server exception")
 
-        return JSONResponse(status_code=500, content={"detail": "An internal server error occurred. Please try again or contact support if the problem persists."})
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "An internal server error occurred. Please try again or contact support if the problem persists."
+            },
+        )
 
     body = await request.body()
 
@@ -974,4 +989,9 @@ async def dynamic_mcp_get_proxy(
     except Exception:
         logger.exception(f"Error proxying to {target_url}")
 
-        return JSONResponse(status_code=500, content={"detail": "An internal server error occurred. Please try again or contact support if the problem persists."})
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "An internal server error occurred. Please try again or contact support if the problem persists."
+            },
+        )

--- a/registry/src/registry/api/proxy_routes.py
+++ b/registry/src/registry/api/proxy_routes.py
@@ -243,7 +243,7 @@ async def proxy_to_mcp_server(
 
         user_msg = (
             f"The tokens for the '{exc.server_name}' MCP server managed by Jarvis Registry have expired. "
-            "Please follow the URL to perform re-authorization in a browser window and come back again.",
+            "Please follow the URL to perform re-authorization in a browser window and come back again."
         )
 
         elicitation_id = _get_elicitation_id(exc.auth_url)

--- a/registry/src/registry/api/proxy_routes.py
+++ b/registry/src/registry/api/proxy_routes.py
@@ -370,35 +370,6 @@ async def proxy_to_mcp_server(
         return JSONResponse(status_code=200, content=_build_jsonrpc_error(request_id, -32603, "gateway internal error"))
 
 
-async def extract_server_path_from_request(request_path: str, server_service) -> str | None:
-    """
-    Extract registered server path prefix from request URL.
-
-    Tries progressively shorter path segments until finding a registered server.
-    For example, "/github/repos/list" will check:
-    1. /github/repos/list
-    2. /github/repos
-    3. /github
-
-    Args:
-        request_path: Full incoming request path (e.g., /github/repos/list)
-        server_service: Server service instance
-
-    Returns:
-        Registered server path if found, None otherwise
-    """
-    segments = [s for s in request_path.split("/") if s]
-
-    for i in range(len(segments), 0, -1):
-        candidate_path = "/" + "/".join(segments[:i])
-
-        server = await server_service.get_server_by_path(candidate_path)
-        if server:
-            return candidate_path
-
-    return None
-
-
 @router.delete("/sessions/{server_id}")
 async def clear_session_endpoint(request: Request, server_id: str, user_context: CurrentUser) -> JSONResponse:
     """
@@ -702,7 +673,12 @@ async def dynamic_mcp_post_proxy(
     MCP protocol only uses GET and POST methods.
     """
     if not ObjectId.is_valid(user_id):
-        return JSONResponse(status_code=400, content={"error": f"Invalid user_id: {user_id}"})
+        return JSONResponse(
+            status_code=400,
+            content={
+                "detail": "The URL contains an invalid user ID. Ensure the user ID segment matches your account identifier."
+            },
+        )
 
     msg_body = await _parse_json_rpc_body(request)
     if msg_body is None:
@@ -726,7 +702,7 @@ async def dynamic_mcp_post_proxy(
     # Extract registered server path from request URL. The `user_id` prefix is never part of a
     # registered server path in MongoDB, so only the server's path segment is matched here.
     path = f"/{server_path}"
-    matched_server_path = await extract_server_path_from_request(path, server_service)
+    matched_server_path = await server_service.extract_server_path(path)
     if matched_server_path is None:
         return JSONResponse(
             status_code=200,
@@ -825,7 +801,7 @@ async def dynamic_mcp_get_proxy(
     # Extract registered server path from request URL. The `user_id` prefix is never part of a
     # registered server path in MongoDB, so only the server's path segment is matched here.
     path = f"/{server_path}"
-    matched_server_path = await extract_server_path_from_request(path, server_service)
+    matched_server_path = await server_service.extract_server_path(path)
     if matched_server_path is None:
         return JSONResponse(
             status_code=404,

--- a/registry/src/registry/api/proxy_routes.py
+++ b/registry/src/registry/api/proxy_routes.py
@@ -815,7 +815,10 @@ async def dynamic_mcp_get_proxy(
     MCP protocol only uses GET and POST methods.
     """
     if not ObjectId.is_valid(user_id):
-        return JSONResponse(status_code=400, content={"error": f"Invalid user_id: {user_id}"})
+        return JSONResponse(
+            status_code=400,
+            content={"detail": "The URL contains an invalid user ID. Ensure the user ID segment matches your account identifier."},
+        )
 
     # Extract registered server path from request URL. The `user_id` prefix is never part of a
     # registered server path in MongoDB, so only the server's path segment is matched here.
@@ -824,7 +827,7 @@ async def dynamic_mcp_get_proxy(
     if matched_server_path is None:
         return JSONResponse(
             status_code=404,
-            content={"error": f"Unknown MCP server with path '{path}'."},
+            content={"detail": f"No MCP server is registered at path '{path}'. Verify the server path and try again."},
         )
 
     # Get server by the extracted path
@@ -832,7 +835,7 @@ async def dynamic_mcp_get_proxy(
     if server is None:
         return JSONResponse(
             status_code=404,
-            content={"error": f"Unknown MCP server with path '{server_path}'."},
+            content={"detail": f"No MCP server is registered at path '{server_path}'. Verify the server path and try again."},
         )
 
     # Check if server is enabled
@@ -840,12 +843,12 @@ async def dynamic_mcp_get_proxy(
     if not config.get("enabled", False):
         return JSONResponse(
             status_code=404,
-            content={"error": f"MCP server with path '{server_path}' is disabled."},
+            content={"detail": f"The MCP server at '{server_path}' is currently disabled. Contact the server owner to enable it."},
         )
     elif config.get("type", "") != "streamable-http":
         return JSONResponse(
             status_code=404,
-            content={"error": f"MCP server with path '{server_path}' is not on streamable-http transport."},
+            content={"detail": f"The MCP server at '{server_path}' does not support the streamable-http transport required for direct connections."},
         )
 
     # Get target URL
@@ -854,7 +857,8 @@ async def dynamic_mcp_get_proxy(
     except InternalServerException:
         # GET requests doesn't use JSON-RPC, so use HTTP status code 500.
         return JSONResponse(
-            status_code=500, content={"error": "Server URL is not configured. The MCP server is not reachable."}
+            status_code=500,
+            content={"detail": "The MCP server's backend URL is not configured and cannot be reached. Contact the administrator."},
         )
 
     # Proxy the request. At this point, auth_context must exist as UserContextDict. Otherwise the UnifiedAuthMiddleware
@@ -904,7 +908,7 @@ async def dynamic_mcp_get_proxy(
     except InternalServerException:
         logger.exception("Internal server exception")
 
-        return JSONResponse(status_code=500, content={"error": "internal server error"})
+        return JSONResponse(status_code=500, content={"detail": "An internal server error occurred. Please try again or contact support if the problem persists."})
 
     body = await request.body()
 
@@ -970,4 +974,4 @@ async def dynamic_mcp_get_proxy(
     except Exception:
         logger.exception(f"Error proxying to {target_url}")
 
-        return JSONResponse(status_code=500, content={"error": "internal server error"})
+        return JSONResponse(status_code=500, content={"detail": "An internal server error occurred. Please try again or contact support if the problem persists."})

--- a/registry/src/registry/api/proxy_routes.py
+++ b/registry/src/registry/api/proxy_routes.py
@@ -9,10 +9,10 @@ from uuid import uuid4
 
 import httpx
 from beanie import PydanticObjectId
+from bson import ObjectId
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from fastapi.responses import JSONResponse, RedirectResponse, StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from redis import Redis
-from starlette.routing import get_route_path
 
 from registry_pkgs.models import ResourceType
 from registry_pkgs.models.a2a_agent import AgentConfig
@@ -119,6 +119,12 @@ def _sanitize_hop_by_hop_headers(headers: httpx.Headers) -> dict[str, str]:
     return {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP_HEADERS}
 
 
+# MCP handshake methods that fire before a tool-call context exists. When the downstream MCP
+# server requires authorization, these get an HTTP 401 RFC 9728 discovery challenge instead of a
+# URL mode elicitation, which most MCP clients cannot process at this stage.
+_INIT_METHODS = frozenset({"initialize", "tools/list"})
+
+
 def _build_jsonrpc_error_result(request_id: str | int | None, error_text: str) -> dict[str, Any]:
     """Build JSON-RPC result response with isError=true."""
     return {
@@ -155,6 +161,7 @@ async def proxy_to_mcp_server(
     oauth_service: MCPOAuthService,
     proxy_client: httpx.AsyncClient,
     redis_client: Redis,
+    mcp_method: str | None = None,
 ) -> Response:
     """
     Proxy request to MCP server with auth headers.
@@ -169,6 +176,10 @@ async def proxy_to_mcp_server(
         oauth_service: OAuth service for building auth headers
         proxy_client: Shared httpx client for connection pooling
         redis_client: Redis client for JWT token caching
+        mcp_method: The JSON-RPC method of the proxied MCP request (e.g. "initialize",
+            "tools/list", "tools/call"). Used to decide how to surface a missing downstream
+            authorization: handshake methods get an HTTP 401 RFC 9728 discovery challenge,
+            everything else keeps the existing URL mode elicitation.
     """
     # Build proxy headers - start with request headers
     headers = dict(request.headers)
@@ -196,6 +207,34 @@ async def proxy_to_mcp_server(
             redis_client=redis_client,
         )
     except UrlElicitationRequiredException as exc:
+        # Handshake methods (initialize / tools/list) fire before the client has a tool-call
+        # context, so most MCP clients cannot process a URL mode elicitation here and treat it
+        # as a failed handshake. Instead, return an HTTP 401 with an RFC 9728 resource_metadata
+        # challenge so the client starts standard downstream OAuth discovery (see Change 4/5).
+        if mcp_method in _INIT_METHODS:
+            user_id = request.path_params.get("user_id", "")
+            server_path = request.path_params.get("server_path", "")
+            resource_metadata_url = (
+                f"{settings.jwt_issuer}/.well-known/oauth-protected-resource"
+                f"{settings.service_base_path}/proxy/server/{user_id}/{server_path}"
+            )
+            return JSONResponse(
+                status_code=401,
+                headers={
+                    "WWW-Authenticate": (
+                        f'Bearer realm="{settings.jarvis_realm}", '
+                        f'resource_metadata="{resource_metadata_url}", '
+                        'scope="mcp-proxy-ops"'
+                    ),
+                },
+                content={
+                    "detail": (
+                        f"Downstream MCP server '{exc.server_name}' requires authorization. "
+                        "Complete authorization via the OAuth discovery flow."
+                    )
+                },
+            )
+
         llm_msg = (
             f"In order to make tool calls to the '{exc.server_name}' MCP server, the client must first perform "
             "out-of-band re-authorization in a browser window. Please direct the client to open the provided URL "
@@ -637,10 +676,11 @@ async def http_json_proxy(
         return JSONResponse(status_code=500, content={"error": "Internal server error"})
 
 
-@router.post("/server/{full_path:path}")
+@router.post("/server/{user_id}/{server_path:path}")
 async def dynamic_mcp_post_proxy(
     request: Request,
-    full_path: str,
+    user_id: str,
+    server_path: str,
     auth_context: CurrentUser,
     server_service: ServerServiceV1 = Depends(get_server_service),
     oauth_service: MCPOAuthService = Depends(get_oauth_service),
@@ -651,15 +691,18 @@ async def dynamic_mcp_post_proxy(
     Dynamic catch-all route for MCP server proxying, but only works for POST.
     Enables developers to connect directly to all MCP servers through the registry.
 
+    The URL carries the connecting user's MongoDB ObjectId as `{user_id}`, so the full
+    downstream OAuth discovery chain (protected resource metadata, authorization server
+    metadata, `/authorize`, `/token`) can thread user identity through URLs alone, without
+    any client-side protocol extension.
+
     CRITICAL: This catch-all route matches ANY path pattern, so it must be defined LAST.
     FastAPI matches routes in order, so this will capture all unmatched routes.
 
     MCP protocol only uses GET and POST methods.
     """
-    # If client accidentally tries to connect to our MCP Gateway via the dynamic catch-all route,
-    # respond with a permanent redirect.
-    if get_route_path(request.scope) == "/proxy/server/mcpgw/mcp":
-        return RedirectResponse(f"{settings.registry_url.rstrip('/')}/proxy/mcpgw/mcp", status_code=308)
+    if not ObjectId.is_valid(user_id):
+        return JSONResponse(status_code=400, content={"detail": f"Invalid user_id: {user_id}"})
 
     msg_body = await _parse_json_rpc_body(request)
     if msg_body is None:
@@ -680,10 +723,11 @@ async def dynamic_mcp_post_proxy(
             ),
         )
 
-    # Extract registered server path from request URL
-    path = f"/{full_path}"
-    server_path = await extract_server_path_from_request(path, server_service)
-    if server_path is None:
+    # Extract registered server path from request URL. The `user_id` prefix is never part of a
+    # registered server path in MongoDB, so only the server's path segment is matched here.
+    path = f"/{server_path}"
+    matched_server_path = await extract_server_path_from_request(path, server_service)
+    if matched_server_path is None:
         return JSONResponse(
             status_code=200,
             content=_build_jsonrpc_error_result(
@@ -692,7 +736,7 @@ async def dynamic_mcp_post_proxy(
         )
 
     # Get server by the extracted path
-    server = await server_service.get_server_by_path(server_path)
+    server = await server_service.get_server_by_path(matched_server_path)
     if server is None:
         return JSONResponse(
             status_code=200,
@@ -744,13 +788,15 @@ async def dynamic_mcp_post_proxy(
         oauth_service=oauth_service,
         proxy_client=proxy_client,
         redis_client=redis_client,
+        mcp_method=msg_body.get("method"),
     )
 
 
-@router.get("/server/{full_path:path}")
+@router.get("/server/{user_id}/{server_path:path}")
 async def dynamic_mcp_get_proxy(
     request: Request,
-    full_path: str,
+    user_id: str,
+    server_path: str,
     auth_context: CurrentUser,
     server_service: ServerServiceV1 = Depends(get_server_service),
     oauth_service: MCPOAuthService = Depends(get_oauth_service),
@@ -761,27 +807,28 @@ async def dynamic_mcp_get_proxy(
     Dynamic catch-all route for MCP server proxying, but only works for GET, i.e. the event stream.
     Enables developers to connect directly to all MCP servers through the registry.
 
+    The URL carries the connecting user's MongoDB ObjectId as `{user_id}` (see the POST handler).
+
     CRITICAL: This catch-all route matches ANY path pattern, so it must be defined LAST.
     FastAPI matches routes in order, so this will capture all unmatched routes.
 
     MCP protocol only uses GET and POST methods.
     """
-    # If client accidentally tries to connect to our MCP Gateway via the dynamic catch-all route,
-    # respond with a permanent redirect.
-    if get_route_path(request.scope) == "/proxy/server/mcpgw/mcp":
-        return RedirectResponse(f"{settings.registry_url.rstrip('/')}/proxy/mcpgw/mcp", status_code=308)
+    if not ObjectId.is_valid(user_id):
+        return JSONResponse(status_code=400, content={"error": f"Invalid user_id: {user_id}"})
 
-    # Extract registered server path from request URL
-    path = f"/{full_path}"
-    server_path = await extract_server_path_from_request(path, server_service)
-    if server_path is None:
+    # Extract registered server path from request URL. The `user_id` prefix is never part of a
+    # registered server path in MongoDB, so only the server's path segment is matched here.
+    path = f"/{server_path}"
+    matched_server_path = await extract_server_path_from_request(path, server_service)
+    if matched_server_path is None:
         return JSONResponse(
             status_code=404,
             content={"error": f"Unknown MCP server with path '{path}'."},
         )
 
     # Get server by the extracted path
-    server = await server_service.get_server_by_path(server_path)
+    server = await server_service.get_server_by_path(matched_server_path)
     if server is None:
         return JSONResponse(
             status_code=404,

--- a/registry/src/registry/api/proxy_routes.py
+++ b/registry/src/registry/api/proxy_routes.py
@@ -702,7 +702,7 @@ async def dynamic_mcp_post_proxy(
     MCP protocol only uses GET and POST methods.
     """
     if not ObjectId.is_valid(user_id):
-        return JSONResponse(status_code=400, content={"detail": f"Invalid user_id: {user_id}"})
+        return JSONResponse(status_code=400, content={"error": f"Invalid user_id: {user_id}"})
 
     msg_body = await _parse_json_rpc_body(request)
     if msg_body is None:

--- a/registry/src/registry/api/v1/mcp/oauth_router.py
+++ b/registry/src/registry/api/v1/mcp/oauth_router.py
@@ -1,13 +1,20 @@
+import json
 import logging
 import time
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from fastapi.responses import RedirectResponse
+from authlib.oauth2.rfc7636 import create_s256_code_challenge
+from bson import ObjectId
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, status
+from fastapi.responses import JSONResponse, RedirectResponse
 from mcp.server.session import ServerSession
+from redis import Redis
+
+from registry_pkgs.core.downstream_oauth import downstream_mcp_code_key
 
 from ....auth.dependencies import CurrentUser
+from ....auth.downstream_token import DOWNSTREAM_MCP_TOKEN_TTL_SECONDS, mint_downstream_mcp_token
 from ....auth.oauth.reconnection import OAuthReconnectionManager
 from ....auth.oauth.types import ClientBranding
 from ....core.config import settings
@@ -16,6 +23,7 @@ from ....core.session_store import SessionStore
 from ....deps import (
     get_mcp_service,
     get_reconnection_manager,
+    get_redis_client,
     get_server_service,
     get_session_store,
     get_token_service,
@@ -27,10 +35,12 @@ from ....schemas.common_api_schemas import (
     OAuthTokensResponse,
 )
 from ....schemas.enums import ConnectionState, OAuthFlowStatus
+from ....schemas.oauth_schema import MCPClientContext, OAuthFlow
 from ....services.oauth.mcp_service import MCPService
 from ....services.oauth.token_service import TokenService
 from ....services.server_service import ServerServiceV1
 from ....utils.schema_converter import convert_dict_keys_to_camel
+from ...proxy_routes import extract_server_path_from_request
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +49,7 @@ router = APIRouter(prefix="/mcp", tags=["oauth"])
 
 @router.get("/oauth/discover", response_model=OAuthMetadataDiscoverResponse, response_model_by_alias=True)
 async def discover_oauth_metadata(
-    url: str = Query(..., description="MCP server URL to discover OAuth metadata from"),
+        url: str = Query(..., description="MCP server URL to discover OAuth metadata from"),
 ) -> OAuthMetadataDiscoverResponse:
     """
     Discover OAuth metadata from MCP server's well-known endpoints.
@@ -112,10 +122,10 @@ async def discover_oauth_metadata(
 
 @router.get("/{server_id}/oauth/initiate", response_model=OAuthInitiateResponse, response_model_by_alias=True)
 async def initiate_oauth_flow(
-    server_id: str,
-    user_context: CurrentUser,
-    mcp_service: MCPService = Depends(get_mcp_service),
-    server_service: ServerServiceV1 = Depends(get_server_service),
+        server_id: str,
+        user_context: CurrentUser,
+        mcp_service: MCPService = Depends(get_mcp_service),
+        server_service: ServerServiceV1 = Depends(get_server_service),
 ) -> OAuthInitiateResponse:
     """
     Initialize OAuth flow
@@ -156,16 +166,117 @@ async def initiate_oauth_flow(
         )
 
 
+async def _reconnect_after_oauth(
+    mcp_service: MCPService,
+    reconnection_manager: OAuthReconnectionManager,
+    flow: OAuthFlow | None,
+    server_path: str,
+) -> None:
+    """Best-effort: mark the user's connection CONNECTED and clear reconnection attempts.
+
+    Failures here never block the callback redirect — the tokens are already saved.
+    """
+    if not (flow and flow.user_id):
+        return
+    user_id, server_id = flow.user_id, flow.server_id
+    try:
+        await mcp_service.connection_service.create_user_connection(
+            user_id=user_id,
+            server_id=server_id,
+            initial_state=ConnectionState.CONNECTED,
+            details={"oauth_completed": True, "flow_id": flow.flow_id, "created_at": time.time()},
+        )
+        logger.info(f"[MCP OAuth] Reconnected {server_path} (server_id: {server_id}) for user {user_id}")
+        try:
+            reconnection_manager.clear_reconnection(user_id, server_id)
+        except Exception as e:
+            logger.error(f"[MCP OAuth] Could not clear reconnection (manager not initialized): {e}")
+    except Exception as e:
+        logger.error(f"[MCP OAuth] Failed to reconnect {server_path} after OAuth, but tokens are saved: {e}")
+
+
+async def _notify_elicitation_complete(
+    state_dict: dict[str, Any],
+    session_store: SessionStore,
+) -> ClientBranding | None:
+    """Best-effort ``elicitation/complete`` notification for mcpgw-initiated flows.
+
+    Returns the client branding carried in the flow state (used to deep-link the user back to their
+    AI app), or None. Never raises.
+    """
+    meta = state_dict.get("meta")
+    if not meta or "elicitation_id" not in meta:
+        return None
+
+    client_branding: ClientBranding | None = meta.get("client_branding")
+    try:
+        elicitation_id = meta["elicitation_id"]
+        if not meta["notify_elicitation_complete"]:
+            # Client connected via the dynamic catch-all route; no live session to notify.
+            logger.info("MCP client connected via dynamic catch-all route. Not sending elicitation/complete.")
+            return client_branding
+
+        session: ServerSession | None = session_store.pop(elicitation_id)
+        if session is None:
+            logger.warning(f"could not find session object for elicitation_id {elicitation_id}")
+            return client_branding
+
+        await session.send_elicit_complete(elicitation_id)
+        logger.info(f"scheduled elicitation/complete notification for elicitation_id {elicitation_id}")
+    except Exception:
+        logger.exception("failed to send elicitation/complete notification to client.")
+    return client_branding
+
+
+def _build_downstream_client_redirect(
+    flow: OAuthFlow | None,
+    code: str,
+    redis_client: Redis,
+) -> RedirectResponse | None:
+    """For an MCP-client-initiated (Layer B) flow, stash the PKCE/binding context and build the
+    redirect back to the client's ``redirect_uri``. Returns None for registry-frontend flows.
+
+    The confirmation token is NOT minted here — it is minted fresh at ``/token`` exchange time so its
+    short TTL is not eaten by any delay before the exchange (AS-1545 review #2).
+
+    NOTE (AS-1545 review, deferred): ``code`` is the upstream provider's authorization code, reused
+    verbatim as the Layer B code / Redis key. Minting a distinct Layer B code is tracked separately.
+    """
+    ctx = flow.metadata.mcp_client_context if (flow and flow.metadata) else None
+    if ctx is None or not (flow and flow.user_id):
+        return None
+
+    # Synchronous redis client (see note in the /token handler): assign to `_` to avoid the
+    # redis-py dual-typed "unused coroutine" false positive; .setex returns a bool, not a coroutine.
+    _ = redis_client.setex(
+        downstream_mcp_code_key(code),
+        _DOWNSTREAM_CODE_TTL_SECONDS,
+        json.dumps(
+            {
+                "code_challenge": ctx["code_challenge"],
+                "client_id": ctx["client_id"],
+                "redirect_uri": ctx["redirect_uri"],
+                # Bound at /token time against the request URL to stop a code minted for one
+                # user/server being redeemed under another's token endpoint.
+                "user_id": flow.user_id,
+                "server_path": ctx["server_path"],
+            }
+        ),
+    )
+    return RedirectResponse(url=_append_query_params(ctx["redirect_uri"], code=code, state=ctx["state"]))
+
+
 @router.get("/{server_path}/oauth/callback")
 async def oauth_callback(
-    server_path: str,
-    request: Request,
-    code: str | None = Query(None, description="OAuth authorization code"),
-    state: str | None = Query(None, description="State parameter (format: flow_id##security_token)"),
-    error: str | None = Query(None, description="OAuth error message"),
-    mcp_service: MCPService = Depends(get_mcp_service),
-    reconnection_manager: OAuthReconnectionManager = Depends(get_reconnection_manager),
-    session_store: SessionStore = Depends(get_session_store),
+        server_path: str,
+        request: Request,
+        code: str | None = Query(None, description="OAuth authorization code"),
+        state: str | None = Query(None, description="State parameter (format: flow_id##security_token)"),
+        error: str | None = Query(None, description="OAuth error message"),
+        mcp_service: MCPService = Depends(get_mcp_service),
+        reconnection_manager: OAuthReconnectionManager = Depends(get_reconnection_manager),
+        session_store: SessionStore = Depends(get_session_store),
+        redis_client: Redis = Depends(get_redis_client),
 ) -> RedirectResponse:
     """
     OAuth callback handler
@@ -180,116 +291,54 @@ async def oauth_callback(
     5. Redirect to success/failure page
     """
     try:
-        # 1. Check for errors returned by OAuth provider
+        # 1. Provider returned an error, or required params are missing.
         if error:
             logger.error(f"[MCP OAuth] OAuth error received from provider: {error}")
             return _redirect_to_page(request, server_path, error_msg=error)
-
-        # 2. Validate required parameters
         if not code or not isinstance(code, str):
             logger.error("[MCP OAuth] Missing or invalid authorization code")
             return _redirect_to_page(request, server_path, error_msg="missing_code")
-
         if not state or not isinstance(state, str):
             logger.error("[MCP OAuth] Missing or invalid state parameter")
             return _redirect_to_page(request, server_path, error_msg="missing_state")
 
-        # 3. Decode flow_id from state
+        # 2. Decode flow_id from state.
         try:
             state_dict = mcp_service.oauth_service.flow_manager.decode_state(state)
-            flow_id, security_token = state_dict["flow_id"], state_dict["security_token"]
-            logger.info(
-                f"[MCP OAuth] Callback received: server={server_path}, "
-                f"flow_id={flow_id}, code={'present' if code else 'missing'}, "
-                f"security_token_length={len(security_token)}"
-            )
+            flow_id = state_dict["flow_id"]
         except ValueError as e:
             logger.error(f"[MCP OAuth] Failed to decode state: {e}")
             return _redirect_to_page(request, server_path, error_msg="invalid_state_format")
+        logger.info(f"[MCP OAuth] Callback received: server={server_path}, flow_id={flow_id}")
 
-        # Check if flow is already completed
+        # 3. Short-circuit a duplicate callback for an already-completed flow.
         flow = mcp_service.oauth_service.flow_manager.get_flow(flow_id)
         if flow and flow.status == OAuthFlowStatus.COMPLETED:
             logger.warning(f"[MCP OAuth] Flow already completed, preventing duplicate token exchange: {flow_id}")
             return _redirect_to_page(request, server_path, flag="success")
 
-        # 4. Complete OAuth flow (validate state + exchange tokens)
-        logger.debug(f"[MCP OAuth] Completing OAuth flow for {server_path}")
+        # 4. Complete the flow (validate state + exchange tokens for downstream MCP tokens).
         success, error_msg = await mcp_service.oauth_service.complete_oauth_flow(
             flow_id=flow_id, authorization_code=code, state=state
         )
-
         if not success:
             logger.error(f"[MCP OAuth] Failed to complete OAuth flow: {error_msg}")
             return _redirect_to_page(request, server_path, error_msg=error_msg or "unknown_error")
-
         logger.info(f"[MCP OAuth] OAuth flow completed successfully for {server_path}")
 
-        # 5. Create user connection and setup server
-        try:
-            # Get user_id and server_id from flow
-            flow = mcp_service.oauth_service.flow_manager.get_flow(flow_id)
-            if flow and flow.user_id:
-                user_id = flow.user_id
-                server_id = flow.server_id  # Extract server_id from flow
-                logger.debug(
-                    f"[MCP OAuth] Attempting to reconnect {server_path} (server_id: {server_id}) with new OAuth tokens"
-                )
+        flow = mcp_service.oauth_service.flow_manager.get_flow(flow_id)
 
-                # Create user connection with CONNECTED state
-                await mcp_service.connection_service.create_user_connection(
-                    user_id=user_id,
-                    server_id=server_id,  # Use server_id instead of server_name
-                    initial_state=ConnectionState.CONNECTED,
-                    details={"oauth_completed": True, "flow_id": flow_id, "created_at": time.time()},
-                )
-                logger.info(
-                    f"[MCP OAuth] Successfully reconnected {server_path} (server_id: {server_id}) for user {user_id}"
-                )
+        # 5. Best-effort post-completion side effects (never block the redirect).
+        await _reconnect_after_oauth(mcp_service, reconnection_manager, flow, server_path)
+        client_branding = await _notify_elicitation_complete(state_dict, session_store)
 
-                # Clear any reconnection attempts
-                try:
-                    reconnection_manager.clear_reconnection(user_id, server_id)  # Use server_id instead of server_name
-                    logger.debug(
-                        f"[MCP OAuth] Cleared reconnection attempts for {server_path} (server_id: {server_id})"
-                    )
-                except Exception as e:
-                    logger.error(f"[MCP OAuth] Could not clear reconnection (manager not initialized): {e}")
+        # 6. MCP-client-initiated (Layer B) flows redirect back to the client; otherwise show the
+        # registry success page.
+        downstream_redirect = _build_downstream_client_redirect(flow, code, redis_client)
+        if downstream_redirect is not None:
+            logger.info(f"[MCP OAuth] Downstream MCP-client flow complete for {server_path}; redirecting to client")
+            return downstream_redirect
 
-                logger.debug(f"[MCP OAuth] User connection created for {server_path}")
-
-        except Exception as error:
-            logger.error(f"[MCP OAuth] Failed to reconnect {server_path} after OAuth, but tokens are saved: {error}")
-
-        # 6. If the flow started from an URL mode elicitation by mcpgw, make a best-effort notification to client.
-        client_branding: ClientBranding | None = None
-        try:
-            if "meta" in state_dict and "elicitation_id" in state_dict["meta"]:
-                client_branding = state_dict["meta"].get("client_branding", None)
-
-                elicitation_id = state_dict["meta"]["elicitation_id"]
-
-                session: ServerSession | None = None
-
-                if state_dict["meta"]["notify_elicitation_complete"]:
-                    session = session_store.pop(elicitation_id)
-
-                if session is not None:
-                    await session.send_elicit_complete(elicitation_id)
-
-                    logger.info(
-                        f"successfully scheduled sending elicitation/complete notification for elicitation_id {elicitation_id}"
-                    )
-                elif not state_dict["meta"]["notify_elicitation_complete"]:
-                    logger.info(
-                        "MCP client connected via dynamic catch-all route. Not sending elicitation/complete notification."
-                    )
-                else:
-                    logger.warning(f"could not find session object for elicitation_id {elicitation_id}")
-        except Exception:
-            logger.exception("failed to send elicitation/complete notification to client.")
-
-        # 7. Redirect to success page
         return _redirect_to_page(request, server_path, flag="success", client_branding=client_branding)
 
     except Exception as e:
@@ -299,7 +348,8 @@ async def oauth_callback(
 
 @router.get("/oauth/tokens/{flow_id}", response_model=OAuthTokensResponse, response_model_by_alias=True)
 async def get_oauth_tokens(
-    flow_id: str, current_user: CurrentUser, mcp_service: MCPService = Depends(get_mcp_service)
+        flow_id: str, current_user: CurrentUser,
+        mcp_service: MCPService = Depends(get_mcp_service)
 ) -> OAuthTokensResponse:
     """
     Get OAuth tokens
@@ -360,10 +410,10 @@ async def get_oauth_status(flow_id: str, mcp_service: MCPService = Depends(get_m
 
 @router.post("/oauth/cancel/{server_id}", response_model=OAuthOperationResponse, response_model_by_alias=True)
 async def cancel_oauth_flow(
-    server_id: str,
-    current_user: CurrentUser,
-    mcp_service: MCPService = Depends(get_mcp_service),
-    server_service: ServerServiceV1 = Depends(get_server_service),
+        server_id: str,
+        current_user: CurrentUser,
+        mcp_service: MCPService = Depends(get_mcp_service),
+        server_service: ServerServiceV1 = Depends(get_server_service),
 ) -> OAuthOperationResponse:
     """
     Cancel OAuth flow
@@ -421,11 +471,11 @@ async def cancel_oauth_flow(
 
 @router.post("/oauth/refresh/{server_id}", response_model=OAuthOperationResponse, response_model_by_alias=True)
 async def refresh_oauth_tokens(
-    server_id: str,
-    current_user: CurrentUser,
-    mcp_service: MCPService = Depends(get_mcp_service),
-    server_service: ServerServiceV1 = Depends(get_server_service),
-    reconnection_manager: OAuthReconnectionManager = Depends(get_reconnection_manager),
+        server_id: str,
+        current_user: CurrentUser,
+        mcp_service: MCPService = Depends(get_mcp_service),
+        server_service: ServerServiceV1 = Depends(get_server_service),
+        reconnection_manager: OAuthReconnectionManager = Depends(get_reconnection_manager),
 ) -> OAuthOperationResponse:
     """
     Refresh OAuth tokens
@@ -503,11 +553,11 @@ async def refresh_oauth_tokens(
 
 @router.delete("/oauth/token/{server_id}", response_model=OAuthOperationResponse, response_model_by_alias=True)
 async def delete_oauth_tokens(
-    server_id: str,
-    current_user: CurrentUser,
-    mcp_service: MCPService = Depends(get_mcp_service),
-    server_service: ServerServiceV1 = Depends(get_server_service),
-    token_service: TokenService = Depends(get_token_service),
+        server_id: str,
+        current_user: CurrentUser,
+        mcp_service: MCPService = Depends(get_mcp_service),
+        server_service: ServerServiceV1 = Depends(get_server_service),
+        token_service: TokenService = Depends(get_token_service),
 ) -> OAuthOperationResponse:
     """
     Delete the OAuth token for this user
@@ -537,16 +587,142 @@ async def delete_oauth_tokens(
         )
 
 
+_DOWNSTREAM_CODE_TTL_SECONDS = 600
+
+
+def _append_query_params(url: str, **params: str) -> str:
+    """Append query params to a URL, preserving any query string it already carries."""
+    parts = urlsplit(url)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query.update(params)
+    return str(urlunsplit(parts._replace(query=urlencode(query))))
+
+
+@router.get("/downstream/oauth/authorize/{user_id}/{server_path:path}")
+async def downstream_oauth_authorize(
+        user_id: str,
+        server_path: str,
+        response_type: str = Query("code"),
+        client_id: str = Query(...),
+        redirect_uri: str = Query(...),
+        code_challenge: str = Query(...),
+        code_challenge_method: str = Query("S256"),
+        state: str = Query(""),
+        mcp_service: MCPService = Depends(get_mcp_service),
+        server_service: ServerServiceV1 = Depends(get_server_service),
+) -> RedirectResponse:
+    """Per-server downstream OAuth authorization endpoint (Layer B: registry-as-AS).
+
+    Called by an MCP client (via browser redirect) after it discovers this endpoint through the
+    RFC 8414 authorization-server metadata. No registry Bearer token is required — OAuth
+    authorization endpoints are reached without one. Captures the client's PKCE/redirect context,
+    kicks off the Layer A flow against the upstream provider, and 302-redirects the browser there.
+    """
+    if not ObjectId.is_valid(user_id):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid user_id: {user_id}")
+
+    # Resolve the registered server by prefix (same as the proxy), so a sub-path the client appends
+    # still finds its server. The confirmation token binds to the raw URL `server_path`, not the
+    # registered prefix, so mint and verify agree on whatever path the client actually uses.
+    registered_path = await extract_server_path_from_request(f"/{server_path}", server_service)
+    server = await server_service.get_server_by_path(registered_path) if registered_path else None
+    if not server:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Server not found for path '{server_path}'")
+
+    ctx: MCPClientContext = {
+        "redirect_uri": redirect_uri,
+        "client_id": client_id,
+        "code_challenge": code_challenge,
+        "state": state,
+        "server_path": server_path,
+    }
+
+    flow_id, auth_url, error = await mcp_service.oauth_service.initiate_oauth_flow(
+        user_id=user_id, server=server, mcp_client_context=ctx
+    )
+    if error or not auth_url:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=error or "Failed to initiate downstream OAuth flow",
+        )
+
+    logger.info(f"[Downstream OAuth] authorize: user={user_id} server={server_path} flow={flow_id}")
+    return RedirectResponse(url=auth_url)
+
+
+@router.post("/downstream/oauth/token/{user_id}/{server_path:path}")
+async def downstream_oauth_token(
+        user_id: str,
+        server_path: str,
+        grant_type: str = Form(...),
+        code: str = Form(...),
+        client_id: str = Form(...),
+        code_verifier: str = Form(...),
+        redirect_uri: str = Form(""),
+        redis_client: Redis = Depends(get_redis_client),
+) -> JSONResponse:
+    """Per-server downstream OAuth token endpoint (Layer B: registry-as-AS).
+
+    Exchanges the Layer B authorization code (issued by the callback) plus the PKCE verifier for
+    the downstream confirmation token. No registry Bearer token is required.
+    """
+    if grant_type != "authorization_code":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="unsupported grant_type")
+
+    raw = redis_client.get(downstream_mcp_code_key(code))
+    if not raw:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid or expired code")
+
+    try:
+        entry = json.loads(raw)
+        stored_challenge = entry["code_challenge"]
+        stored_client_id = entry["client_id"]
+        bound_user_id = entry["user_id"]
+        bound_server_path = entry["server_path"]
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        logger.error(f"[Downstream OAuth] corrupt code entry for code exchange: {e}")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid or expired code")
+
+    if create_s256_code_challenge(code_verifier) != stored_challenge:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="PKCE verification failed")
+
+    if client_id != stored_client_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="client_id mismatch")
+
+    # Bind the code to the (user_id, server_path) it was issued for, so a leaked code cannot be
+    # redeemed under a different token endpoint URL.
+    if user_id != bound_user_id or server_path != bound_server_path:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="code does not match this endpoint")
+
+    # One-time use: drop the code so it cannot be replayed. The redis client is synchronous
+    _ = redis_client.delete(downstream_mcp_code_key(code))
+
+    # Mint the confirmation token now (not at callback time) so its TTL starts at exchange.
+    confirmation_token = mint_downstream_mcp_token(
+        settings.jwt_token_config, user_id=bound_user_id, server_path=bound_server_path
+    )
+
+    logger.info(f"[Downstream OAuth] token issued: user={user_id} server={server_path}")
+    return JSONResponse(
+        status_code=200,
+        content={
+            "access_token": confirmation_token,
+            "token_type": "Bearer",
+            "expires_in": DOWNSTREAM_MCP_TOKEN_TTL_SECONDS,
+        },
+    )
+
+
 # ==================== Helper Functions ====================
 
 
 def _redirect_to_page(
-    request: Request,
-    server_path: str,
-    flag: str = "error",
-    error_msg: str | None = None,
-    *,
-    client_branding: ClientBranding | None = None,
+        request: Request,
+        server_path: str,
+        flag: str = "error",
+        error_msg: str | None = None,
+        *,
+        client_branding: ClientBranding | None = None,
 ) -> RedirectResponse:
     """
     Generate a response that redirects to frontend OAuth callback page.

--- a/registry/src/registry/api/v1/mcp/oauth_router.py
+++ b/registry/src/registry/api/v1/mcp/oauth_router.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import secrets
 import time
 from typing import Any
 from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
@@ -49,7 +50,7 @@ router = APIRouter(prefix="/mcp", tags=["oauth"])
 
 @router.get("/oauth/discover", response_model=OAuthMetadataDiscoverResponse, response_model_by_alias=True)
 async def discover_oauth_metadata(
-        url: str = Query(..., description="MCP server URL to discover OAuth metadata from"),
+    url: str = Query(..., description="MCP server URL to discover OAuth metadata from"),
 ) -> OAuthMetadataDiscoverResponse:
     """
     Discover OAuth metadata from MCP server's well-known endpoints.
@@ -122,10 +123,10 @@ async def discover_oauth_metadata(
 
 @router.get("/{server_id}/oauth/initiate", response_model=OAuthInitiateResponse, response_model_by_alias=True)
 async def initiate_oauth_flow(
-        server_id: str,
-        user_context: CurrentUser,
-        mcp_service: MCPService = Depends(get_mcp_service),
-        server_service: ServerServiceV1 = Depends(get_server_service),
+    server_id: str,
+    user_context: CurrentUser,
+    mcp_service: MCPService = Depends(get_mcp_service),
+    server_service: ServerServiceV1 = Depends(get_server_service),
 ) -> OAuthInitiateResponse:
     """
     Initialize OAuth flow
@@ -230,7 +231,6 @@ async def _notify_elicitation_complete(
 
 def _build_downstream_client_redirect(
     flow: OAuthFlow | None,
-    code: str,
     redis_client: Redis,
 ) -> RedirectResponse | None:
     """For an MCP-client-initiated (Layer B) flow, stash the PKCE/binding context and build the
@@ -239,44 +239,40 @@ def _build_downstream_client_redirect(
     The confirmation token is NOT minted here — it is minted fresh at ``/token`` exchange time so its
     short TTL is not eaten by any delay before the exchange (AS-1545 review #2).
 
-    NOTE (AS-1545 review, deferred): ``code`` is the upstream provider's authorization code, reused
-    verbatim as the Layer B code / Redis key. Minting a distinct Layer B code is tracked separately.
     """
     ctx = flow.metadata.mcp_client_context if (flow and flow.metadata) else None
     if ctx is None or not (flow and flow.user_id):
         return None
 
-    # Synchronous redis client (see note in the /token handler): assign to `_` to avoid the
-    # redis-py dual-typed "unused coroutine" false positive; .setex returns a bool, not a coroutine.
+    b_code = secrets.token_urlsafe(32)
+
     _ = redis_client.setex(
-        downstream_mcp_code_key(code),
+        downstream_mcp_code_key(b_code),
         _DOWNSTREAM_CODE_TTL_SECONDS,
         json.dumps(
             {
                 "code_challenge": ctx["code_challenge"],
                 "client_id": ctx["client_id"],
                 "redirect_uri": ctx["redirect_uri"],
-                # Bound at /token time against the request URL to stop a code minted for one
-                # user/server being redeemed under another's token endpoint.
                 "user_id": flow.user_id,
                 "server_path": ctx["server_path"],
             }
         ),
     )
-    return RedirectResponse(url=_append_query_params(ctx["redirect_uri"], code=code, state=ctx["state"]))
+    return RedirectResponse(url=_append_query_params(ctx["redirect_uri"], code=b_code, state=ctx["state"]))
 
 
 @router.get("/{server_path}/oauth/callback")
 async def oauth_callback(
-        server_path: str,
-        request: Request,
-        code: str | None = Query(None, description="OAuth authorization code"),
-        state: str | None = Query(None, description="State parameter (format: flow_id##security_token)"),
-        error: str | None = Query(None, description="OAuth error message"),
-        mcp_service: MCPService = Depends(get_mcp_service),
-        reconnection_manager: OAuthReconnectionManager = Depends(get_reconnection_manager),
-        session_store: SessionStore = Depends(get_session_store),
-        redis_client: Redis = Depends(get_redis_client),
+    server_path: str,
+    request: Request,
+    code: str | None = Query(None, description="OAuth authorization code"),
+    state: str | None = Query(None, description="State parameter (format: flow_id##security_token)"),
+    error: str | None = Query(None, description="OAuth error message"),
+    mcp_service: MCPService = Depends(get_mcp_service),
+    reconnection_manager: OAuthReconnectionManager = Depends(get_reconnection_manager),
+    session_store: SessionStore = Depends(get_session_store),
+    redis_client: Redis = Depends(get_redis_client),
 ) -> RedirectResponse:
     """
     OAuth callback handler
@@ -332,9 +328,8 @@ async def oauth_callback(
         await _reconnect_after_oauth(mcp_service, reconnection_manager, flow, server_path)
         client_branding = await _notify_elicitation_complete(state_dict, session_store)
 
-        # 6. MCP-client-initiated (Layer B) flows redirect back to the client; otherwise show the
-        # registry success page.
-        downstream_redirect = _build_downstream_client_redirect(flow, code, redis_client)
+        # 6. MCP-client-initiated flows redirect back to the client;
+        downstream_redirect = _build_downstream_client_redirect(flow, redis_client)
         if downstream_redirect is not None:
             logger.info(f"[MCP OAuth] Downstream MCP-client flow complete for {server_path}; redirecting to client")
             return downstream_redirect
@@ -348,8 +343,7 @@ async def oauth_callback(
 
 @router.get("/oauth/tokens/{flow_id}", response_model=OAuthTokensResponse, response_model_by_alias=True)
 async def get_oauth_tokens(
-        flow_id: str, current_user: CurrentUser,
-        mcp_service: MCPService = Depends(get_mcp_service)
+    flow_id: str, current_user: CurrentUser, mcp_service: MCPService = Depends(get_mcp_service)
 ) -> OAuthTokensResponse:
     """
     Get OAuth tokens
@@ -410,10 +404,10 @@ async def get_oauth_status(flow_id: str, mcp_service: MCPService = Depends(get_m
 
 @router.post("/oauth/cancel/{server_id}", response_model=OAuthOperationResponse, response_model_by_alias=True)
 async def cancel_oauth_flow(
-        server_id: str,
-        current_user: CurrentUser,
-        mcp_service: MCPService = Depends(get_mcp_service),
-        server_service: ServerServiceV1 = Depends(get_server_service),
+    server_id: str,
+    current_user: CurrentUser,
+    mcp_service: MCPService = Depends(get_mcp_service),
+    server_service: ServerServiceV1 = Depends(get_server_service),
 ) -> OAuthOperationResponse:
     """
     Cancel OAuth flow
@@ -426,7 +420,7 @@ async def cancel_oauth_flow(
     2. Update user connection state to DISCONNECTED
     """
     try:
-        user_id = current_user.get("user_id")
+        user_id = str(current_user.get("user_id"))
         logger.info(f"[OAuth Cancel] Cancelling OAuth flow for {server_id} by user {user_id}")
 
         mcp_server = await server_service.get_server_by_id(server_id)
@@ -471,11 +465,11 @@ async def cancel_oauth_flow(
 
 @router.post("/oauth/refresh/{server_id}", response_model=OAuthOperationResponse, response_model_by_alias=True)
 async def refresh_oauth_tokens(
-        server_id: str,
-        current_user: CurrentUser,
-        mcp_service: MCPService = Depends(get_mcp_service),
-        server_service: ServerServiceV1 = Depends(get_server_service),
-        reconnection_manager: OAuthReconnectionManager = Depends(get_reconnection_manager),
+    server_id: str,
+    current_user: CurrentUser,
+    mcp_service: MCPService = Depends(get_mcp_service),
+    server_service: ServerServiceV1 = Depends(get_server_service),
+    reconnection_manager: OAuthReconnectionManager = Depends(get_reconnection_manager),
 ) -> OAuthOperationResponse:
     """
     Refresh OAuth tokens
@@ -489,7 +483,7 @@ async def refresh_oauth_tokens(
     3. Clear any reconnection attempts
     """
     try:
-        user_id = current_user.get("user_id")
+        user_id = str(current_user.get("user_id"))
         logger.info(f"[OAuth Refresh] Refreshing OAuth tokens for {server_id} by user {user_id}")
         mcp_server = await server_service.get_server_by_id(server_id)
         if not mcp_server:
@@ -553,11 +547,11 @@ async def refresh_oauth_tokens(
 
 @router.delete("/oauth/token/{server_id}", response_model=OAuthOperationResponse, response_model_by_alias=True)
 async def delete_oauth_tokens(
-        server_id: str,
-        current_user: CurrentUser,
-        mcp_service: MCPService = Depends(get_mcp_service),
-        server_service: ServerServiceV1 = Depends(get_server_service),
-        token_service: TokenService = Depends(get_token_service),
+    server_id: str,
+    current_user: CurrentUser,
+    mcp_service: MCPService = Depends(get_mcp_service),
+    server_service: ServerServiceV1 = Depends(get_server_service),
+    token_service: TokenService = Depends(get_token_service),
 ) -> OAuthOperationResponse:
     """
     Delete the OAuth token for this user
@@ -566,7 +560,7 @@ async def delete_oauth_tokens(
     server = await server_service.get_server_by_id(server_id)
     if not server:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Server not found")
-    user_id = current_user.get("user_id")
+    user_id = str(current_user.get("user_id"))
     try:
         disconnected = await mcp_service.connection_service.disconnect_user_connection(user_id, server_id)
         if disconnected:
@@ -600,26 +594,31 @@ def _append_query_params(url: str, **params: str) -> str:
 
 @router.get("/downstream/oauth/authorize/{user_id}/{server_path:path}")
 async def downstream_oauth_authorize(
-        user_id: str,
-        server_path: str,
-        response_type: str = Query("code"),
-        client_id: str = Query(...),
-        redirect_uri: str = Query(...),
-        code_challenge: str = Query(...),
-        code_challenge_method: str = Query("S256"),
-        state: str = Query(""),
-        mcp_service: MCPService = Depends(get_mcp_service),
-        server_service: ServerServiceV1 = Depends(get_server_service),
+    user_id: str,
+    server_path: str,
+    user_context: CurrentUser,
+    response_type: str = Query("code"),
+    client_id: str = Query(...),
+    redirect_uri: str = Query(...),
+    code_challenge: str = Query(...),
+    code_challenge_method: str = Query("S256"),
+    state: str = Query(""),
+    mcp_service: MCPService = Depends(get_mcp_service),
+    server_service: ServerServiceV1 = Depends(get_server_service),
 ) -> RedirectResponse:
     """Per-server downstream OAuth authorization endpoint (Layer B: registry-as-AS).
 
-    Called by an MCP client (via browser redirect) after it discovers this endpoint through the
-    RFC 8414 authorization-server metadata. No registry Bearer token is required — OAuth
-    authorization endpoints are reached without one. Captures the client's PKCE/redirect context,
-    kicks off the Layer A flow against the upstream provider, and 302-redirects the browser there.
+    Captures the client's PKCE/redirect context, kicks off the Layer A flow against the upstream
+    provider, and 302-redirects the browser there.
     """
     if not ObjectId.is_valid(user_id):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid user_id: {user_id}")
+
+    if user_context["user_id"] != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="user_id does not match the authenticated session",
+        )
 
     # Resolve the registered server by prefix (same as the proxy), so a sub-path the client appends
     # still finds its server. The confirmation token binds to the raw URL `server_path`, not the
@@ -652,14 +651,14 @@ async def downstream_oauth_authorize(
 
 @router.post("/downstream/oauth/token/{user_id}/{server_path:path}")
 async def downstream_oauth_token(
-        user_id: str,
-        server_path: str,
-        grant_type: str = Form(...),
-        code: str = Form(...),
-        client_id: str = Form(...),
-        code_verifier: str = Form(...),
-        redirect_uri: str = Form(""),
-        redis_client: Redis = Depends(get_redis_client),
+    user_id: str,
+    server_path: str,
+    grant_type: str = Form(...),
+    code: str = Form(...),
+    client_id: str = Form(...),
+    code_verifier: str = Form(...),
+    redirect_uri: str = Form(""),
+    redis_client: Redis = Depends(get_redis_client),
 ) -> JSONResponse:
     """Per-server downstream OAuth token endpoint (Layer B: registry-as-AS).
 
@@ -677,6 +676,7 @@ async def downstream_oauth_token(
         entry = json.loads(raw)
         stored_challenge = entry["code_challenge"]
         stored_client_id = entry["client_id"]
+        stored_redirect_uri = entry["redirect_uri"]
         bound_user_id = entry["user_id"]
         bound_server_path = entry["server_path"]
     except (json.JSONDecodeError, KeyError, TypeError) as e:
@@ -689,15 +689,16 @@ async def downstream_oauth_token(
     if client_id != stored_client_id:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="client_id mismatch")
 
+    if redirect_uri != stored_redirect_uri:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="redirect_uri mismatch")
+
     # Bind the code to the (user_id, server_path) it was issued for, so a leaked code cannot be
     # redeemed under a different token endpoint URL.
     if user_id != bound_user_id or server_path != bound_server_path:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="code does not match this endpoint")
 
-    # One-time use: drop the code so it cannot be replayed. The redis client is synchronous
     _ = redis_client.delete(downstream_mcp_code_key(code))
 
-    # Mint the confirmation token now (not at callback time) so its TTL starts at exchange.
     confirmation_token = mint_downstream_mcp_token(
         settings.jwt_token_config, user_id=bound_user_id, server_path=bound_server_path
     )
@@ -717,12 +718,12 @@ async def downstream_oauth_token(
 
 
 def _redirect_to_page(
-        request: Request,
-        server_path: str,
-        flag: str = "error",
-        error_msg: str | None = None,
-        *,
-        client_branding: ClientBranding | None = None,
+    request: Request,
+    server_path: str,
+    flag: str = "error",
+    error_msg: str | None = None,
+    *,
+    client_branding: ClientBranding | None = None,
 ) -> RedirectResponse:
     """
     Generate a response that redirects to frontend OAuth callback page.

--- a/registry/src/registry/api/v1/mcp/oauth_router.py
+++ b/registry/src/registry/api/v1/mcp/oauth_router.py
@@ -42,7 +42,6 @@ from ....services.oauth.mcp_service import MCPService
 from ....services.oauth.token_service import TokenService
 from ....services.server_service import ServerServiceV1
 from ....utils.schema_converter import convert_dict_keys_to_camel
-from ...proxy_routes import extract_server_path_from_request
 
 logger = logging.getLogger(__name__)
 
@@ -656,7 +655,7 @@ async def downstream_oauth_authorize(
     # Resolve the registered server by prefix (same as the proxy), so a sub-path the client appends
     # still finds its server. The confirmation token binds to the raw URL `server_path`, not the
     # registered prefix, so mint and verify agree on whatever path the client actually uses.
-    registered_path = await extract_server_path_from_request(f"/{server_path}", server_service)
+    registered_path = await server_service.extract_server_path(f"/{server_path}")
     server = await server_service.get_server_by_path(registered_path) if registered_path else None
     if not server:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Server not found for path '{server_path}'")
@@ -690,7 +689,7 @@ async def downstream_oauth_token(
     code: str = Form(...),
     client_id: str = Form(...),
     code_verifier: str = Form(...),
-    redirect_uri: str = Form(""),
+    redirect_uri: str = Form(...),
     redis_client: Redis = Depends(get_redis_client),
 ) -> JSONResponse:
     """Per-server downstream OAuth token endpoint (Layer B: registry-as-AS).
@@ -701,7 +700,7 @@ async def downstream_oauth_token(
     if grant_type != "authorization_code":
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="unsupported grant_type")
 
-    raw = redis_client.get(downstream_mcp_code_key(code))
+    raw = redis_client.getdel(downstream_mcp_code_key(code))
     if not raw:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid or expired code")
 
@@ -729,8 +728,6 @@ async def downstream_oauth_token(
     # redeemed under a different token endpoint URL.
     if user_id != bound_user_id or server_path != bound_server_path:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="code does not match this endpoint")
-
-    _ = redis_client.delete(downstream_mcp_code_key(code))
 
     confirmation_token = mint_downstream_mcp_token(
         settings.jwt_token_config, user_id=bound_user_id, server_path=bound_server_path

--- a/registry/src/registry/api/v1/mcp/oauth_router.py
+++ b/registry/src/registry/api/v1/mcp/oauth_router.py
@@ -13,9 +13,9 @@ from mcp.server.session import ServerSession
 from redis import Redis
 
 from registry_pkgs.core.downstream_oauth import downstream_mcp_code_key
+from registry_pkgs.core.jwt_tokens import mint_managed_agent_token
 
 from ....auth.dependencies import CurrentUser
-from ....auth.downstream_token import DOWNSTREAM_MCP_TOKEN_TTL_SECONDS, mint_downstream_mcp_token
 from ....auth.oauth.reconnection import OAuthReconnectionManager
 from ....auth.oauth.types import ClientBranding
 from ....constants import DownstreamOAuthConstants
@@ -729,17 +729,26 @@ async def downstream_oauth_token(
     if user_id != bound_user_id or server_path != bound_server_path:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="code does not match this endpoint")
 
-    confirmation_token = mint_downstream_mcp_token(
-        settings.jwt_token_config, user_id=bound_user_id, server_path=bound_server_path
+    current_time = int(time.time())
+    access_token = mint_managed_agent_token(
+        settings.jwt_token_config,
+        subject=bound_user_id,
+        client_id=client_id,
+        expires_in_seconds=3600,
+        iat=current_time,
+        extra_claims={
+            "user_id": bound_user_id,
+            "scope": "mcp-proxy-ops",
+        },
     )
 
     logger.info(f"[Downstream OAuth] token issued: user={user_id} server={server_path}")
     return JSONResponse(
         status_code=200,
         content={
-            "access_token": confirmation_token,
+            "access_token": access_token,
             "token_type": "Bearer",
-            "expires_in": DOWNSTREAM_MCP_TOKEN_TTL_SECONDS,
+            "expires_in": 3600,
         },
     )
 

--- a/registry/src/registry/api/v1/mcp/oauth_router.py
+++ b/registry/src/registry/api/v1/mcp/oauth_router.py
@@ -18,6 +18,7 @@ from ....auth.dependencies import CurrentUser
 from ....auth.downstream_token import DOWNSTREAM_MCP_TOKEN_TTL_SECONDS, mint_downstream_mcp_token
 from ....auth.oauth.reconnection import OAuthReconnectionManager
 from ....auth.oauth.types import ClientBranding
+from ....constants import DownstreamOAuthConstants
 from ....core.config import settings
 from ....core.mcp_client import get_oauth_metadata_from_server
 from ....core.session_store import SessionStore
@@ -248,7 +249,7 @@ def _build_downstream_client_redirect(
 
     _ = redis_client.setex(
         downstream_mcp_code_key(b_code),
-        _DOWNSTREAM_CODE_TTL_SECONDS,
+        DownstreamOAuthConstants.CODE_TTL_SECONDS,
         json.dumps(
             {
                 "code_challenge": ctx["code_challenge"],
@@ -581,15 +582,45 @@ async def delete_oauth_tokens(
         )
 
 
-_DOWNSTREAM_CODE_TTL_SECONDS = 600
-
-
 def _append_query_params(url: str, **params: str) -> str:
     """Append query params to a URL, preserving any query string it already carries."""
     parts = urlsplit(url)
     query = dict(parse_qsl(parts.query, keep_blank_values=True))
     query.update(params)
     return str(urlunsplit(parts._replace(query=urlencode(query))))
+
+
+def _validate_downstream_authorize_params(
+    response_type: str,
+    code_challenge_method: str,
+    redirect_uri: str,
+) -> None:
+    """Reject unsupported OAuth params before the captured ``redirect_uri`` becomes a redirect sink.
+
+    The registry only ever drives a ``code`` + S256 PKCE flow and later 302-redirects the browser to
+    ``redirect_uri`` with the authorization code attached, so reject non-http schemes
+    (``javascript:``, ``data:``) and malformed values before they reach that sink. The host itself is
+    NOT allowlisted yet (clients are deployed across many hosts) — pinning it requires downstream
+    client registration and is deferred.
+    """
+    if response_type != DownstreamOAuthConstants.SUPPORTED_RESPONSE_TYPE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"unsupported response_type: {response_type}",
+        )
+
+    if code_challenge_method != DownstreamOAuthConstants.SUPPORTED_CODE_CHALLENGE_METHOD:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"unsupported code_challenge_method: {code_challenge_method}",
+        )
+
+    redirect_parts = urlsplit(redirect_uri)
+    if redirect_parts.scheme not in {"http", "https"} or not redirect_parts.netloc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="redirect_uri must be an absolute http(s) URL",
+        )
 
 
 @router.get("/downstream/oauth/authorize/{user_id}/{server_path:path}")
@@ -619,6 +650,8 @@ async def downstream_oauth_authorize(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="user_id does not match the authenticated session",
         )
+
+    _validate_downstream_authorize_params(response_type, code_challenge_method, redirect_uri)
 
     # Resolve the registered server by prefix (same as the proxy), so a sub-path the client appends
     # still finds its server. The confirmation token binds to the raw URL `server_path`, not the

--- a/registry/src/registry/auth/downstream_token.py
+++ b/registry/src/registry/auth/downstream_token.py
@@ -1,0 +1,74 @@
+"""Downstream MCP confirmation tokens.
+
+A *downstream confirmation token* is a short-lived, registry-signed JWT handed to an MCP client
+once it has completed the downstream OAuth flow (Layer B: registry-as-AS) for a specific
+``(user_id, server_path)`` pair. The client presents it as a Bearer token on its next
+``initialize`` attempt; ``UnifiedAuthMiddleware`` accepts it for that one direct-connect route.
+
+The ``iss`` claim encodes both ``user_id`` and ``server_path`` so the verifier can cross-check
+them against the request URL, preventing a token minted for one user/server from being replayed
+on another. Minting and verification live together here so the two stay in lock-step.
+"""
+
+import logging
+import re
+
+from registry_pkgs.core.config import JwtTokenConfig
+from registry_pkgs.core.downstream_oauth import downstream_mcp_issuer
+from registry_pkgs.core.jwt_utils import build_jwt_payload, decode_jwt, encode_jwt
+
+from ..core.config import settings
+
+logger = logging.getLogger(__name__)
+
+DIRECT_CONNECT_RE = re.compile(r"^/proxy/server/([^/]+)/(.+)$")
+
+TOKEN_CLASS_DOWNSTREAM_MCP = "downstream_mcp"
+DOWNSTREAM_MCP_TOKEN_TTL_SECONDS = 300
+
+
+def mint_downstream_mcp_token(config: JwtTokenConfig, *, user_id: str, server_path: str) -> str:
+    """Mint a downstream confirmation token bound to a single ``(user_id, server_path)``."""
+    payload = build_jwt_payload(
+        subject=user_id,
+        issuer=downstream_mcp_issuer(config.jwt_issuer, user_id, server_path),
+        audience=config.managed_agents_audience,
+        expires_in_seconds=DOWNSTREAM_MCP_TOKEN_TTL_SECONDS,
+        extra_claims={"token_class": TOKEN_CLASS_DOWNSTREAM_MCP},
+    )
+    return encode_jwt(payload, config.jwt_private_key, kid=config.jwt_self_signed_kid)
+
+
+def verify_downstream_mcp_token(token: str, path: str, jwt_public_key: str) -> str | None:
+    """Verify a downstream confirmation token for a direct-connect request.
+
+    Returns the bound ``user_id`` if the token is valid for *this* request path, else ``None``.
+
+    The token's ``iss`` encodes ``(user_id, server_path)``. We reconstruct the expected issuer
+    from the request URL and require an exact match during decode, so a token minted for user A's
+    GitHub is cryptographically rejected on user B's GitHub route or on any other server — the
+    cross-user / cross-server confusion guard collapses into the standard ``iss`` check.
+    """
+    match = DIRECT_CONNECT_RE.match(path)
+    if match is None:
+        return None
+    url_user_id, url_server_path = match.group(1), match.group(2)
+
+    expected_iss = downstream_mcp_issuer(settings.jwt_issuer, url_user_id, url_server_path)
+
+    try:
+        claims = decode_jwt(
+            token,
+            jwt_public_key,
+            issuer=expected_iss,
+            audience=settings.jwt_audience_managed_agents,
+        )
+    except Exception as e:  # noqa: BLE001 — any verification failure means "not a usable token"
+        logger.debug(f"downstream confirmation token rejected: {e}")
+        return None
+
+    if claims.get("token_class") != TOKEN_CLASS_DOWNSTREAM_MCP:
+        logger.debug("downstream confirmation token rejected: wrong token_class")
+        return None
+
+    return claims.get("sub")

--- a/registry/src/registry/auth/oauth/flow_state_manager.py
+++ b/registry/src/registry/auth/oauth/flow_state_manager.py
@@ -15,6 +15,7 @@ from ...auth.oauth.types import OAuthFlowState, StateMetadata
 from ...core.config import settings
 from ...schemas.enums import OAuthFlowStatus
 from ...schemas.oauth_schema import (
+    MCPClientContext,
     MCPOAuthFlowMetadata,
     OAuthClientInformation,
     OAuthFlow,
@@ -146,6 +147,7 @@ class FlowStateManager:
         flow_id: str,
         *,
         state_metadata: StateMetadata | None = None,
+        mcp_client_context: MCPClientContext | None = None,
     ) -> MCPOAuthFlowMetadata:
         """Create OAuth flow metadata"""
         # Generate secure state parameter (base64url encoded JSON string)
@@ -168,6 +170,7 @@ class FlowStateManager:
             client_info=self._create_client_info(oauth_config, server_path),
             metadata=self._create_oauth_metadata(oauth_config),
             resource_metadata=resource_metadata,
+            mcp_client_context=mcp_client_context,
         )
 
     def create_flow(

--- a/registry/src/registry/constants.py
+++ b/registry/src/registry/constants.py
@@ -1,0 +1,6 @@
+class DownstreamOAuthConstants:
+    """Layer B (registry-as-AS) downstream OAuth protocol invariants"""
+
+    CODE_TTL_SECONDS = 600
+    SUPPORTED_RESPONSE_TYPE = "code"
+    SUPPORTED_CODE_CHALLENGE_METHOD = "S256"

--- a/registry/src/registry/middleware/auth.py
+++ b/registry/src/registry/middleware/auth.py
@@ -72,7 +72,6 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
                 "/api/auth/providers",
                 "/api/auth/config",
                 f"/api/{settings.api_version}/mcp/{{server_name}}/oauth/callback",  # OAuth callback is public
-                f"/api/{settings.api_version}/mcp/downstream/oauth/authorize/{{user_id}}/{{server_path:path}}",
                 f"/api/{settings.api_version}/mcp/downstream/oauth/token/{{user_id}}/{{server_path:path}}",
                 "/.well-known/{path:path}",  # OAuth discovery endpoints must be public
             ]

--- a/registry/src/registry/middleware/auth.py
+++ b/registry/src/registry/middleware/auth.py
@@ -10,11 +10,25 @@ from registry_pkgs.core.jwt_utils import ExpiredSignatureError, InvalidTokenErro
 from registry_pkgs.core.scopes import map_groups_to_scopes
 
 from ..auth.dependencies import UserContextDict
+from ..auth.downstream_token import DIRECT_CONNECT_RE, verify_downstream_mcp_token
 from ..core.config import settings
 from ..core.telemetry_decorators import AuthMetricsContext
 from ..utils.crypto_utils import verify_access_token
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_bearer_token(request: Request) -> str | None:
+    """Extract a non-empty Bearer token from the Authorization header, or None."""
+    auth_header = request.headers.get("Authorization")
+    if not auth_header:
+        return None
+
+    scheme, _, token = auth_header.partition(" ")
+    if scheme.lower() != "bearer":
+        return None
+
+    return token.strip() or None
 
 
 class UnifiedAuthMiddleware(BaseHTTPMiddleware):
@@ -44,15 +58,6 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
 
     def __init__(self, app):
         super().__init__(app)
-        # Paths that require authentication (checked before public paths)
-        # self.authenticated_paths_compiled = self._compile_patterns([
-        #     "/api/auth/me",
-        #     "/api/{versions}/servers/{path:path}",
-        #     "/api/{versions}/servers",
-        #     "/proxy/{path:path}",
-        #     "/api/{versions}/mcp/{path:path}",
-        #     "/api/search/{path:path}",
-        # ])
         self.public_paths_compiled = self._compile_patterns(
             [
                 "/",
@@ -67,6 +72,8 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
                 "/api/auth/providers",
                 "/api/auth/config",
                 f"/api/{settings.api_version}/mcp/{{server_name}}/oauth/callback",  # OAuth callback is public
+                f"/api/{settings.api_version}/mcp/downstream/oauth/authorize/{{user_id}}/{{server_path:path}}",
+                f"/api/{settings.api_version}/mcp/downstream/oauth/token/{{user_id}}/{{server_path:path}}",
                 "/.well-known/{path:path}",  # OAuth discovery endpoints must be public
             ]
         )
@@ -178,7 +185,7 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
         path) from being replayed as a dashboard session cookie, and vice versa.
         """
         if self._is_proxy_route(path):
-            user_context = self._try_jwt_auth(request)
+            user_context = self._try_jwt_auth(request, path)
             if user_context:
                 return user_context
             raise AuthenticationError("Managed-agent Bearer token required for proxy routes")
@@ -188,84 +195,109 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
             return user_context
         raise AuthenticationError("Session authentication required")
 
-    def _try_jwt_auth(self, request: Request) -> UserContextDict | None:
-        """Managed-agent Bearer-token authentication for proxy routes"""
+    def _try_jwt_auth(self, request: Request, path: str) -> UserContextDict | None:
+        """Bearer-token authentication for proxy routes.
+
+        Accepts either a managed-agent token (the normal proxy credential) or a downstream
+        confirmation token (the one-time entry ticket issued after a direct-connect downstream
+        OAuth flow). On direct-connect routes that carry a ``user_id`` segment, the token's
+        ``user_id`` must match the URL's ``user_id``.
+        """
+        access_token = _parse_bearer_token(request)
+        if access_token is None:
+            return None
+
         try:
-            # Get Authorization header
-            auth_header = request.headers.get("Authorization")
-            if not auth_header:
-                logger.debug("Missing Authorization header for managed-agent auth")
-                return None
+            claims = self._verify_managed_agent_claims(access_token)
+            if claims is not None:
+                return self._build_managed_agent_context(claims, path)
 
-            parts = auth_header.split(" ", 1)
-            if len(parts) != 2 or parts[0].lower() != "bearer":
-                logger.debug("Authorization header is not a Bearer scheme")
-                return None
-
-            access_token = parts[1].strip()
-            if not access_token:
-                logger.debug("Empty Bearer token after split")
-                return None
-
-            # Validate as a managed-agent (proxy) token. Wrong class/audience/kid/client_id
-            # all raise InvalidTokenError.
-            try:
-                claims = verify_managed_agent_token(settings.jwt_token_config, access_token)
-                logger.info(
-                    f"Managed-agent token validated: sub={claims.get('sub')}, "
-                    f"aud={claims.get('aud')}, client_id={claims.get('client_id')}"
-                )
-            except ExpiredSignatureError:
-                logger.debug("Managed-agent token has expired")
-                return None
-            except InvalidTokenError as e:
-                logger.debug(f"Invalid managed-agent token: {e}")
-                return None
-
-            # Extract user information from claims
-            username = claims.get("sub", "")
-            if not username:
-                logger.debug("JWT token missing 'sub' claim")
-                return None
-
-            # Extract groups first
-            groups = claims.get("groups", [])
-
-            # Extract scopes from space-separated string
-            scope_string = claims.get("scope", "")
-            scopes = scope_string.split() if scope_string else []
-
-            # If no scopes but has groups, map groups to scopes
-            if not scopes and groups:
-                scopes = map_groups_to_scopes(groups, settings.scopes_file_config)
-                logger.info(f"Mapped JWT groups {groups} to scopes: {scopes}")
-
-            # Verify we have at least some scopes
-            if not scopes:
-                logger.debug(f"JWT token has no scopes and groups mapping failed. Groups: {groups}")
-                return None
-
-            # Log token validation success with additional details
-            token_class = claims.get("token_class", "unknown")
-            description = claims.get("description", "")
-            logger.info(f"Managed-agent token validated for user: {username}, class: {token_class}, scopes: {scopes}")
-            if description:
-                logger.debug(f"Token description: {description}")
-            user_id = claims.get("user_id")
-            logger.debug(f"jwt enhencement user id {user_id}")
-
-            return self._build_user_context(
-                user_id=user_id,
-                username=username,
-                groups=groups,
-                scopes=scopes,
-                auth_method="jwt",
-                provider="jwt",
-                auth_source="jwt_auth",
-            )
+            # Fallback: a downstream confirmation token (Layer B entry ticket).
+            return self._build_downstream_token_context(access_token, path)
         except Exception as e:
             logger.debug(f"JWT auth failed: {e}")
             return None
+
+    @staticmethod
+    def _verify_managed_agent_claims(access_token: str) -> dict | None:
+        """Validate a managed-agent (proxy) token. Returns its claims, or None if it is not one.
+
+        Wrong class/audience/kid/client_id all raise InvalidTokenError; a downstream confirmation
+        token also fails here (different iss + token_class) and is handled by the caller's fallback.
+        """
+        try:
+            claims = verify_managed_agent_token(settings.jwt_token_config, access_token)
+        except (ExpiredSignatureError, InvalidTokenError) as e:
+            logger.debug(f"Not a valid managed-agent token: {e}")
+            return None
+
+        logger.info(
+            f"Managed-agent token validated: sub={claims.get('sub')}, "
+            f"aud={claims.get('aud')}, client_id={claims.get('client_id')}"
+        )
+        return claims
+
+    def _build_downstream_token_context(self, access_token: str, path: str) -> UserContextDict | None:
+        """Build a context from a downstream confirmation token, or None if it is not valid here.
+
+        ``verify_downstream_mcp_token`` enforces the user_id / server_path binding against the path.
+        """
+        user_id = verify_downstream_mcp_token(access_token, path, settings.jwt_public_key)
+        if user_id is None:
+            return None
+
+        logger.info(f"Downstream confirmation token validated for user {user_id}")
+        return self._build_user_context(
+            user_id=user_id,
+            username=user_id,
+            groups=[],
+            scopes=["mcp-proxy-ops"],
+            auth_method="downstream_mcp_token",
+            provider="registry",
+            auth_source="downstream_mcp_token",
+        )
+
+    def _build_managed_agent_context(self, claims: dict, path: str) -> UserContextDict | None:
+        """Build a user context from validated managed-agent claims, enforcing user_id binding."""
+        username = claims.get("sub", "")
+        if not username:
+            logger.debug("JWT token missing 'sub' claim")
+            return None
+
+        groups = claims.get("groups", [])
+
+        scope_string = claims.get("scope", "")
+        scopes = scope_string.split() if scope_string else []
+
+        if not scopes and groups:
+            scopes = map_groups_to_scopes(groups, settings.scopes_file_config)
+            logger.info(f"Mapped JWT groups {groups} to scopes: {scopes}")
+
+        if not scopes:
+            logger.debug(f"JWT token has no scopes and groups mapping failed. Groups: {groups}")
+            return None
+
+        user_id = claims.get("user_id")
+
+        binding = DIRECT_CONNECT_RE.match(path)
+        if binding is not None:
+            url_user_id = binding.group(1)
+            if user_id != url_user_id:
+                logger.warning(f"user_id mismatch: token has {user_id}, URL has {url_user_id}")
+                return None
+
+        token_class = claims.get("token_class", "unknown")
+        logger.info(f"Managed-agent token validated for user: {username}, class: {token_class}, scopes: {scopes}")
+
+        return self._build_user_context(
+            user_id=user_id,
+            username=username,
+            groups=groups,
+            scopes=scopes,
+            auth_method="jwt",
+            provider="jwt",
+            auth_source="jwt_auth",
+        )
 
     async def _try_session_auth(self, request: Request) -> UserContextDict | None:
         """JWT-based session authentication from httpOnly cookie"""

--- a/registry/src/registry/schemas/__init__.py
+++ b/registry/src/registry/schemas/__init__.py
@@ -12,7 +12,6 @@ from .anthropic_schema import (
     StdioTransport,
     StreamableHttpTransport,
 )
-from .enums import TokenType
 from .errors import (
     APIErrorDetail,
     APIErrorResponse,
@@ -50,5 +49,4 @@ __all__ = [
     "OAuthProtectedResourceMetadata",
     "MCPOAuthFlowMetadata",
     "OAuthFlow",
-    "TokenType",
 ]

--- a/registry/src/registry/schemas/enums.py
+++ b/registry/src/registry/schemas/enums.py
@@ -42,12 +42,3 @@ class HealthStatus(StrEnum):
     def is_healthy(cls, status: str) -> bool:
         """Check if a status should be considered healthy."""
         return status in cls.get_healthy_statuses()
-
-
-class TokenType(StrEnum):
-    """Token type enumeration"""
-
-    MCP_OAUTH_ACCESS = "mcp_oauth"  # Access token (canonical name, value unchanged for DB compatibility)
-    MCP_OAUTH = MCP_OAUTH_ACCESS  # Deprecated: backward-compatible alias, use MCP_OAUTH_ACCESS instead
-    MCP_OAUTH_REFRESH = "mcp_oauth_refresh"  # Refresh token
-    MCP_OAUTH_CLIENT = "mcp_oauth_client"  # Client credentials (client_id, client_secret)

--- a/registry/src/registry/schemas/oauth_schema.py
+++ b/registry/src/registry/schemas/oauth_schema.py
@@ -1,10 +1,29 @@
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, TypedDict
 
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 from .enums import OAuthFlowStatus
+
+
+class MCPClientContext(TypedDict):
+    """OAuth 2.0 / PKCE parameters of an MCP client that initiated a downstream OAuth flow via
+    the per-server `/downstream/oauth/authorize` endpoint (Layer B: registry-as-AS).
+
+    Stored on the flow metadata so the callback can redirect the browser back to the MCP client
+    (`redirect_uri`) and the `/token` endpoint can complete PKCE. Distinct from the Layer A PKCE
+    the registry runs against the upstream provider.
+
+    Defined here (not in ``auth/oauth/types.py``) because ``schemas`` must not import the
+    ``auth.oauth`` package — doing so creates a circular import via the package ``__init__``.
+    """
+
+    redirect_uri: str
+    client_id: str
+    code_challenge: str
+    state: str
+    server_path: str
 
 
 class OAuthTokens(BaseModel):
@@ -80,6 +99,10 @@ class MCPOAuthFlowMetadata(BaseModel):
     client_info: OAuthClientInformation = Field(..., description="Client information")
     metadata: OAuthMetadata = Field(..., description="OAuth metadata")
     resource_metadata: OAuthProtectedResourceMetadata | None = Field(None, description="Resource metadata")
+    mcp_client_context: MCPClientContext | None = Field(
+        None,
+        description="OAuth/PKCE context of an MCP client that initiated a downstream OAuth flow (Layer B)",
+    )
 
 
 @dataclass

--- a/registry/src/registry/services/oauth/oauth_service.py
+++ b/registry/src/registry/services/oauth/oauth_service.py
@@ -9,6 +9,7 @@ from ...auth.oauth.oauth_utils import get_default_redirect_uri
 from ...auth.oauth.types import StateMetadata
 from ...schemas.enums import OAuthFlowStatus
 from ...schemas.oauth_schema import (
+    MCPClientContext,
     OAuthTokens,
 )
 from ...services.oauth.token_service import TokenService
@@ -114,6 +115,7 @@ class MCPOAuthService:
         server: ExtendedMCPServer,
         *,
         state_metadata: StateMetadata | None = None,
+        mcp_client_context: MCPClientContext | None = None,
     ) -> tuple[str | None, str | None, str | None]:
         """
         Initialize OAuth flow with automatic DCR support.
@@ -277,6 +279,7 @@ class MCPOAuthService:
                 oauth_config=oauth_config,
                 flow_id=flow_id,
                 state_metadata=state_metadata,
+                mcp_client_context=mcp_client_context,
             )
 
             # Create OAuth flow

--- a/registry/src/registry/services/oauth/token_service.py
+++ b/registry/src/registry/services/oauth/token_service.py
@@ -5,9 +5,8 @@ from typing import Any
 
 from beanie import PydanticObjectId
 
-from registry_pkgs.models import Token, User
+from registry_pkgs.models import Token, TokenType, User
 
-from ...schemas.enums import TokenType
 from ...schemas.oauth_schema import OAuthClientInformation, OAuthTokens
 from ...services.user_service import UserService
 from ...utils.crypto_utils import decrypt_value, encrypt_value

--- a/registry/src/registry/services/server_service.py
+++ b/registry/src/registry/services/server_service.py
@@ -705,6 +705,19 @@ class ServerServiceV1:
         """
         return await ExtendedMCPServer.find_one({"path": path})
 
+    async def extract_server_path(self, request_path: str) -> str | None:
+        """Return the longest registered path prefix that matches ``request_path``.
+
+        Tries progressively shorter segments so a sub-path like ``/github/repos/list``
+        resolves to the registered server at ``/github``.
+        """
+        segments = [s for s in request_path.split("/") if s]
+        for i in range(len(segments), 0, -1):
+            candidate_path = "/" + "/".join(segments[:i])
+            if await self.get_server_by_path(candidate_path):
+                return candidate_path
+        return None
+
     async def create_server(
         self,
         data: ServerCreateRequest,

--- a/registry/tests/unit/api/test_downstream_oauth_endpoints.py
+++ b/registry/tests/unit/api/test_downstream_oauth_endpoints.py
@@ -1,0 +1,160 @@
+"""Unit tests for the Layer B downstream OAuth endpoints (registry-as-AS):
+``/downstream/oauth/authorize`` and ``/downstream/oauth/token``.
+"""
+
+import json
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from authlib.oauth2.rfc7636 import create_s256_code_challenge
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from registry.api.v1.mcp.oauth_router import router
+from registry.deps import get_mcp_service, get_redis_client, get_server_service
+from registry_pkgs.core.downstream_oauth import downstream_mcp_code_key
+
+USER_A = "507f1f77bcf86cd799439011"
+USER_B = "507f1f77bcf86cd799439012"
+CODE = "upstream-auth-code-xyz"
+VERIFIER = "verifier-0123456789-0123456789-0123456789-0123456789"
+
+
+@pytest.fixture
+def redis_mock() -> Mock:
+    return Mock()
+
+
+@pytest.fixture
+def mcp_service_mock() -> Mock:
+    svc = Mock()
+    svc.oauth_service.initiate_oauth_flow = AsyncMock(
+        return_value=("flow-1", "https://github.com/login/oauth/authorize?x=1", None)
+    )
+    return svc
+
+
+@pytest.fixture
+def server_service_mock() -> Mock:
+    svc = Mock()
+    server = Mock()
+    server.path = "/github"
+    server.serverName = "github"
+    svc.get_server_by_path = AsyncMock(return_value=server)
+    return svc
+
+
+@pytest.fixture
+def client(redis_mock, mcp_service_mock, server_service_mock) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_redis_client] = lambda: redis_mock
+    app.dependency_overrides[get_mcp_service] = lambda: mcp_service_mock
+    app.dependency_overrides[get_server_service] = lambda: server_service_mock
+    return TestClient(app)
+
+
+def _stored_entry(user_id: str = USER_A, server_path: str = "github", client_id: str = "claude") -> str:
+    return json.dumps(
+        {
+            "code_challenge": create_s256_code_challenge(VERIFIER),
+            "client_id": client_id,
+            "redirect_uri": "http://localhost:33418/cb",
+            "user_id": user_id,
+            "server_path": server_path,
+        }
+    )
+
+
+def test_authorize_redirects_to_provider(client, redis_mock):
+    resp = client.get(
+        f"/mcp/downstream/oauth/authorize/{USER_A}/github",
+        params={"client_id": "claude", "redirect_uri": "http://localhost:33418/cb", "code_challenge": "abc"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "https://github.com/login/oauth/authorize?x=1"
+
+
+def test_authorize_invalid_user_id_returns_400(client):
+    resp = client.get(
+        "/mcp/downstream/oauth/authorize/mcpgw/github",
+        params={"client_id": "claude", "redirect_uri": "http://x/cb", "code_challenge": "abc"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+
+
+def test_authorize_unknown_server_returns_404(client, server_service_mock):
+    server_service_mock.get_server_by_path = AsyncMock(return_value=None)
+    resp = client.get(
+        f"/mcp/downstream/oauth/authorize/{USER_A}/ghost",
+        params={"client_id": "claude", "redirect_uri": "http://x/cb", "code_challenge": "abc"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 404
+
+
+def _post_token(client, *, user_id=USER_A, server_path="github", code=CODE, client_id="claude", verifier=VERIFIER):
+    return client.post(
+        f"/mcp/downstream/oauth/token/{user_id}/{server_path}",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": client_id,
+            "code_verifier": verifier,
+            "redirect_uri": "http://localhost:33418/cb",
+        },
+    )
+
+
+def test_token_happy_path_returns_confirmation_token(client, redis_mock):
+    redis_mock.get.return_value = _stored_entry()
+    resp = _post_token(client)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["token_type"] == "Bearer"
+    assert body["expires_in"] == 300
+    assert body["access_token"]
+    # One-time use: the code is deleted from Redis.
+    redis_mock.delete.assert_called_once_with(downstream_mcp_code_key(CODE))
+
+
+def test_token_unknown_code_returns_400(client, redis_mock):
+    redis_mock.get.return_value = None
+    assert _post_token(client).status_code == 400
+
+
+def test_token_corrupt_entry_returns_400(client, redis_mock):
+    redis_mock.get.return_value = "not-json"
+    assert _post_token(client).status_code == 400
+
+
+def test_token_pkce_mismatch_returns_400(client, redis_mock):
+    redis_mock.get.return_value = _stored_entry()
+    assert _post_token(client, verifier="wrong-verifier").status_code == 400
+
+
+def test_token_client_id_mismatch_returns_400(client, redis_mock):
+    redis_mock.get.return_value = _stored_entry(client_id="claude")
+    assert _post_token(client, client_id="someone-else").status_code == 400
+
+
+def test_token_rejects_cross_user_binding(client, redis_mock):
+    # Code minted for USER_A, redeemed under USER_B's token endpoint URL → rejected.
+    redis_mock.get.return_value = _stored_entry(user_id=USER_A)
+    assert _post_token(client, user_id=USER_B).status_code == 400
+
+
+def test_token_rejects_cross_server_binding(client, redis_mock):
+    redis_mock.get.return_value = _stored_entry(server_path="github")
+    assert _post_token(client, server_path="slack").status_code == 400
+
+
+def test_token_unsupported_grant_type_returns_400(client, redis_mock):
+    redis_mock.get.return_value = _stored_entry()
+    resp = client.post(
+        f"/mcp/downstream/oauth/token/{USER_A}/github",
+        data={"grant_type": "client_credentials", "code": CODE, "client_id": "claude", "code_verifier": VERIFIER},
+    )
+    assert resp.status_code == 400

--- a/registry/tests/unit/api/test_downstream_oauth_endpoints.py
+++ b/registry/tests/unit/api/test_downstream_oauth_endpoints.py
@@ -217,7 +217,7 @@ def test_token_happy_path_returns_confirmation_token(client, redis_mock):
     assert resp.status_code == 200
     body = resp.json()
     assert body["token_type"] == "Bearer"
-    assert body["expires_in"] == 300
+    assert body["expires_in"] == 3600
     assert body["access_token"]
     # One-time use: the code is atomically fetched-and-deleted in a single GETDEL call.
     redis_mock.getdel.assert_called_once_with(downstream_mcp_code_key(CODE))

--- a/registry/tests/unit/api/test_downstream_oauth_endpoints.py
+++ b/registry/tests/unit/api/test_downstream_oauth_endpoints.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from registry.api.v1.mcp.oauth_router import router
+from registry.auth.dependencies import get_current_user
 from registry.deps import get_mcp_service, get_redis_client, get_server_service
 from registry_pkgs.core.downstream_oauth import downstream_mcp_code_key
 
@@ -18,6 +19,18 @@ USER_A = "507f1f77bcf86cd799439011"
 USER_B = "507f1f77bcf86cd799439012"
 CODE = "upstream-auth-code-xyz"
 VERIFIER = "verifier-0123456789-0123456789-0123456789-0123456789"
+
+
+def _session_user(user_id: str = USER_A) -> dict:
+    return {
+        "user_id": user_id,
+        "username": "alice",
+        "groups": [],
+        "scopes": [],
+        "auth_method": "traditional",
+        "provider": "local",
+        "auth_source": "jwt_session_auth",
+    }
 
 
 @pytest.fixture
@@ -51,15 +64,22 @@ def client(redis_mock, mcp_service_mock, server_service_mock) -> TestClient:
     app.dependency_overrides[get_redis_client] = lambda: redis_mock
     app.dependency_overrides[get_mcp_service] = lambda: mcp_service_mock
     app.dependency_overrides[get_server_service] = lambda: server_service_mock
+    # By default the authorize endpoint sees a session for USER_A (matches the URL user_id).
+    app.dependency_overrides[get_current_user] = lambda: _session_user(USER_A)
     return TestClient(app)
 
 
-def _stored_entry(user_id: str = USER_A, server_path: str = "github", client_id: str = "claude") -> str:
+def _stored_entry(
+    user_id: str = USER_A,
+    server_path: str = "github",
+    client_id: str = "claude",
+    redirect_uri: str = "http://localhost:33418/cb",
+) -> str:
     return json.dumps(
         {
             "code_challenge": create_s256_code_challenge(VERIFIER),
             "client_id": client_id,
-            "redirect_uri": "http://localhost:33418/cb",
+            "redirect_uri": redirect_uri,
             "user_id": user_id,
             "server_path": server_path,
         }
@@ -95,7 +115,44 @@ def test_authorize_unknown_server_returns_404(client, server_service_mock):
     assert resp.status_code == 404
 
 
-def _post_token(client, *, user_id=USER_A, server_path="github", code=CODE, client_id="claude", verifier=VERIFIER):
+def test_authorize_session_user_mismatch_returns_403(client, mcp_service_mock):
+    # AS-1545 review #3: a logged-in user (USER_B) cannot initiate a downstream flow for another
+    # user's account (USER_A in the URL) — that would inject a token into the victim's account.
+    client.app.dependency_overrides[get_current_user] = lambda: _session_user(USER_B)
+    resp = client.get(
+        f"/mcp/downstream/oauth/authorize/{USER_A}/github",
+        params={"client_id": "claude", "redirect_uri": "http://localhost:33418/cb", "code_challenge": "abc"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 403
+    # The Layer A flow must never be initiated for a mismatched session.
+    mcp_service_mock.oauth_service.initiate_oauth_flow.assert_not_called()
+
+
+def test_authorize_unauthenticated_is_not_public(client, mcp_service_mock):
+    # AS-1545 review #3: with no session, the real get_current_user dependency rejects the request
+    # (401). In production the UnifiedAuthMiddleware 401s first; either way authorize is not public
+    # and the downstream flow is never initiated.
+    client.app.dependency_overrides.pop(get_current_user)
+    resp = client.get(
+        f"/mcp/downstream/oauth/authorize/{USER_A}/github",
+        params={"client_id": "claude", "redirect_uri": "http://localhost:33418/cb", "code_challenge": "abc"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 401
+    mcp_service_mock.oauth_service.initiate_oauth_flow.assert_not_called()
+
+
+def _post_token(
+    client,
+    *,
+    user_id=USER_A,
+    server_path="github",
+    code=CODE,
+    client_id="claude",
+    verifier=VERIFIER,
+    redirect_uri="http://localhost:33418/cb",
+):
     return client.post(
         f"/mcp/downstream/oauth/token/{user_id}/{server_path}",
         data={
@@ -103,7 +160,7 @@ def _post_token(client, *, user_id=USER_A, server_path="github", code=CODE, clie
             "code": code,
             "client_id": client_id,
             "code_verifier": verifier,
-            "redirect_uri": "http://localhost:33418/cb",
+            "redirect_uri": redirect_uri,
         },
     )
 
@@ -138,6 +195,11 @@ def test_token_pkce_mismatch_returns_400(client, redis_mock):
 def test_token_client_id_mismatch_returns_400(client, redis_mock):
     redis_mock.get.return_value = _stored_entry(client_id="claude")
     assert _post_token(client, client_id="someone-else").status_code == 400
+
+
+def test_token_redirect_uri_mismatch_returns_400(client, redis_mock):
+    redis_mock.get.return_value = _stored_entry(redirect_uri="http://localhost:33418/cb")
+    assert _post_token(client, redirect_uri="http://evil.localhost/cb").status_code == 400
 
 
 def test_token_rejects_cross_user_binding(client, redis_mock):

--- a/registry/tests/unit/api/test_downstream_oauth_endpoints.py
+++ b/registry/tests/unit/api/test_downstream_oauth_endpoints.py
@@ -109,10 +109,55 @@ def test_authorize_unknown_server_returns_404(client, server_service_mock):
     server_service_mock.get_server_by_path = AsyncMock(return_value=None)
     resp = client.get(
         f"/mcp/downstream/oauth/authorize/{USER_A}/ghost",
-        params={"client_id": "claude", "redirect_uri": "http://x/cb", "code_challenge": "abc"},
+        params={"client_id": "claude", "redirect_uri": "https://x/cb", "code_challenge": "abc"},
         follow_redirects=False,
     )
     assert resp.status_code == 404
+
+
+def test_authorize_rejects_unsupported_response_type(client, mcp_service_mock):
+    resp = client.get(
+        f"/mcp/downstream/oauth/authorize/{USER_A}/github",
+        params={
+            "client_id": "claude",
+            "redirect_uri": "https://app.example.com/cb",
+            "code_challenge": "abc",
+            "response_type": "token",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    mcp_service_mock.oauth_service.initiate_oauth_flow.assert_not_called()
+
+
+def test_authorize_rejects_non_s256_challenge_method(client, mcp_service_mock):
+    resp = client.get(
+        f"/mcp/downstream/oauth/authorize/{USER_A}/github",
+        params={
+            "client_id": "claude",
+            "redirect_uri": "https://app.example.com/cb",
+            "code_challenge": "abc",
+            "code_challenge_method": "plain",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    mcp_service_mock.oauth_service.initiate_oauth_flow.assert_not_called()
+
+
+def test_authorize_rejects_non_http_redirect_scheme(client, mcp_service_mock):
+    # A non-http(s) scheme must never reach the redirect sink (open-redirect / exfil via javascript:).
+    resp = client.get(
+        f"/mcp/downstream/oauth/authorize/{USER_A}/github",
+        params={
+            "client_id": "claude",
+            "redirect_uri": "javascript:alert(1)",
+            "code_challenge": "abc",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    mcp_service_mock.oauth_service.initiate_oauth_flow.assert_not_called()
 
 
 def test_authorize_session_user_mismatch_returns_403(client, mcp_service_mock):

--- a/registry/tests/unit/api/test_downstream_oauth_endpoints.py
+++ b/registry/tests/unit/api/test_downstream_oauth_endpoints.py
@@ -54,6 +54,7 @@ def server_service_mock() -> Mock:
     server.path = "/github"
     server.serverName = "github"
     svc.get_server_by_path = AsyncMock(return_value=server)
+    svc.extract_server_path = AsyncMock(return_value="/github")
     return svc
 
 
@@ -106,7 +107,7 @@ def test_authorize_invalid_user_id_returns_400(client):
 
 
 def test_authorize_unknown_server_returns_404(client, server_service_mock):
-    server_service_mock.get_server_by_path = AsyncMock(return_value=None)
+    server_service_mock.extract_server_path = AsyncMock(return_value=None)
     resp = client.get(
         f"/mcp/downstream/oauth/authorize/{USER_A}/ghost",
         params={"client_id": "claude", "redirect_uri": "https://x/cb", "code_challenge": "abc"},
@@ -211,15 +212,15 @@ def _post_token(
 
 
 def test_token_happy_path_returns_confirmation_token(client, redis_mock):
-    redis_mock.get.return_value = _stored_entry()
+    redis_mock.getdel.return_value = _stored_entry()
     resp = _post_token(client)
     assert resp.status_code == 200
     body = resp.json()
     assert body["token_type"] == "Bearer"
     assert body["expires_in"] == 300
     assert body["access_token"]
-    # One-time use: the code is deleted from Redis.
-    redis_mock.delete.assert_called_once_with(downstream_mcp_code_key(CODE))
+    # One-time use: the code is atomically fetched-and-deleted in a single GETDEL call.
+    redis_mock.getdel.assert_called_once_with(downstream_mcp_code_key(CODE))
 
 
 def test_token_unknown_code_returns_400(client, redis_mock):
@@ -259,9 +260,15 @@ def test_token_rejects_cross_server_binding(client, redis_mock):
 
 
 def test_token_unsupported_grant_type_returns_400(client, redis_mock):
-    redis_mock.get.return_value = _stored_entry()
+    redis_mock.getdel.return_value = _stored_entry()
     resp = client.post(
         f"/mcp/downstream/oauth/token/{USER_A}/github",
-        data={"grant_type": "client_credentials", "code": CODE, "client_id": "claude", "code_verifier": VERIFIER},
+        data={
+            "grant_type": "client_credentials",
+            "code": CODE,
+            "client_id": "claude",
+            "code_verifier": VERIFIER,
+            "redirect_uri": "http://localhost:33418/cb",
+        },
     )
     assert resp.status_code == 400

--- a/registry/tests/unit/api/test_oauth_router.py
+++ b/registry/tests/unit/api/test_oauth_router.py
@@ -114,6 +114,7 @@ def client():
         token_service=mock_container.token_service,
         mcp_service=mock_container.mcp_service,
         session_store=SessionStore(),
+        redis_client=Mock(),
     )
     yield TestClient(app)
 
@@ -260,6 +261,8 @@ class TestOAuthRouter:
         mock_flow.user_id = "test_user"
         mock_flow.server_id = TEST_SERVER_ID
         mock_flow.status = "pending"
+        # Registry-frontend-initiated flow (not an MCP client) → no downstream redirect branch.
+        mock_flow.metadata.mcp_client_context = None
         mock_mcp_service.oauth_service.flow_manager.get_flow = lambda flow_id: mock_flow
 
         # Mock successful completion
@@ -281,6 +284,42 @@ class TestOAuthRouter:
         assert "oauth-callback?type=success" in response.headers["location"]
         # The serverPath query parameter should contain the server_path from the URL
         assert "serverPath=test_server" in response.headers["location"]
+
+    def test_oauth_callback_mcp_client_redirect(self, client):
+        """MCP-client-initiated (Layer B) flow: callback redirects to the client's redirect_uri
+        with a code + state instead of the registry success page."""
+        mock_mcp_service.oauth_service.flow_manager.decode_state = lambda _: {
+            "flow_id": "test_user-flow123",
+            "security_token": "security_token",
+        }
+
+        mock_flow = Mock()
+        mock_flow.user_id = "test_user"
+        mock_flow.server_id = TEST_SERVER_ID
+        mock_flow.status = "pending"
+        mock_flow.metadata.mcp_client_context = {
+            "redirect_uri": "http://localhost:33418/cb",
+            "client_id": "claude",
+            "code_challenge": "cc",
+            "state": "st123",
+            "server_path": "github",
+        }
+        mock_mcp_service.oauth_service.flow_manager.get_flow = lambda flow_id: mock_flow
+        mock_mcp_service.oauth_service.complete_oauth_flow = make_async(lambda *args, **kwargs: (True, None))
+        mock_mcp_service.connection_service.create_user_connection = AsyncMock(return_value=None)
+
+        response = client.get(
+            "/mcp/github/oauth/callback?code=GHCODE&state=test_user-flow123##security_token",
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 307
+        location = response.headers["location"]
+        assert location.startswith("http://localhost:33418/cb")
+        assert "code=GHCODE" in location
+        assert "state=st123" in location
+        # Must NOT fall through to the registry success page.
+        assert "oauth-callback?type=success" not in location
 
     def test_oauth_callback_missing_code(self, client):
         """Test OAuth callback with missing code parameter"""

--- a/registry/tests/unit/api/test_oauth_router.py
+++ b/registry/tests/unit/api/test_oauth_router.py
@@ -316,8 +316,12 @@ class TestOAuthRouter:
         assert response.status_code == 307
         location = response.headers["location"]
         assert location.startswith("http://localhost:33418/cb")
-        assert "code=GHCODE" in location
-        assert "state=st123" in location
+        from urllib.parse import parse_qs, urlsplit
+
+        query = parse_qs(urlsplit(location).query)
+        assert query["state"] == ["st123"]
+        assert query["code"][0] and query["code"][0] != "GHCODE"
+        assert "GHCODE" not in location
         # Must NOT fall through to the registry success page.
         assert "oauth-callback?type=success" not in location
 

--- a/registry/tests/unit/api/test_proxy_init_discovery.py
+++ b/registry/tests/unit/api/test_proxy_init_discovery.py
@@ -1,0 +1,96 @@
+"""Tests for the AS-1545 headline fix in ``proxy_to_mcp_server``:
+
+When the downstream MCP token is missing, handshake methods (``initialize`` / ``tools/list``)
+must return HTTP 401 with an RFC 9728 ``resource_metadata`` challenge — NOT a 200 URL-mode
+elicitation, which clients cannot process at handshake time. Other methods keep the elicitation.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from starlette.requests import Request
+
+from registry.api.proxy_routes import proxy_to_mcp_server
+from registry.core.config import settings
+from registry.core.exceptions import UrlElicitationRequiredException
+
+USER_ID = "507f1f77bcf86cd799439011"
+
+
+def _request(user_id: str = USER_ID, server_path: str = "github") -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "path": f"/proxy/server/{user_id}/{server_path}",
+        "query_string": b"",
+        "headers": [(b"accept", b"text/event-stream")],
+        "path_params": {"user_id": user_id, "server_path": server_path},
+    }
+    return Request(scope)
+
+
+def _server() -> Mock:
+    s = Mock()
+    s.serverName = "github"
+    return s
+
+
+_AUTH_CONTEXT = {"auth_method": "downstream_mcp_token", "user_id": USER_ID, "username": USER_ID}
+
+
+@pytest.fixture
+def raise_elicitation(monkeypatch):
+    async def _raise(*args, **kwargs):
+        raise UrlElicitationRequiredException(
+            "needs auth", auth_url="https://github.com/login/oauth/authorize?x=1", server_name="github"
+        )
+
+    monkeypatch.setattr("registry.api.proxy_routes.build_authenticated_headers", _raise)
+
+
+@pytest.mark.parametrize("method", ["initialize", "tools/list"])
+async def test_init_methods_return_401_with_discovery_header(raise_elicitation, method):
+    resp = await proxy_to_mcp_server(
+        1,
+        request=_request(),
+        target_url="http://backend/mcp",
+        auth_context=_AUTH_CONTEXT,
+        server=_server(),
+        oauth_service=Mock(),
+        proxy_client=Mock(),
+        redis_client=Mock(),
+        mcp_method=method,
+    )
+    assert resp.status_code == 401
+    www = resp.headers["WWW-Authenticate"]
+    assert www.startswith("Bearer")
+    expected = (
+        f"{settings.jwt_issuer}/.well-known/oauth-protected-resource"
+        f"{settings.service_base_path}/proxy/server/{USER_ID}/github"
+    )
+    assert f'resource_metadata="{expected}"' in www
+    # RFC 6750 §3.1: no `error` attribute when no relevant token was presented.
+    assert "error=" not in www
+
+
+async def test_tool_call_still_returns_elicitation(raise_elicitation):
+    resp = await proxy_to_mcp_server(
+        1,
+        request=_request(),
+        target_url="http://backend/mcp",
+        auth_context=_AUTH_CONTEXT,
+        server=_server(),
+        oauth_service=Mock(),
+        proxy_client=Mock(),
+        redis_client=Mock(),
+        mcp_method="tools/call",
+    )
+    # Non-handshake methods keep the HTTP 200 + JSON-RPC -32042 URL-mode elicitation.
+    assert resp.status_code == 200
+    import json
+
+    body = json.loads(bytes(resp.body))
+    assert body["error"]["code"] == -32042
+    assert body["error"]["data"]["elicitations"][0]["mode"] == "url"

--- a/registry/tests/unit/api/test_proxy_routes.py
+++ b/registry/tests/unit/api/test_proxy_routes.py
@@ -1,0 +1,117 @@
+"""Tests for ObjectId validation in the dynamic proxy GET/POST handlers.
+
+The spec required updating proxy-route assertions for the new {user_id}/{server_path} URL
+format. These tests verify that both handlers reject non-ObjectId user_id values with a
+400 and a ``{"detail": ...}`` body before any further processing occurs.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from starlette.requests import Request
+
+from registry.api.proxy_routes import dynamic_mcp_get_proxy, dynamic_mcp_post_proxy
+
+VALID_OBJECT_ID = "507f1f77bcf86cd799439011"
+INVALID_USER_IDS = ["mcpgw", "not-an-objectid", "123", ""]
+
+_AUTH_CONTEXT = {"auth_method": "bearer", "user_id": VALID_OBJECT_ID, "username": "test"}
+
+
+def _post_request(user_id: str, server_path: str = "github") -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "path": f"/proxy/server/{user_id}/{server_path}",
+        "query_string": b"",
+        "headers": [],
+        "path_params": {"user_id": user_id, "server_path": server_path},
+    }
+    return Request(scope)
+
+
+def _get_request(user_id: str, server_path: str = "github") -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "path": f"/proxy/server/{user_id}/{server_path}",
+        "query_string": b"",
+        "headers": [(b"accept", b"text/event-stream")],
+        "path_params": {"user_id": user_id, "server_path": server_path},
+    }
+    return Request(scope)
+
+
+@pytest.mark.parametrize("user_id", INVALID_USER_IDS)
+async def test_post_proxy_rejects_invalid_user_id(user_id):
+    resp = await dynamic_mcp_post_proxy(
+        request=_post_request(user_id),
+        user_id=user_id,
+        server_path="github",
+        auth_context=_AUTH_CONTEXT,
+        server_service=Mock(),
+        oauth_service=Mock(),
+        proxy_client=Mock(),
+        redis_client=Mock(),
+    )
+    assert resp.status_code == 400
+    import json
+
+    body = json.loads(resp.body)
+    assert "detail" in body
+    assert "error" not in body
+
+
+@pytest.mark.parametrize("user_id", INVALID_USER_IDS)
+async def test_get_proxy_rejects_invalid_user_id(user_id):
+    resp = await dynamic_mcp_get_proxy(
+        request=_get_request(user_id),
+        user_id=user_id,
+        server_path="github",
+        auth_context=_AUTH_CONTEXT,
+        server_service=Mock(),
+        oauth_service=Mock(),
+        proxy_client=Mock(),
+        redis_client=Mock(),
+    )
+    assert resp.status_code == 400
+    import json
+
+    body = json.loads(resp.body)
+    assert "detail" in body
+    assert "error" not in body
+
+
+async def test_post_proxy_does_not_reject_valid_object_id(monkeypatch):
+    """A valid ObjectId must not be rejected at the user_id guard — processing continues."""
+    import json as _json
+
+    monkeypatch.setattr(
+        "registry.api.proxy_routes._parse_json_rpc_body",
+        AsyncMock(return_value={"jsonrpc": "2.0", "method": "tools/call", "id": 1}),
+    )
+    monkeypatch.setattr("registry.api.proxy_routes._is_notification", Mock(return_value=False))
+    monkeypatch.setattr("registry.api.proxy_routes._extract_request_id", Mock(return_value=1))
+
+    mock_server_service = AsyncMock()
+    mock_server_service.extract_server_path.return_value = None
+
+    resp = await dynamic_mcp_post_proxy(
+        request=_post_request(VALID_OBJECT_ID),
+        user_id=VALID_OBJECT_ID,
+        server_path="github",
+        auth_context=_AUTH_CONTEXT,
+        server_service=mock_server_service,
+        oauth_service=Mock(),
+        proxy_client=Mock(),
+        redis_client=Mock(),
+    )
+    # ObjectId guard would produce {"detail": "...invalid user ID..."}.
+    # Any other response (e.g. 404 for unknown server) means the guard passed.
+    if resp.status_code == 400:
+        body = _json.loads(resp.body)
+        assert "invalid user ID" not in body.get("detail", "")

--- a/registry/tests/unit/auth/test_downstream_token.py
+++ b/registry/tests/unit/auth/test_downstream_token.py
@@ -1,0 +1,97 @@
+"""Unit tests for downstream MCP confirmation tokens (mint + verify).
+
+The security-critical property is the ``(user_id, server_path)`` binding encoded in ``iss``:
+a token minted for one user/server must be rejected on any other user/server route.
+"""
+
+from registry.auth.downstream_token import (
+    DOWNSTREAM_MCP_TOKEN_TTL_SECONDS,
+    mint_downstream_mcp_token,
+    verify_downstream_mcp_token,
+)
+from registry.core.config import settings
+from registry_pkgs.core.downstream_oauth import downstream_mcp_issuer
+from registry_pkgs.core.jwt_tokens import mint_managed_agent_token
+
+USER_A = "507f1f77bcf86cd799439011"
+USER_B = "507f1f77bcf86cd799439012"
+
+
+def _mint(user_id: str = USER_A, server_path: str = "github") -> str:
+    return mint_downstream_mcp_token(settings.jwt_token_config, user_id=user_id, server_path=server_path)
+
+
+def _path(user_id: str = USER_A, server_path: str = "github") -> str:
+    return f"/proxy/server/{user_id}/{server_path}"
+
+
+def test_round_trip_returns_user_id():
+    token = _mint()
+    assert verify_downstream_mcp_token(token, _path(), settings.jwt_public_key) == USER_A
+
+
+def test_round_trip_with_sub_path():
+    # The token binds to whatever server_path string was used; a sub-path round-trips as long as
+    # mint and verify see the same string.
+    token = _mint(server_path="github/mcp")
+    assert verify_downstream_mcp_token(token, _path(server_path="github/mcp"), settings.jwt_public_key) == USER_A
+
+
+def test_rejects_cross_user():
+    # Token minted for user A, presented on user B's route → rejected (iss mismatch).
+    token = _mint(user_id=USER_A)
+    assert verify_downstream_mcp_token(token, _path(user_id=USER_B), settings.jwt_public_key) is None
+
+
+def test_rejects_cross_server():
+    # Token minted for github, presented on slack's route → rejected (iss mismatch).
+    token = _mint(server_path="github")
+    assert verify_downstream_mcp_token(token, _path(server_path="slack"), settings.jwt_public_key) is None
+
+
+def test_rejects_sub_path_mismatch():
+    # Bound to bare "github" but presented on "github/mcp" → rejected.
+    token = _mint(server_path="github")
+    assert verify_downstream_mcp_token(token, _path(server_path="github/mcp"), settings.jwt_public_key) is None
+
+
+def test_rejects_non_direct_connect_path():
+    token = _mint()
+    assert verify_downstream_mcp_token(token, "/proxy/mcpgw/mcp", settings.jwt_public_key) is None
+
+
+def test_rejects_managed_agent_token_wrong_class():
+    # A valid managed-agent token (different token_class, different iss) must not pass.
+    token = mint_managed_agent_token(
+        settings.jwt_token_config,
+        subject="alice",
+        client_id="mcp-client-abc",
+        expires_in_seconds=3600,
+        extra_claims={"scope": "mcp-proxy-ops"},
+    )
+    assert verify_downstream_mcp_token(token, _path(), settings.jwt_public_key) is None
+
+
+def test_rejects_garbage_token():
+    assert verify_downstream_mcp_token("not.a.jwt", _path(), settings.jwt_public_key) is None
+
+
+def test_rejects_expired_token(monkeypatch):
+    # Mint with a negative TTL so the token is already expired, then verify rejects it.
+    monkeypatch.setattr("registry.auth.downstream_token.DOWNSTREAM_MCP_TOKEN_TTL_SECONDS", -3600)
+    token = _mint()
+    assert verify_downstream_mcp_token(token, _path(), settings.jwt_public_key) is None
+
+
+def test_issuer_format_matches_helper():
+    # The token's iss must be exactly what the shared builder produces (the AS-metadata contract).
+    expected = downstream_mcp_issuer(settings.jwt_issuer, USER_A, "github")
+    assert expected == f"{settings.jwt_issuer}/proxy/server/oauth/{USER_A}/github"
+    # And a token minted for that pair verifies only on the matching path.
+    token = _mint()
+    assert verify_downstream_mcp_token(token, _path(), settings.jwt_public_key) == USER_A
+
+
+def test_ttl_constant_is_short():
+    # Guards against accidentally widening the confirmation token's lifetime.
+    assert DOWNSTREAM_MCP_TOKEN_TTL_SECONDS == 300

--- a/registry/tests/unit/middleware/test_auth_dispatch.py
+++ b/registry/tests/unit/middleware/test_auth_dispatch.py
@@ -3,12 +3,16 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from starlette.testclient import TestClient
 
+from registry.auth.downstream_token import mint_downstream_mcp_token
 from registry.core.config import settings
 from registry.middleware.auth import UnifiedAuthMiddleware
 from registry.utils.crypto_utils import generate_access_token
 from registry_pkgs.core.jwt_tokens import mint_managed_agent_token
 
 _COOKIE = settings.session_cookie_name
+
+USER_A = "507f1f77bcf86cd799439011"
+USER_B = "507f1f77bcf86cd799439012"
 
 
 def _build_app() -> FastAPI:
@@ -18,6 +22,10 @@ def _build_app() -> FastAPI:
     @app.get("/proxy/mcpgw/mcp")
     async def proxy_ep():  # pragma: no cover - body trivial
         return JSONResponse({"ok": "proxy"})
+
+    @app.get("/proxy/server/{user_id}/{server_path:path}")
+    async def direct_connect_ep(user_id: str, server_path: str):  # pragma: no cover - body trivial
+        return JSONResponse({"ok": "direct", "user_id": user_id, "server_path": server_path})
 
     @app.get("/api/v1/servers")
     async def crud_ep():  # pragma: no cover - body trivial
@@ -31,13 +39,16 @@ def client() -> TestClient:
     return TestClient(_build_app())
 
 
-def _managed_agent_token(client_id: str = "mcp-client-abc") -> str:
+def _managed_agent_token(client_id: str = "mcp-client-abc", user_id: str | None = None) -> str:
+    extra: dict = {"scope": "mcp-proxy-ops"}
+    if user_id is not None:
+        extra["user_id"] = user_id
     return mint_managed_agent_token(
         settings.jwt_token_config,
         subject="alice",
         client_id=client_id,
         expires_in_seconds=3600,
-        extra_claims={"scope": "mcp-proxy-ops"},
+        extra_claims=extra,
     )
 
 
@@ -116,6 +127,48 @@ def test_proxy_401_advertises_bearer_challenge(client):
     resp = client.get("/proxy/mcpgw/mcp")
     assert resp.status_code == 401
     assert resp.headers.get("WWW-Authenticate", "").startswith("Bearer")
+
+
+def _downstream_token(user_id: str = USER_A, server_path: str = "github") -> str:
+    return mint_downstream_mcp_token(settings.jwt_token_config, user_id=user_id, server_path=server_path)
+
+
+def test_direct_connect_accepts_matching_user_id(client):
+    token = _managed_agent_token(user_id=USER_A)
+    resp = client.get(f"/proxy/server/{USER_A}/github", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+
+
+def test_direct_connect_rejects_user_id_mismatch(client):
+    # User A's managed-agent token on user B's direct-connect URL must be rejected.
+    token = _managed_agent_token(user_id=USER_A)
+    resp = client.get(f"/proxy/server/{USER_B}/github", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_direct_connect_rejects_token_without_user_id(client):
+    # A managed-agent token carrying no user_id claim cannot satisfy the binding.
+    token = _managed_agent_token(user_id=None)
+    resp = client.get(f"/proxy/server/{USER_A}/github", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_direct_connect_accepts_downstream_confirmation_token(client):
+    token = _downstream_token(user_id=USER_A, server_path="github")
+    resp = client.get(f"/proxy/server/{USER_A}/github", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+
+
+def test_downstream_token_rejected_cross_user(client):
+    token = _downstream_token(user_id=USER_A, server_path="github")
+    resp = client.get(f"/proxy/server/{USER_B}/github", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_downstream_token_rejected_cross_server(client):
+    token = _downstream_token(user_id=USER_A, server_path="github")
+    resp = client.get(f"/proxy/server/{USER_A}/slack", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
 
 
 def test_all_proxy_router_paths_classify_as_proxy():

--- a/registry/tests/unit/middleware/test_auth_dispatch.py
+++ b/registry/tests/unit/middleware/test_auth_dispatch.py
@@ -24,12 +24,20 @@ def _build_app() -> FastAPI:
         return JSONResponse({"ok": "proxy"})
 
     @app.get("/proxy/server/{user_id}/{server_path:path}")
-    async def direct_connect_ep(user_id: str, server_path: str):  # pragma: no cover - body trivial
+    async def direct_connect_ep(user_id: str, server_path: str):
         return JSONResponse({"ok": "direct", "user_id": user_id, "server_path": server_path})
 
     @app.get("/api/v1/servers")
-    async def crud_ep():  # pragma: no cover - body trivial
+    async def crud_ep():
         return JSONResponse({"ok": "crud"})
+
+    @app.get("/api/v1/mcp/downstream/oauth/authorize/{user_id}/{server_path:path}")
+    async def ds_authorize_ep(user_id: str, server_path: str):
+        return JSONResponse({"ok": "authorize"})
+
+    @app.post("/api/v1/mcp/downstream/oauth/token/{user_id}/{server_path:path}")
+    async def ds_token_ep(user_id: str, server_path: str):
+        return JSONResponse({"ok": "token"})
 
     return app
 
@@ -168,6 +176,17 @@ def test_downstream_token_rejected_cross_user(client):
 def test_downstream_token_rejected_cross_server(client):
     token = _downstream_token(user_id=USER_A, server_path="github")
     resp = client.get(f"/proxy/server/{USER_A}/slack", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_downstream_token_endpoint_is_public(client):
+    # The PKCE-protected /token exchange carries no registry credential, so it must be public.
+    resp = client.post(f"/api/v1/mcp/downstream/oauth/token/{USER_A}/github")
+    assert resp.status_code == 200
+
+
+def test_downstream_authorize_endpoint_is_not_public(client):
+    resp = client.get(f"/api/v1/mcp/downstream/oauth/authorize/{USER_A}/github")
     assert resp.status_code == 401
 
 

--- a/registry/tests/unit/middleware/test_rbac.py
+++ b/registry/tests/unit/middleware/test_rbac.py
@@ -848,3 +848,26 @@ class TestIntegrationScenarios:
         client = TestClient(app)
         assert client.get("/workflows/abc").status_code == 200
         assert client.post("/workflows/abc/runs").status_code == 403
+
+
+@pytest.mark.unit
+class TestRealScopesConfigDownstreamOAuth:
+    """Validate the REAL scopes.yml (not a synthetic config) covers the Layer B /authorize endpoint."""
+
+    _USER_ID = "507f1f77bcf86cd799439011"
+
+    def test_authorize_granted_with_user_read(self):
+        mw = ScopePermissionMiddleware(FastAPI())
+        path = f"/mcp/downstream/oauth/authorize/{self._USER_ID}/github"
+        assert mw._has_permission(["user-read"], path, "GET") is True
+
+    def test_authorize_denied_without_user_read(self):
+        mw = ScopePermissionMiddleware(FastAPI())
+        path = f"/mcp/downstream/oauth/authorize/{self._USER_ID}/github"
+        assert mw._has_permission(["servers-read"], path, "GET") is False
+
+    def test_authorize_rule_matches_nested_server_path(self):
+        # server_path is a catch-all, so the rule's {path} must match slashes too.
+        mw = ScopePermissionMiddleware(FastAPI())
+        path = f"/mcp/downstream/oauth/authorize/{self._USER_ID}/github/sub/path"
+        assert mw._has_permission(["user-read"], path, "GET") is True

--- a/registry/tests/unit/services/test_token_service.py
+++ b/registry/tests/unit/services/test_token_service.py
@@ -7,10 +7,9 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from beanie import PydanticObjectId
 
-from registry.schemas.enums import TokenType
 from registry.schemas.oauth_schema import OAuthClientInformation, OAuthTokens
 from registry.services.oauth.token_service import TokenService
-from registry_pkgs.models import Token
+from registry_pkgs.models import Token, TokenType
 
 
 class TestTokenServiceBasicMethods:

--- a/tartufo.toml
+++ b/tartufo.toml
@@ -98,4 +98,5 @@ exclude-signatures = [
     {signature = '825ab751e8abc35b71f1a33d63fe5fa85ca647463334cf1f02051afe1536c582', reason = 'execute_agent ACL unit test uses a synthetic MongoDB ObjectId and mock base64 file blobs, not real credentials'},
     {signature = '36da6ea5898e1f2c93a7b27d083232c8bf77382183dd684040b8187ee63acf71', reason = 'proxied.py renamed to server.py — example MongoDB ObjectId in tool docstrings is not a credential'},
     {signature = '009966069305bd3305ca2391a2ec1e11bfc0ad98bf6d48a1f342ea01764a766e', reason = 'test_agent_invoke.py renamed to test_agent.py — synthetic ObjectIds and mock base64 file blobs are not credentials'},
+    {signature = '78d01adee21354e8a9067df8178b7a7627f8d23f7829c3519ab4de93e257daf4', reason = 'synthetic MongoDB ObjectId in downstream OAuth RBAC unit test is not a credential'},
 ]

--- a/tartufo.toml
+++ b/tartufo.toml
@@ -99,4 +99,5 @@ exclude-signatures = [
     {signature = '36da6ea5898e1f2c93a7b27d083232c8bf77382183dd684040b8187ee63acf71', reason = 'proxied.py renamed to server.py — example MongoDB ObjectId in tool docstrings is not a credential'},
     {signature = '009966069305bd3305ca2391a2ec1e11bfc0ad98bf6d48a1f342ea01764a766e', reason = 'test_agent_invoke.py renamed to test_agent.py — synthetic ObjectIds and mock base64 file blobs are not credentials'},
     {signature = '78d01adee21354e8a9067df8178b7a7627f8d23f7829c3519ab4de93e257daf4', reason = 'synthetic MongoDB ObjectId in downstream OAuth RBAC unit test is not a credential'},
+    {signature = 'c66d96e35e34cd9069c85814389a000667f2952f5cdc253776bb94b15b2fc0c3', reason = 'synthetic MongoDB ObjectId in unit test is not a credential'},
 ]

--- a/tartufo.toml
+++ b/tartufo.toml
@@ -100,4 +100,5 @@ exclude-signatures = [
     {signature = '009966069305bd3305ca2391a2ec1e11bfc0ad98bf6d48a1f342ea01764a766e', reason = 'test_agent_invoke.py renamed to test_agent.py — synthetic ObjectIds and mock base64 file blobs are not credentials'},
     {signature = '78d01adee21354e8a9067df8178b7a7627f8d23f7829c3519ab4de93e257daf4', reason = 'synthetic MongoDB ObjectId in downstream OAuth RBAC unit test is not a credential'},
     {signature = 'c66d96e35e34cd9069c85814389a000667f2952f5cdc253776bb94b15b2fc0c3', reason = 'synthetic MongoDB ObjectId in unit test is not a credential'},
+    {signature = 'd6e756c6b1841dacf1bc05da766d361ec1c495c1fc13db65b1e54a2ce59f4d8d', reason = 'synthetic MongoDB ObjectId in unit test is not a credential'},
 ]


### PR DESCRIPTION
## Summary
Adds a downstream OAuth flow where the registry acts as an authorization server (Layer B) in front of upstream MCP providers, and threads the user's identity through direct-connect proxy URLs so MCP clients can authenticate per-user.

## What changed
Downstream OAuth (registry-as-AS)
- New per-server authorize / token endpoints under /downstream/oauth/... (oauth_router.py), issuing short-lived Layer B codes bound to (user_id, server_path).
- Downstream confirmation tokens + middleware validation (auth/downstream_token.py, middleware/auth.py).
- Discovery exposed via auth-server well-known (well_known.py, downstream_token_service.py).
downstream_oauth helpers + scope user-read added (registry_pkgs/core/downstream_oauth.py, scopes.yml).

## Direct-connect proxy
- user_id is now threaded through the direct-connect proxy URL (/proxy/server/{user_id}/{path}), with a new GET/POST dynamic handler and an RFC 9728 401 discovery challenge for handshake methods (proxy_routes.py).