### PR TITLE
Feature/AS 1686 Enforce MCP server ACL on tool execution and proxy paths

### DIFF
--- a/registry/src/registry/api/proxy_routes.py
+++ b/registry/src/registry/api/proxy_routes.py
@@ -657,6 +657,7 @@ async def dynamic_mcp_post_proxy(
     oauth_service: MCPOAuthService = Depends(get_oauth_service),
     proxy_client: httpx.AsyncClient = Depends(get_mcp_proxy_client),
     redis_client: Redis = Depends(get_redis_client),
+    acl_service: ACLService = Depends(get_acl_service),
 ):
     """
     Dynamic catch-all route for MCP server proxying, but only works for POST.
@@ -721,6 +722,19 @@ async def dynamic_mcp_post_proxy(
             ),
         )
 
+    try:
+        await acl_service.check_user_permission(
+            user_id=PydanticObjectId(auth_context["user_id"]),
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_id=server.id,
+            required_permission="VIEW",
+        )
+    except HTTPException:
+        return JSONResponse(
+            status_code=200,
+            content=_build_jsonrpc_error_result(request_id, "Access denied to this MCP server."),
+        )
+
     # Check if server is enabled
     config = server.config or {}
     if not config.get("enabled", False):
@@ -778,6 +792,7 @@ async def dynamic_mcp_get_proxy(
     oauth_service: MCPOAuthService = Depends(get_oauth_service),
     proxy_client: httpx.AsyncClient = Depends(get_mcp_proxy_client),
     redis_client: Redis = Depends(get_redis_client),
+    acl_service: ACLService = Depends(get_acl_service),
 ):
     """
     Dynamic catch-all route for MCP server proxying, but only works for GET, i.e. the event stream.
@@ -816,6 +831,19 @@ async def dynamic_mcp_get_proxy(
             content={
                 "detail": f"No MCP server is registered at path '{server_path}'. Verify the server path and try again."
             },
+        )
+
+    try:
+        await acl_service.check_user_permission(
+            user_id=PydanticObjectId(auth_context["user_id"]),
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_id=server.id,
+            required_permission="VIEW",
+        )
+    except HTTPException:
+        return JSONResponse(
+            status_code=403,
+            content={"detail": "Access denied to this MCP server."},
         )
 
     # Check if server is enabled

--- a/registry/src/registry/mcpgw/tools/server.py
+++ b/registry/src/registry/mcpgw/tools/server.py
@@ -10,6 +10,8 @@ import logging
 from collections.abc import Callable
 from typing import Annotated, Any
 
+from beanie import PydanticObjectId
+from bson import ObjectId
 from httpx_sse import EventSource
 from mcp.server.fastmcp import Context
 from mcp.server.session import ServerSession
@@ -26,6 +28,8 @@ from mcp.types import (
 from pydantic import Field
 from pydantic.networks import AnyUrl
 
+from registry_pkgs.models import ResourceType
+
 from ...auth.dependencies import UserContextDict
 from ...auth.oauth.types import ClientBranding, StateMetadata
 from ...core.exceptions import (
@@ -36,6 +40,7 @@ from ...core.exceptions import (
     UrlElicitationRequiredException,
 )
 from ...core.mcp_client import call_tool_via_sse_ephemeral
+from ...services.access_control_service import ACLService
 from ...utils.otel_metrics import record_server_request
 from ..core.types import McpAppContext
 from .types import get_meta_field
@@ -60,6 +65,31 @@ def _get_session_store(ctx: Context[ServerSession, McpAppContext]):
 
 def _get_mcp_client_service(ctx: Context[ServerSession, McpAppContext]):
     return ctx.request_context.lifespan_context.mcp_client_service
+
+
+def _extract_authenticated_user_context(ctx: Context[ServerSession, McpAppContext]) -> UserContextDict | None:
+    try:
+        user_context: UserContextDict = ctx.request_context.request.state.user  # type: ignore[union-attr]
+    except AttributeError:
+        return None
+
+    user_id = user_context.get("user_id") if user_context else None
+    if not user_id or not ObjectId.is_valid(user_id):
+        return None
+
+    return user_context
+
+
+async def _user_can_view_server(
+    acl_service: ACLService,
+    user_id: str,
+    server_id: PydanticObjectId,
+) -> bool:
+    accessible = await acl_service.get_accessible_resource_ids(
+        user_id=PydanticObjectId(user_id),
+        resource_type=ResourceType.MCPSERVER.value,
+    )
+    return str(server_id) in accessible
 
 
 async def _downstream_tool_call(
@@ -267,10 +297,18 @@ async def execute_tool_impl(
     """
 
     try:
-        user_context: UserContextDict = ctx.request_context.request.state.user  # type: ignore[union-attr]
+        user_context = _extract_authenticated_user_context(ctx)
+        if user_context is None:
+            logger.warning(
+                "execute_tool: missing or invalid authenticated user context; rejecting server_id=%s", server_id
+            )
+            return CallToolResult(
+                content=[TextContent(type="text", text="Authentication required: missing user context.")],
+                isError=True,
+            )
 
         username = user_context.get("username", "unknown")
-        user_id = user_context.get("user_id", "unknown")
+        user_id = user_context["user_id"]
         logger.info(f"Tool execution from user '{username}:{user_id}': {tool_name} on {server_id}")
 
         server = await _get_server_service(ctx).get_server_by_id(server_id)
@@ -278,6 +316,24 @@ async def execute_tool_impl(
             # Invalid input. Return a JSON-RPC **result response** with `isError=True` so that LLM can try another request.
             return CallToolResult(
                 content=[TextContent(type="text", text="There is no server with the given server_id.")],
+                isError=True,
+            )
+
+        lifespan = ctx.request_context.lifespan_context
+        if not await _user_can_view_server(lifespan.acl_service, user_id, server.id):
+            logger.warning(
+                "execute_tool: user_id=%s denied access to server_id=%s path=%s",
+                user_id,
+                server_id,
+                server.path,
+            )
+            return CallToolResult(
+                content=[
+                    TextContent(
+                        type="text",
+                        text=f"Access denied: server {server_id!r} is not in your accessible set.",
+                    )
+                ],
                 isError=True,
             )
 

--- a/registry/tests/unit/api/test_proxy_routes.py
+++ b/registry/tests/unit/api/test_proxy_routes.py
@@ -220,4 +220,6 @@ async def test_get_proxy_acl_allowed_continues():
         acl_service=_acl_service(),
     )
 
-    assert resp.status_code != 403
+    body = json.loads(resp.body)
+    assert resp.status_code == 404
+    assert "disabled" in body["detail"].lower()

--- a/registry/tests/unit/api/test_proxy_routes.py
+++ b/registry/tests/unit/api/test_proxy_routes.py
@@ -5,9 +5,13 @@ format. These tests verify that both handlers reject non-ObjectId user_id values
 400 and a ``{"detail": ...}`` body before any further processing occurs.
 """
 
+import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from beanie import PydanticObjectId
+from fastapi import HTTPException
 from starlette.requests import Request
 
 from registry.api.proxy_routes import dynamic_mcp_get_proxy, dynamic_mcp_post_proxy
@@ -16,6 +20,31 @@ VALID_OBJECT_ID = "507f1f77bcf86cd799439011"
 INVALID_USER_IDS = ["mcpgw", "not-an-objectid", "123", ""]
 
 _AUTH_CONTEXT = {"auth_method": "bearer", "user_id": VALID_OBJECT_ID, "username": "test"}
+
+
+def _make_server(*, enabled: bool = True):
+    return SimpleNamespace(
+        id=PydanticObjectId(),
+        path="/github",
+        serverName="github",
+        config={"enabled": enabled, "type": "streamable-http", "url": "https://example.com/mcp"},
+    )
+
+
+def _server_service(server):
+    service = AsyncMock()
+    service.extract_server_path.return_value = "/github"
+    service.get_server_by_path.return_value = server
+    return service
+
+
+def _acl_service(*, denied: bool = False):
+    service = AsyncMock()
+    if denied:
+        service.check_user_permission.side_effect = HTTPException(status_code=403)
+    else:
+        service.check_user_permission.return_value = None
+    return service
 
 
 def _post_request(user_id: str, server_path: str = "github") -> Request:
@@ -59,7 +88,6 @@ async def test_post_proxy_rejects_invalid_user_id(user_id):
         redis_client=Mock(),
     )
     assert resp.status_code == 400
-    import json
 
     body = json.loads(resp.body)
     assert "detail" in body
@@ -79,7 +107,6 @@ async def test_get_proxy_rejects_invalid_user_id(user_id):
         redis_client=Mock(),
     )
     assert resp.status_code == 400
-    import json
 
     body = json.loads(resp.body)
     assert "detail" in body
@@ -88,8 +115,6 @@ async def test_get_proxy_rejects_invalid_user_id(user_id):
 
 async def test_post_proxy_does_not_reject_valid_object_id(monkeypatch):
     """A valid ObjectId must not be rejected at the user_id guard — processing continues."""
-    import json as _json
-
     monkeypatch.setattr(
         "registry.api.proxy_routes._parse_json_rpc_body",
         AsyncMock(return_value={"jsonrpc": "2.0", "method": "tools/call", "id": 1}),
@@ -113,5 +138,86 @@ async def test_post_proxy_does_not_reject_valid_object_id(monkeypatch):
     # ObjectId guard would produce {"detail": "...invalid user ID..."}.
     # Any other response (e.g. 404 for unknown server) means the guard passed.
     if resp.status_code == 400:
-        body = _json.loads(resp.body)
+        body = json.loads(resp.body)
         assert "invalid user ID" not in body.get("detail", "")
+
+
+async def test_post_proxy_acl_denied_returns_jsonrpc_error(monkeypatch):
+    monkeypatch.setattr(
+        "registry.api.proxy_routes._parse_json_rpc_body",
+        AsyncMock(return_value={"jsonrpc": "2.0", "method": "tools/call", "id": 1}),
+    )
+
+    resp = await dynamic_mcp_post_proxy(
+        request=_post_request(VALID_OBJECT_ID),
+        user_id=VALID_OBJECT_ID,
+        server_path="github",
+        auth_context=_AUTH_CONTEXT,
+        server_service=_server_service(_make_server()),
+        oauth_service=Mock(),
+        proxy_client=Mock(),
+        redis_client=Mock(),
+        acl_service=_acl_service(denied=True),
+    )
+
+    body = json.loads(resp.body)
+    assert resp.status_code == 200
+    assert body["result"]["isError"] is True
+    assert "Access denied" in body["result"]["content"][0]["text"]
+
+
+async def test_post_proxy_acl_allowed_continues(monkeypatch):
+    monkeypatch.setattr(
+        "registry.api.proxy_routes._parse_json_rpc_body",
+        AsyncMock(return_value={"jsonrpc": "2.0", "method": "tools/call", "id": 1}),
+    )
+
+    resp = await dynamic_mcp_post_proxy(
+        request=_post_request(VALID_OBJECT_ID),
+        user_id=VALID_OBJECT_ID,
+        server_path="github",
+        auth_context=_AUTH_CONTEXT,
+        server_service=_server_service(_make_server(enabled=False)),
+        oauth_service=Mock(),
+        proxy_client=Mock(),
+        redis_client=Mock(),
+        acl_service=_acl_service(),
+    )
+
+    body = json.loads(resp.body)
+    assert body["result"]["isError"] is True
+    assert "Access denied" not in body["result"]["content"][0]["text"]
+
+
+async def test_get_proxy_acl_denied_returns_403():
+    resp = await dynamic_mcp_get_proxy(
+        request=_get_request(VALID_OBJECT_ID),
+        user_id=VALID_OBJECT_ID,
+        server_path="github",
+        auth_context=_AUTH_CONTEXT,
+        server_service=_server_service(_make_server()),
+        oauth_service=Mock(),
+        proxy_client=Mock(),
+        redis_client=Mock(),
+        acl_service=_acl_service(denied=True),
+    )
+
+    body = json.loads(resp.body)
+    assert resp.status_code == 403
+    assert "Access denied" in body["detail"]
+
+
+async def test_get_proxy_acl_allowed_continues():
+    resp = await dynamic_mcp_get_proxy(
+        request=_get_request(VALID_OBJECT_ID),
+        user_id=VALID_OBJECT_ID,
+        server_path="github",
+        auth_context=_AUTH_CONTEXT,
+        server_service=_server_service(_make_server(enabled=False)),
+        oauth_service=Mock(),
+        proxy_client=Mock(),
+        redis_client=Mock(),
+        acl_service=_acl_service(),
+    )
+
+    assert resp.status_code != 403

--- a/registry/tests/unit/mcpgw/test_server.py
+++ b/registry/tests/unit/mcpgw/test_server.py
@@ -1,9 +1,68 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from beanie import PydanticObjectId
 
 from registry.mcpgw.tools import server
+from registry.mcpgw.tools.server import execute_tool_impl
+
+
+class _PermissiveAccessibleSet:
+    """Mock-friendly container that allows every `<id> in self` ACL check."""
+
+    def __contains__(self, _item: object) -> bool:
+        return True
+
+
+def _make_ctx(
+    *,
+    user_id: str | None = "507f1f77bcf86cd799439011",
+    accessible_server_ids: list[str] | None = None,
+    include_user_context: bool = True,
+):
+    accessible: object = _PermissiveAccessibleSet() if accessible_server_ids is None else accessible_server_ids
+    acl_service = MagicMock()
+    acl_service.get_accessible_resource_ids = AsyncMock(return_value=accessible)
+
+    server_service = MagicMock()
+    server_service.get_server_by_id = AsyncMock()
+
+    lifespan_context = SimpleNamespace(
+        acl_service=acl_service,
+        server_service=server_service,
+        mcp_client_service=MagicMock(),
+        oauth_service=MagicMock(),
+        redis_client=MagicMock(),
+    )
+    request_state = SimpleNamespace()
+    if include_user_context:
+        request_state.user = {"user_id": user_id, "username": "test"}
+    request_context = SimpleNamespace(
+        lifespan_context=lifespan_context,
+        request=SimpleNamespace(state=request_state),
+    )
+
+    ctx = MagicMock()
+    ctx.request_context = request_context
+    ctx.session = SimpleNamespace(client_params=None)
+    ctx.request_id = "req-1"
+    return ctx
+
+
+def _make_server(server_id: str | None = None):
+    oid = PydanticObjectId(server_id) if server_id else PydanticObjectId()
+    return SimpleNamespace(
+        id=oid,
+        path="/github",
+        serverName="github",
+        config={
+            "enabled": True,
+            "requiresInit": False,
+            "type": "streamable-http",
+            "url": "https://example.com/mcp",
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -23,3 +82,70 @@ async def test_execute_tool_wrapper_uses_tool_name_as_downstream_name(monkeypatc
     )
 
     execute_mock.assert_awaited_once_with(ctx, "tavily_search", arguments, "server-123")
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_impl_missing_user_context_returns_auth_error():
+    ctx = _make_ctx(include_user_context=False)
+
+    result = await execute_tool_impl(ctx, "tavily_search", {"query": "ai"}, str(PydanticObjectId()))
+
+    assert result.isError is True
+    assert "Authentication required" in result.content[0].text
+    ctx.request_context.lifespan_context.server_service.get_server_by_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_impl_invalid_user_id_returns_auth_error():
+    ctx = _make_ctx(user_id="not-an-objectid")
+
+    result = await execute_tool_impl(ctx, "tavily_search", {"query": "ai"}, str(PydanticObjectId()))
+
+    assert result.isError is True
+    assert "Authentication required" in result.content[0].text
+    ctx.request_context.lifespan_context.server_service.get_server_by_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_impl_no_server_returns_error():
+    ctx = _make_ctx()
+    ctx.request_context.lifespan_context.server_service.get_server_by_id.return_value = None
+
+    result = await execute_tool_impl(ctx, "tavily_search", {"query": "ai"}, str(PydanticObjectId()))
+
+    assert result.isError is True
+    assert "no server" in result.content[0].text.lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_impl_acl_denied_returns_error(monkeypatch):
+    server_id = str(PydanticObjectId())
+    other_id = str(PydanticObjectId())
+    ctx = _make_ctx(accessible_server_ids=[other_id])
+    ctx.request_context.lifespan_context.server_service.get_server_by_id.return_value = _make_server(server_id)
+    downstream_call = AsyncMock()
+    monkeypatch.setattr(server, "_downstream_tool_call", downstream_call)
+
+    result = await execute_tool_impl(ctx, "tavily_search", {"query": "ai"}, server_id)
+
+    assert result.isError is True
+    assert "Access denied" in result.content[0].text
+    downstream_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_impl_acl_allowed_proceeds(monkeypatch):
+    server_id = str(PydanticObjectId())
+    ctx = _make_ctx(accessible_server_ids=[server_id])
+    ctx.request_context.lifespan_context.server_service.get_server_by_id.return_value = _make_server(server_id)
+    monkeypatch.setattr(server, "record_server_request", MagicMock())
+    monkeypatch.setattr(server, "build_authenticated_headers", AsyncMock(return_value={}))
+    monkeypatch.setattr(
+        server,
+        "_downstream_tool_call",
+        AsyncMock(return_value={"result": {"content": [{"type": "text", "text": "ok"}]}}),
+    )
+
+    result = await execute_tool_impl(ctx, "tavily_search", {"query": "ai"}, server_id)
+
+    assert not result.isError


### PR DESCRIPTION
Add VIEW permission checks to MCP tool execution and direct-connect proxy handlers so unauthorized users cannot invoke or proxy servers they cannot access.