### PR TITLE
Hotfix: MCP on AgentCore Runtime should advertise root AS metadata route on 401

### DIFF
--- a/auth-server/src/auth_server/container.py
+++ b/auth-server/src/auth_server/container.py
@@ -9,6 +9,7 @@ from .providers.factory import get_auth_provider
 from .services.cognito_validator_service import SimplifiedCognitoValidator
 from .services.downstream_token_service import DownstreamTokenCheckService
 from .services.oauth_state_store import OAuthStateStore
+from .services.server_service import ServerService
 from .services.user_service import UserService
 from .utils.config_loader import AuthProviderConfig, EntraConfig, OAuth2Config, OAuth2ConfigLoader
 
@@ -26,6 +27,10 @@ class AuthContainer:
     @property
     def oauth2_config(self) -> OAuth2Config:
         return self._oauth2_config
+
+    @cached_property
+    def server_service(self) -> ServerService:
+        return ServerService()
 
     @cached_property
     def user_service(self) -> UserService:

--- a/auth-server/src/auth_server/deps.py
+++ b/auth-server/src/auth_server/deps.py
@@ -8,12 +8,17 @@ from .providers.base import AuthProvider
 from .services.cognito_validator_service import SimplifiedCognitoValidator
 from .services.downstream_token_service import DownstreamTokenCheckService
 from .services.oauth_state_store import OAuthStateStore
+from .services.server_service import ServerService
 from .services.user_service import UserService
 from .utils.config_loader import OAuth2Config
 
 
 def get_container(request: Request) -> AuthContainer:
     return request.app.state.container
+
+
+def get_server_service(container: AuthContainer = Depends(get_container)) -> ServerService:
+    return container.server_service
 
 
 def get_user_service(container: AuthContainer = Depends(get_container)) -> UserService:

--- a/auth-server/src/auth_server/routes/well_known.py
+++ b/auth-server/src/auth_server/routes/well_known.py
@@ -169,11 +169,11 @@ async def protected_resource_metadata(server_path: str):
     The current way of writing it only makes a difference when running services locally in Docker Compose,
     where registry backend and auth-server live on different ports of localhost.
 
-    Direct-connect resources have the shape ``server/{user_id}/{actual_server_path}``. For those, the
-    advertised authorization server is always the per-server downstream issuer, so that MCP clients
-    (e.g. VS Code) always go through the downstream OAuth flow and receive a managed-agent token
-    bound to that specific (user_id, server_path) pair.
-    **MCP client such as VS Code caches the discovered AS metadata URL, so it only uses the first-time discovered URL no matter what.**
+    Direct-connect resources have the shape ``server/{user_id}/{actual_server_path}``. For MCPs NOT on AgentCore Runtime,
+    the advertised authorization server is the per-server downstream issuer, so that MCP clients (e.g. VS Code) go through
+    the downstream OAuth flow and receive a managed-agent token bound to that specific (user_id, server_path) pair.
+    MCP client such as VS Code caches the discovered AS metadata URL, so it only uses the first-time discovered URL no matter what.
+    For AgentCore Runtime MCPs, the root Authorization Server metadata is advertised.
     """
     authorization_servers = [settings.jwt_issuer]
 

--- a/auth-server/src/auth_server/routes/well_known.py
+++ b/auth-server/src/auth_server/routes/well_known.py
@@ -182,7 +182,14 @@ async def protected_resource_metadata(server_path: str):
         parts = rest.split("/", 1)
         if len(parts) == 2 and parts[0] and parts[1]:
             user_id, actual_server_path = parts[0], parts[1]
-            authorization_servers = [downstream_mcp_issuer(settings.jwt_issuer, user_id, actual_server_path)]
+            # MCPs on AgentCore Runtime use the root AS metadata document—because we don't need to store
+            # access and refresh tokens of such MCPs in MongoDB—instead, Registry mints a JWT token for AgentCore Runtime
+            # at the point of invocation. Root AS metadata gives user access to Registry itself, and that's also sufficient.
+            # The condition in the `if` block below relies on the fact that MCPs on AgentCore Runtime have a `path` field
+            # of the format `/agentcore/mcp/***`, which is guaranteed by AgentCore federation code at
+            # @registry/src/registry/services/federation/agentcore_discovery.py#L377-377.
+            if not actual_server_path.startswith("agentcore/mcp/"):
+                authorization_servers = [downstream_mcp_issuer(settings.jwt_issuer, user_id, actual_server_path)]
 
     return {
         "resource": f"{settings.registry_url}/proxy/{server_path}",

--- a/auth-server/src/auth_server/routes/well_known.py
+++ b/auth-server/src/auth_server/routes/well_known.py
@@ -7,13 +7,15 @@ Also implements RFC 9728 Protected Resource Metadata.
 
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
 from registry_pkgs.core.downstream_oauth import DOWNSTREAM_OAUTH_NAMESPACE, downstream_mcp_issuer
 from registry_pkgs.core.jwt_utils import build_jwks
 
 # Import settings
 from ..core.config import settings
+from ..deps import get_server_service
+from ..services.server_service import ServerService
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +161,10 @@ async def jwks_endpoint():
 
 
 @router.get(f"/.well-known/oauth-protected-resource{settings.service_base_path}/proxy/{{server_path:path}}")
-async def protected_resource_metadata(server_path: str):
+async def protected_resource_metadata(
+    server_path: str,
+    server_service: ServerService = Depends(get_server_service),
+):
     """
     `resource` lives on the registry backend, so we use `settings.registry_url`.
     `authorization_servers` includes our auth-server, so we use `settings.jwt_issuer`,
@@ -169,11 +174,13 @@ async def protected_resource_metadata(server_path: str):
     The current way of writing it only makes a difference when running services locally in Docker Compose,
     where registry backend and auth-server live on different ports of localhost.
 
-    Direct-connect resources have the shape ``server/{user_id}/{actual_server_path}``. For MCPs NOT on AgentCore Runtime,
-    the advertised authorization server is the per-server downstream issuer, so that MCP clients (e.g. VS Code) go through
-    the downstream OAuth flow and receive a managed-agent token bound to that specific (user_id, server_path) pair.
-    MCP client such as VS Code caches the discovered AS metadata URL, so it only uses the first-time discovered URL no matter what.
-    For AgentCore Runtime MCPs, the root Authorization Server metadata is advertised.
+    Direct-connect resources have the shape ``server/{user_id}/{actual_server_path}``. The advertised authorization server
+    is the per-server downstream issuer only when the server has `$.config.requiresOAuth=True` — so that MCP clients
+    (e.g. VS Code) go through the downstream OAuth flow and receive a managed-agent token bound to that specific
+    (user_id, server_path) pair. MCP client such as VS Code caches the discovered AS metadata URL, so it only uses
+    the first-time discovered URL no matter what.
+    For servers that do not require downstream OAuth (e.g. AgentCore Runtime MCPs, API key based server, public server),
+    the root AS metadata is advertised.
     """
     authorization_servers = [settings.jwt_issuer]
 
@@ -182,13 +189,7 @@ async def protected_resource_metadata(server_path: str):
         parts = rest.split("/", 1)
         if len(parts) == 2 and parts[0] and parts[1]:
             user_id, actual_server_path = parts[0], parts[1]
-            # MCPs on AgentCore Runtime use the root AS metadata document—because we don't need to store
-            # access and refresh tokens of such MCPs in MongoDB—instead, Registry mints a JWT token for AgentCore Runtime
-            # at the point of invocation. Root AS metadata gives user access to Registry itself, and that's also sufficient.
-            # The condition in the `if` block below relies on the fact that MCPs on AgentCore Runtime have a `path` field
-            # of the format `/agentcore/mcp/***`, which is guaranteed by AgentCore federation code at
-            # @registry/src/registry/services/federation/agentcore_discovery.py#L377-377.
-            if not actual_server_path.startswith("agentcore/mcp/"):
+            if await server_service.requires_oauth(actual_server_path):
                 authorization_servers = [downstream_mcp_issuer(settings.jwt_issuer, user_id, actual_server_path)]
 
     return {

--- a/auth-server/src/auth_server/services/server_service.py
+++ b/auth-server/src/auth_server/services/server_service.py
@@ -1,0 +1,48 @@
+"""
+Server service for auth-server - handles user lookups of ExtendedMCPServer from MongoDB.
+"""
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel
+
+from registry_pkgs.models import ExtendedMCPServer
+
+logger = logging.getLogger(__name__)
+
+
+class _RequiresOAuthProjection(BaseModel):
+    config: dict[str, Any]
+
+    class Settings:
+        projection = {"config.requiresOAuth": 1, "_id": 0}
+
+
+class ServerService:
+    """Service for server-related operations in auth-server."""
+
+    def __init__(self) -> None:
+        self._requires_oauth_cache: dict[str, bool] = {}
+
+    async def requires_oauth(self, server_path: str) -> bool:
+        """Return whether the server requires downstream OAuth.
+
+        Args:
+            server_path: Bare server path without leading slash (e.g. ``github``, ``agentcore/mcp/myserver``).
+
+        Returns:
+            Value of ``config.requiresOAuth``; False when the field is absent or the server does not exist.
+        """
+        normalized = f"/{server_path}"
+        if normalized in self._requires_oauth_cache:
+            return self._requires_oauth_cache[normalized]
+
+        # MongoDB errors bubble up unhandled and become HTTP 500 in the route layer.
+        doc = await ExtendedMCPServer.find_one({"path": normalized}, projection_model=_RequiresOAuthProjection)
+
+        result = bool(doc.config.get("requiresOAuth", False)) if doc else False
+
+        self._requires_oauth_cache[normalized] = result
+
+        return result

--- a/auth-server/src/auth_server/services/server_service.py
+++ b/auth-server/src/auth_server/services/server_service.py
@@ -3,6 +3,7 @@ Server service for auth-server - handles user lookups of ExtendedMCPServer from 
 """
 
 import logging
+from collections import OrderedDict
 from typing import Any
 
 from pydantic import BaseModel
@@ -23,7 +24,8 @@ class ServerService:
     """Service for server-related operations in auth-server."""
 
     def __init__(self) -> None:
-        self._requires_oauth_cache: dict[str, bool] = {}
+        self._cache_max_size = 1024
+        self._requires_oauth_cache: OrderedDict[str, bool] = OrderedDict()
 
     async def requires_oauth(self, server_path: str) -> bool:
         """Return whether the server requires downstream OAuth.
@@ -34,15 +36,19 @@ class ServerService:
         Returns:
             Value of ``config.requiresOAuth``; False when the field is absent or the server does not exist.
         """
-        normalized = f"/{server_path}"
+
+        normalized = "/" + server_path.lstrip("/")
         if normalized in self._requires_oauth_cache:
             return self._requires_oauth_cache[normalized]
 
         # MongoDB errors bubble up unhandled and become HTTP 500 in the route layer.
+        logger.info(f"querying '{normalized}' MCP server for $.config.requiresOAuth")
         doc = await ExtendedMCPServer.find_one({"path": normalized}, projection_model=_RequiresOAuthProjection)
 
         result = bool(doc.config.get("requiresOAuth", False)) if doc else False
 
         self._requires_oauth_cache[normalized] = result
+        if len(self._requires_oauth_cache) > self._cache_max_size:
+            self._requires_oauth_cache.popitem(last=False)
 
         return result

--- a/auth-server/tests/integration/test_downstream_well_known.py
+++ b/auth-server/tests/integration/test_downstream_well_known.py
@@ -3,16 +3,31 @@
 - per-server authorization server metadata (RFC 8414)
 """
 
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 from fastapi.testclient import TestClient
 
 from auth_server.core.config import settings
+from auth_server.deps import get_server_service
 from registry_pkgs.core.downstream_oauth import downstream_mcp_issuer
 
 USER_ID = "507f1f77bcf86cd799439011"
 _PRM_BASE = f"/.well-known/oauth-protected-resource{settings.service_base_path}/proxy"
 
 
-def test_prm_direct_connect_points_to_downstream_issuer(test_client: TestClient):
+@pytest.fixture
+def mock_server_service(auth_server_app):
+    """Override get_server_service so tests don't hit MongoDB. Default: server does not require OAuth."""
+    svc = MagicMock()
+    svc.requires_oauth = AsyncMock(return_value=False)
+    auth_server_app.dependency_overrides[get_server_service] = lambda: svc
+    yield svc
+    auth_server_app.dependency_overrides.pop(get_server_service, None)
+
+
+def test_prm_direct_connect_points_to_downstream_issuer(test_client: TestClient, mock_server_service):
+    mock_server_service.requires_oauth = AsyncMock(return_value=True)
     resp = test_client.get(f"{_PRM_BASE}/server/{USER_ID}/github")
     assert resp.status_code == 200
     body = resp.json()
@@ -27,10 +42,8 @@ def test_prm_non_direct_connect_unchanged(test_client: TestClient):
     assert resp.json()["authorization_servers"] == [settings.jwt_issuer]
 
 
-def test_prm_direct_connect_agentcore_points_to_root_issuer(test_client: TestClient):
-    # AgentCore Runtime MCPs don't need a downstream OAuth token — the registry mints a JWT at
-    # proxy time. Advertising the root issuer here sends the client through the registry's own
-    # auth flow instead of triggering a downstream OAuth browser popup.
+def test_prm_direct_connect_no_oauth_points_to_root_issuer(test_client: TestClient, mock_server_service):
+    # Servers with requiresOAuth=False (including AgentCore Runtime MCPs) advertise the root issuer.
     resp = test_client.get(f"{_PRM_BASE}/server/{USER_ID}/agentcore/mcp/myserver")
     assert resp.status_code == 200
     assert resp.json()["authorization_servers"] == [settings.jwt_issuer]

--- a/auth-server/tests/integration/test_downstream_well_known.py
+++ b/auth-server/tests/integration/test_downstream_well_known.py
@@ -27,6 +27,15 @@ def test_prm_non_direct_connect_unchanged(test_client: TestClient):
     assert resp.json()["authorization_servers"] == [settings.jwt_issuer]
 
 
+def test_prm_direct_connect_agentcore_points_to_root_issuer(test_client: TestClient):
+    # AgentCore Runtime MCPs don't need a downstream OAuth token — the registry mints a JWT at
+    # proxy time. Advertising the root issuer here sends the client through the registry's own
+    # auth flow instead of triggering a downstream OAuth browser popup.
+    resp = test_client.get(f"{_PRM_BASE}/server/{USER_ID}/agentcore/mcp/myserver")
+    assert resp.status_code == 200
+    assert resp.json()["authorization_servers"] == [settings.jwt_issuer]
+
+
 def test_downstream_as_metadata_issuer_and_endpoints(test_client: TestClient):
     resp = test_client.get(f"/.well-known/oauth-authorization-server/proxy/server/oauth/{USER_ID}/github")
     assert resp.status_code == 200

--- a/registry/src/registry/services/federation/agentcore_discovery.py
+++ b/registry/src/registry/services/federation/agentcore_discovery.py
@@ -372,6 +372,8 @@ class AgentCoreFederationClient:
 
         server_info = {
             "server_name": runtime_name,
+            # The `path` field of an MCP server federated from AWS AgentCore Runtime must be of the following format.
+            # In @auth-server/src/auth_server/routes/well_known.py, we use the path format to tell if an MCP is on AgentCore.
             "path": f"/agentcore/mcp/{self._slug(runtime_name)}",
             "tags": ["bedrock", "agentcore", "aws", "mcp-runtime", "federated"],
             "config": {

--- a/registry/src/registry/services/federation/agentcore_discovery.py
+++ b/registry/src/registry/services/federation/agentcore_discovery.py
@@ -372,8 +372,6 @@ class AgentCoreFederationClient:
 
         server_info = {
             "server_name": runtime_name,
-            # The `path` field of an MCP server federated from AWS AgentCore Runtime must be of the following format.
-            # In @auth-server/src/auth_server/routes/well_known.py, we use the path format to tell if an MCP is on AgentCore.
             "path": f"/agentcore/mcp/{self._slug(runtime_name)}",
             "tags": ["bedrock", "agentcore", "aws", "mcp-runtime", "federated"],
             "config": {


### PR DESCRIPTION
Because such MCPs don't need to manage downstream access and refresh tokens—Registry mints a JWT for AgentCore at invocation time. For such MCPs, we just need to give users access to Registry itself to enable "direct connect" mode.

Update:
- All downstream MCPs that don't need OAuth should advertise root AS metadata.
- Whether an MCP requires OAuth or not depends on `ExtendedMCPServer.config.requiresOAuth`.