### PR TITLE
fix(mcpgw): render A2A image artifacts inline and as image renders using MCP ImageContent

### DIFF
--- a/registry/src/registry/mcpgw/tools/agent.py
+++ b/registry/src/registry/mcpgw/tools/agent.py
@@ -32,6 +32,9 @@ from ..core.types import McpAppContext
 
 logger = logging.getLogger(__name__)
 
+# MCP content blocks an A2A response can render to: text, inline image, or embedded resource.
+_AgentContent = TextContent | ImageContent | EmbeddedResource
+
 
 def _file_to_resource(f: FileWithBytes | FileWithUri) -> ImageContent | EmbeddedResource | None:
     """Convert one A2A file payload to its most faithful MCP content type.
@@ -70,9 +73,9 @@ def _file_to_resource(f: FileWithBytes | FileWithUri) -> ImageContent | Embedded
     return None
 
 
-def _render_artifact(artifact: Artifact) -> list[TextContent | ImageContent | EmbeddedResource]:
+def _render_artifact(artifact: Artifact) -> list[_AgentContent]:
     """Render one artifact as text (with `[<name>]` label) + files + data."""
-    items: list[TextContent | ImageContent | EmbeddedResource] = []
+    items: list[_AgentContent] = []
     text = get_artifact_text(artifact, delimiter="")
     if text:
         labelled = f"[{artifact.name}]\n{text}" if artifact.name else text
@@ -86,9 +89,9 @@ def _render_artifact(artifact: Artifact) -> list[TextContent | ImageContent | Em
     return items
 
 
-def _render_message(message: Message) -> list[TextContent | ImageContent | EmbeddedResource]:
+def _render_message(message: Message) -> list[_AgentContent]:
     """Render a Message reply as text + files + data (no label — single block)."""
-    items: list[TextContent | ImageContent | EmbeddedResource] = []
+    items: list[_AgentContent] = []
     text = get_message_text(message)
     if text:
         items.append(TextContent(type="text", text=text))
@@ -102,11 +105,11 @@ def _render_message(message: Message) -> list[TextContent | ImageContent | Embed
     return items
 
 
-def _render_task(task: Task) -> list[TextContent | ImageContent | EmbeddedResource]:
+def _render_task(task: Task) -> list[_AgentContent]:
     """Render a Task's content. Per the A2A spec, both `task.status.message`
     and `task.artifacts` carry content — surface both in that order
     (matches a2a-samples host_agent.py)."""
-    items: list[TextContent | ImageContent | EmbeddedResource] = []
+    items: list[_AgentContent] = []
     if task.status.message is not None:
         items.extend(_render_message(task.status.message))
     for artifact in task.artifacts or []:
@@ -114,7 +117,7 @@ def _render_task(task: Task) -> list[TextContent | ImageContent | EmbeddedResour
     return items
 
 
-def _convert_response(result: A2ACallResult) -> list[TextContent | ImageContent | EmbeddedResource]:
+def _convert_response(result: A2ACallResult) -> list[_AgentContent]:
     """Render the successful A2ACallResult into MCP content items."""
     if result.message is not None:
         return _render_message(result.message)

--- a/registry/src/registry/mcpgw/tools/agent.py
+++ b/registry/src/registry/mcpgw/tools/agent.py
@@ -17,6 +17,7 @@ from mcp.types import (
     BlobResourceContents,
     CallToolResult,
     EmbeddedResource,
+    ImageContent,
     TextContent,
     TextResourceContents,
 )
@@ -32,15 +33,28 @@ from ..core.types import McpAppContext
 logger = logging.getLogger(__name__)
 
 
-def _file_to_resource(f: FileWithBytes | FileWithUri) -> EmbeddedResource | None:
-    """Convert one A2A file payload to an MCP EmbeddedResource. None for unsupported."""
+def _file_to_resource(f: FileWithBytes | FileWithUri) -> ImageContent | EmbeddedResource | None:
+    """Convert one A2A file payload to its most faithful MCP content type.
+
+    image/* FileWithBytes -> ImageContent  (MCP hosts render this inline)
+    other   FileWithBytes -> EmbeddedResource(BlobResourceContents)  (lossless fallback)
+    FileWithUri           -> EmbeddedResource(TextResourceContents)
+    None for unsupported payload types.
+    """
     if isinstance(f, FileWithBytes):
+        mime = f.mime_type or "application/octet-stream"
+        # MIME types are case-insensitive and may carry parameters (RFC 6838); normalize for dispatch.
+        media_type = mime.split(";", 1)[0].strip().lower()
+        if media_type.startswith("image/"):
+            # f.bytes is already base64-encoded by the a2a SDK and is passed through verbatim into
+            # ImageContent.data — no decode/re-encode. The original mimeType is preserved.
+            return ImageContent(type="image", data=f.bytes, mimeType=mime)
         return EmbeddedResource(
             type="resource",
             resource=BlobResourceContents(
                 uri=AnyUrl(f"urn:a2a:file:{uuid.uuid4().hex}"),
                 blob=f.bytes,  # already base64-encoded by the a2a SDK
-                mimeType=f.mime_type or "application/octet-stream",
+                mimeType=mime,
             ),
         )
     if isinstance(f, FileWithUri):
@@ -56,9 +70,9 @@ def _file_to_resource(f: FileWithBytes | FileWithUri) -> EmbeddedResource | None
     return None
 
 
-def _render_artifact(artifact: Artifact) -> list[TextContent | EmbeddedResource]:
+def _render_artifact(artifact: Artifact) -> list[TextContent | ImageContent | EmbeddedResource]:
     """Render one artifact as text (with `[<name>]` label) + files + data."""
-    items: list[TextContent | EmbeddedResource] = []
+    items: list[TextContent | ImageContent | EmbeddedResource] = []
     text = get_artifact_text(artifact, delimiter="")
     if text:
         labelled = f"[{artifact.name}]\n{text}" if artifact.name else text
@@ -72,9 +86,9 @@ def _render_artifact(artifact: Artifact) -> list[TextContent | EmbeddedResource]
     return items
 
 
-def _render_message(message: Message) -> list[TextContent | EmbeddedResource]:
+def _render_message(message: Message) -> list[TextContent | ImageContent | EmbeddedResource]:
     """Render a Message reply as text + files + data (no label — single block)."""
-    items: list[TextContent | EmbeddedResource] = []
+    items: list[TextContent | ImageContent | EmbeddedResource] = []
     text = get_message_text(message)
     if text:
         items.append(TextContent(type="text", text=text))
@@ -88,11 +102,11 @@ def _render_message(message: Message) -> list[TextContent | EmbeddedResource]:
     return items
 
 
-def _render_task(task: Task) -> list[TextContent | EmbeddedResource]:
+def _render_task(task: Task) -> list[TextContent | ImageContent | EmbeddedResource]:
     """Render a Task's content. Per the A2A spec, both `task.status.message`
     and `task.artifacts` carry content — surface both in that order
     (matches a2a-samples host_agent.py)."""
-    items: list[TextContent | EmbeddedResource] = []
+    items: list[TextContent | ImageContent | EmbeddedResource] = []
     if task.status.message is not None:
         items.extend(_render_message(task.status.message))
     for artifact in task.artifacts or []:
@@ -100,7 +114,7 @@ def _render_task(task: Task) -> list[TextContent | EmbeddedResource]:
     return items
 
 
-def _convert_response(result: A2ACallResult) -> list[TextContent | EmbeddedResource]:
+def _convert_response(result: A2ACallResult) -> list[TextContent | ImageContent | EmbeddedResource]:
     """Render the successful A2ACallResult into MCP content items."""
     if result.message is not None:
         return _render_message(result.message)

--- a/registry/tests/unit/mcpgw/test_agent.py
+++ b/registry/tests/unit/mcpgw/test_agent.py
@@ -332,6 +332,21 @@ def test_convert_response_message_image_file_with_bytes():
     assert items[0].mimeType == "image/png"
 
 
+def test_convert_response_image_mimetype_case_and_params_normalized():
+    """Image dispatch normalizes the mime for matching (case-insensitive, strips RFC 6838
+    parameters) yet preserves the original declared mimeType on the ImageContent."""
+    declared = "IMAGE/PNG; charset=binary"
+    artifact = _text_artifact(
+        "Diagram",
+        "",
+        extra_parts=[Part(root=FilePart(kind="file", file=FileWithBytes(bytes="iVBORw0KGgo=", mimeType=declared)))],
+    )
+    items = _convert_response(_result_with_task(artifact))
+    assert len(items) == 1
+    assert isinstance(items[0], ImageContent)
+    assert items[0].mimeType == declared
+
+
 def test_convert_response_task_file_with_uri():
     artifact = _text_artifact(
         "Report",

--- a/registry/tests/unit/mcpgw/test_agent.py
+++ b/registry/tests/unit/mcpgw/test_agent.py
@@ -17,7 +17,7 @@ from a2a.types import (
     TextPart,
 )
 from beanie import PydanticObjectId
-from mcp.types import BlobResourceContents, EmbeddedResource, TextContent, TextResourceContents
+from mcp.types import BlobResourceContents, EmbeddedResource, ImageContent, TextContent, TextResourceContents
 
 from registry.mcpgw.tools import agent
 from registry.mcpgw.tools.agent import AgentMessageInput, _convert_response, execute_agent_impl
@@ -299,6 +299,39 @@ def test_convert_response_task_file_with_bytes():
     assert "urn:a2a:file:" in str(resource.uri)
 
 
+def test_convert_response_task_image_file_with_bytes():
+    """image/* FileWithBytes render as inline ImageContent (not an opaque blob resource),
+    preserving the base64 payload verbatim. This is the reported image_agent path."""
+    b64_data = "iVBORw0KGgo="
+    artifact = _text_artifact(
+        "Diagram",
+        "",
+        extra_parts=[Part(root=FilePart(kind="file", file=FileWithBytes(bytes=b64_data, mimeType="image/png")))],
+    )
+    items = _convert_response(_result_with_task(artifact))
+    assert len(items) == 1
+    assert isinstance(items[0], ImageContent)
+    assert items[0].data == b64_data
+    assert items[0].mimeType == "image/png"
+
+
+def test_convert_response_message_image_file_with_bytes():
+    """`_file_to_resource` is shared by `_render_message`, so an image carried on a
+    Message reply (not a Task artifact) must also become inline ImageContent."""
+    b64_data = "iVBORw0KGgo="
+    msg = Message(
+        kind="message",
+        role=Role.user,
+        message_id="m",
+        parts=[Part(root=FilePart(kind="file", file=FileWithBytes(bytes=b64_data, mimeType="image/png")))],
+    )
+    items = _convert_response(A2ACallResult(message=msg, success=True))
+    assert len(items) == 1
+    assert isinstance(items[0], ImageContent)
+    assert items[0].data == b64_data
+    assert items[0].mimeType == "image/png"
+
+
 def test_convert_response_task_file_with_uri():
     artifact = _text_artifact(
         "Report",
@@ -338,8 +371,8 @@ def test_convert_response_task_multiple_files_get_unique_uris():
         "Bundle",
         "",
         extra_parts=[
-            Part(root=FilePart(kind="file", file=FileWithBytes(bytes=b64_data, mimeType="image/png"))),
-            Part(root=FilePart(kind="file", file=FileWithBytes(bytes=b64_data, mimeType="image/png"))),
+            Part(root=FilePart(kind="file", file=FileWithBytes(bytes=b64_data, mimeType="application/pdf"))),
+            Part(root=FilePart(kind="file", file=FileWithBytes(bytes=b64_data, mimeType="application/pdf"))),
         ],
     )
     items = _convert_response(_result_with_task(artifact))


### PR DESCRIPTION
## Background
  The `execute_agent` mcpgw tool relays an A2A agent's response to the calling
  MCP host. Agents that produce images return them as inline base64
  `FileWithBytes` parts (e.g. image_agent returns PNG/JPEG diagrams as `image/*`
  artifacts).
  
  ## Problem
  `_file_to_resource` converted every `FileWithBytes` — images included — into a
  generic MCP `EmbeddedResource`/`BlobResourceContents`. Since `BlobResourceContents`
  requires a `uri`, the code minted a throwaway `urn:a2a:file:<uuid>` that is not
  stored, not addressable, and has no dereference endpoint. Hosts treat such generic
  blobs as opaque attachments and surface that URN instead of the image, so users
  saw `urn:a2a:file:…` handles rather than the picture, and downstream chat clients
  never routed the bytes into their file-persistence path. The bytes were always
  present — the MCP representation was simply wrong for images.

  ## Intent
  Relay images in the representation MCP hosts actually render and persist, with no
  change required of agents or chat clients.

  ## Method
  - Route `image/*` `FileWithBytes` to MCP's native `ImageContent` (`type=image`,
    base64 `data`, `mimeType`) instead of a blob resource. `ImageContent` is the
    standard inline-image type every spec-compliant host renders; the base64 is
    passed through verbatim (no decode/re-encode) and the original `mimeType` is
    preserved. 
  - Normalize the mime for matching (case-insensitive, strips RFC 6838 parameters)
    so labels like `IMAGE/PNG; charset=binary` still dispatch correctly.
  - Non-image `FileWithBytes` keep the existing `BlobResourceContents` path — it
    relays any format losslessly and there is no better MCP type for them;
    `FileWithUri` is unchanged. This keeps the fix surgical and avoids regressing
    other file types.
  - Audio / size-guard / hosted-URL variants were considered and intentionally
    deferred (no current need, available in future).

  ## Changes
  - `_file_to_resource`: add the `image/*` → `ImageContent` branch.
  - Widen the render/convert return types to include `ImageContent`, via a new
    `_AgentContent` alias (removes a 7×-repeated union).
  - Tests: image artifact on both the task and message paths; mimeType
    normalization + preservation; existing multi-file blob-URI test retargeted to a
    non-image type. 