### PR TITLE
Improve error handling mechanisms

### DIFF
--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
@@ -316,10 +316,12 @@ def _result_from_task(task: Task) -> A2ACallResult:
         )
 
     # Remaining: failed / canceled / rejected / unknown.
+    detail = get_message_text(task.status.message) if task.status.message is not None else ""
+    base = f"task terminated in non-completed state: {state.value}"
     return A2ACallResult(
         task=task,
         success=False,
-        error=f"task terminated in non-completed state: {state.value}",
+        error=f"{base} — {detail}" if detail else base,
     )
 
 

--- a/registry-pkgs/tests/unit/workflow/test_a2a_client.py
+++ b/registry-pkgs/tests/unit/workflow/test_a2a_client.py
@@ -478,6 +478,32 @@ async def test_call_a2a_non_completed_terminal_state_returns_failure_with_task()
 
 
 @pytest.mark.asyncio
+async def test_call_a2a_failed_surfaces_status_message_detail():
+    """Failed Task with a status.message → reason text surfaces in error; success=False."""
+    agent = _make_agent()
+    reason = "agent overloaded (HTTP 503), retryable, retry in a few minutes"
+    failed_task = Task(
+        id="t",
+        context_id="c",
+        kind="task",
+        status=TaskStatus(state=TaskState.failed, message=_msg(reason)),
+        artifacts=None,
+    )
+    mock_factory, _ = _mock_client([(failed_task, None)])
+
+    with (
+        patch("registry_pkgs.workflows.a2a_client.build_headers", return_value={}),
+        patch("registry_pkgs.workflows.a2a_client.ClientFactory", return_value=mock_factory),
+    ):
+        result = await call_a2a(agent, "test", jwt_config=_jwt_config())
+
+    assert result.success is False
+    assert result.task_state == TaskState.failed
+    assert "non-completed" in result.error
+    assert reason in result.error
+
+
+@pytest.mark.asyncio
 async def test_call_a2a_uses_http_json_protocol_for_rest_transport():
     """ClientConfig must receive TransportProtocol.http_json for http_json agents."""
     agent = _make_agent(transport="http_json")

--- a/registry/tests/unit/mcpgw/test_agent.py
+++ b/registry/tests/unit/mcpgw/test_agent.py
@@ -247,6 +247,31 @@ async def test_execute_agent_a2a_failure_returns_error():
 
 
 @pytest.mark.asyncio
+async def test_execute_agent_a2a_failure_surfaces_status_message_detail():
+    """A terminal `failed` task surfaces its status.message reason to the caller."""
+    ctx = _make_ctx()
+    valid_id = str(PydanticObjectId())
+    agent = _make_agent(valid_id)
+    reason = "agent overloaded (HTTP 503), retryable, retry in a few minutes"
+
+    with (
+        patch("registry.mcpgw.tools.agent.A2AAgent") as mock_model,
+        patch("registry.mcpgw.tools.agent.call_a2a", new_callable=AsyncMock) as mock_call,
+    ):
+        mock_model.id = MagicMock()
+        mock_model.find_one = AsyncMock(return_value=agent)
+        mock_call.return_value = A2ACallResult(
+            success=False,
+            error=f"task terminated in non-completed state: failed — {reason}",
+        )
+
+        result = await execute_agent_impl(valid_id, _msg("Do something"), ctx)
+
+    assert result.isError is True
+    assert reason in result.content[0].text
+
+
+@pytest.mark.asyncio
 async def test_get_tools_returns_execute_agent():
     tools = agent.get_tools()
     names = [name for name, _ in tools]


### PR DESCRIPTION
This pull request improves error reporting for failed or non-completed agent tasks by ensuring that detailed status messages from the task are included in error outputs. It also adds new tests to verify that these error details are correctly surfaced to callers.

**Enhanced error reporting for failed agent tasks:**

* Modified the `_result_from_task` function in `a2a_client.py` to include the `status.message` detail in the error message when a task fails, providing more context about the failure.

**Improved test coverage for error details:**

* Added a test in `test_a2a_client.py` to verify that when a task fails with a status message, the error returned includes both the generic failure message and the specific reason.
* Added a test in `test_agent.py` to ensure that the detailed reason from a failed task's status message is surfaced to the caller in the execution result.