### PR TITLE
Feature/AS 1687 Fix group-based ACL resolution

### DIFF
--- a/registry/src/registry/services/access_control_service.py
+++ b/registry/src/registry/services/access_control_service.py
@@ -155,13 +155,21 @@ class ACLService:
         user_id: PydanticObjectId,
         session: AsyncClientSession | None = None,
     ) -> list[PydanticObjectId]:
-        """Return MongoDB Group _id values for every group the user belongs to."""
-        user = await User.get(user_id, session=session)
-        if not user or not user.idOnTheSource:
-            return []
+        """Return MongoDB Group _id values for every group the user belongs to.
 
-        groups = await Group.find({"memberIds": user.idOnTheSource}, session=session).to_list()
-        return [group.id for group in groups]
+        Raises on DB error — callers catch this and return empty permissions
+        (fail-closed: deny under uncertainty rather than silently grant access).
+        Returns [] for local users with no idOnTheSource.
+        """
+        try:
+            user = await User.get(user_id, session=session)
+            if not user or not user.idOnTheSource:
+                return []
+            groups = await Group.find({"memberIds": user.idOnTheSource}, session=session).to_list()
+            return [group.id for group in groups]
+        except Exception as e:
+            logger.warning("Failed to resolve group IDs for user %s: %s", user_id, e)
+            raise
 
     async def grant_permission(
         self,

--- a/registry/src/registry/services/access_control_service.py
+++ b/registry/src/registry/services/access_control_service.py
@@ -8,6 +8,7 @@ from fastapi import status as http_status
 from pymongo.asynchronous.client_session import AsyncClientSession
 
 from registry_pkgs.models import (
+    Group,
     PrincipalType,
     RegistryAccessRole,
     User,
@@ -134,6 +135,33 @@ class ACLService:
             name=getattr(obj, "name", None),
             email=getattr(obj, "email", None),
         )
+
+    def _build_acl_principal_or_clause(
+        self,
+        user_id: PydanticObjectId,
+        group_ids: list[PydanticObjectId],
+    ) -> list[dict[str, Any]]:
+        """Build the principal match clause used by ACL read paths."""
+        or_clause: list[dict[str, Any]] = [
+            {"principalType": PrincipalType.USER.value, "principalId": user_id},
+            {"principalType": PrincipalType.PUBLIC.value, "principalId": None},
+        ]
+        if group_ids:
+            or_clause.append({"principalType": PrincipalType.GROUP.value, "principalId": {"$in": group_ids}})
+        return or_clause
+
+    async def _resolve_group_ids_for_user(
+        self,
+        user_id: PydanticObjectId,
+        session: AsyncClientSession | None = None,
+    ) -> list[PydanticObjectId]:
+        """Return MongoDB Group _id values for every group the user belongs to."""
+        user = await User.get(user_id, session=session)
+        if not user or not user.idOnTheSource:
+            return []
+
+        groups = await Group.find({"memberIds": user.idOnTheSource}, session=session).to_list()
+        return [group.id for group in groups]
 
     async def grant_permission(
         self,
@@ -278,13 +306,20 @@ class ACLService:
                 type_filters = None
 
         results: list[PermissionPrincipalOut] = []
+        users: list[Any] = []
+        groups: list[Any] = []
         if not type_filters or PrincipalType.USER.value in type_filters:
-            for user in await self.user_service.search_users(query):
-                results.append(self._principal_result_obj(PrincipalType.USER, user))
+            users = await self.user_service.search_users(query, limit=limit)
 
         if not type_filters or PrincipalType.GROUP.value in type_filters:
-            for group in await self.group_service.search_groups(query):
-                results.append(self._principal_result_obj(PrincipalType.GROUP, group))
+            groups = await self.group_service.search_groups(query, limit=limit)
+
+        for idx in range(max(len(users), len(groups))):
+            if idx < len(users):
+                results.append(self._principal_result_obj(PrincipalType.USER, users[idx]))
+            if idx < len(groups):
+                results.append(self._principal_result_obj(PrincipalType.GROUP, groups[idx]))
+
         return results[:limit]
 
     async def get_resource_permissions(
@@ -305,27 +340,62 @@ class ACLService:
 
             principals: list[PrincipalDetailOut] = []
             is_public = False
+            user_principal_ids: list[tuple[PydanticObjectId, PydanticObjectId | None]] = []
+            group_principal_ids: list[tuple[PydanticObjectId, PydanticObjectId | None]] = []
 
             for entry in acl_entries:
                 if entry.principalType == PrincipalType.PUBLIC.value:
                     is_public = True
-                    continue
+                elif entry.principalType == PrincipalType.USER.value and entry.principalId:
+                    user_principal_ids.append((entry.principalId, entry.roleId))
+                elif entry.principalType == PrincipalType.GROUP.value and entry.principalId:
+                    group_principal_ids.append((entry.principalId, entry.roleId))
 
-                if entry.principalType == PrincipalType.USER.value and entry.principalId:
-                    user = await User.get(entry.principalId, session=session)
-                    if user:
-                        principals.append(
-                            PrincipalDetailOut(
-                                type="user",
-                                id=str(user.id),
-                                name=user.name,
-                                email=user.email,
-                                avatar=getattr(user, "avatar", None),
-                                source=getattr(user, "source", None),
-                                idOnTheSource=user.idOnTheSource,
-                                roleId=entry.roleId,
-                            )
-                        )
+            users_by_id = {}
+            if user_principal_ids:
+                user_ids = [principal_id for principal_id, _ in user_principal_ids]
+                fetched_users = await User.find({"_id": {"$in": user_ids}}, session=session).to_list()
+                users_by_id = {user.id: user for user in fetched_users}
+
+            groups_by_id = {}
+            if group_principal_ids:
+                group_ids = [principal_id for principal_id, _ in group_principal_ids]
+                fetched_groups = await Group.find({"_id": {"$in": group_ids}}, session=session).to_list()
+                groups_by_id = {group.id: group for group in fetched_groups}
+
+            for principal_id, role_id in user_principal_ids:
+                user = users_by_id.get(principal_id)
+                if not user:
+                    continue
+                principals.append(
+                    PrincipalDetailOut(
+                        type="user",
+                        id=str(user.id),
+                        name=user.name,
+                        email=user.email,
+                        avatar=getattr(user, "avatar", None),
+                        source=getattr(user, "source", None),
+                        idOnTheSource=user.idOnTheSource,
+                        roleId=role_id,
+                    )
+                )
+
+            for principal_id, role_id in group_principal_ids:
+                group = groups_by_id.get(principal_id)
+                if not group:
+                    continue
+                principals.append(
+                    PrincipalDetailOut(
+                        type="group",
+                        id=str(group.id),
+                        name=group.name,
+                        email=group.email,
+                        avatar=group.avatar,
+                        source=group.source,
+                        idOnTheSource=group.idOnTheSource,
+                        roleId=role_id,
+                    )
+                )
 
             return {
                 "resourceType": resource_type,
@@ -352,15 +422,15 @@ class ACLService:
         User-specific entries take precedence (sorted by permBits descending).
         """
         try:
+            group_ids = await self._resolve_group_ids_for_user(user_id, session=session)
+            or_clause = self._build_acl_principal_or_clause(user_id, group_ids)
+
             acl_entries = (
                 await RegistryAclEntry.find(
                     {
                         "resourceType": resource_type,
                         "resourceId": resource_id,
-                        "$or": [
-                            {"principalType": PrincipalType.USER.value, "principalId": user_id},
-                            {"principalType": PrincipalType.PUBLIC.value, "principalId": None},
-                        ],
+                        "$or": or_clause,
                     },
                     session=session,
                 )
@@ -403,15 +473,15 @@ class ACLService:
         if not resource_ids:
             return result
         try:
+            group_ids = await self._resolve_group_ids_for_user(user_id, session=session)
+            or_clause = self._build_acl_principal_or_clause(user_id, group_ids)
+
             acl_entries = (
                 await RegistryAclEntry.find(
                     {
                         "resourceType": resource_type,
                         "resourceId": {"$in": resource_ids},
-                        "$or": [
-                            {"principalType": PrincipalType.USER.value, "principalId": user_id},
-                            {"principalType": PrincipalType.PUBLIC.value, "principalId": None},
-                        ],
+                        "$or": or_clause,
                     },
                     session=session,
                 )
@@ -496,13 +566,13 @@ class ACLService:
                 Returns an empty list on error.
         """
         try:
+            group_ids = await self._resolve_group_ids_for_user(user_id, session=session)
+            or_clause = self._build_acl_principal_or_clause(user_id, group_ids)
+
             acl_entries = await RegistryAclEntry.find(
                 {
                     "resourceType": resource_type,
-                    "$or": [
-                        {"principalType": PrincipalType.USER.value, "principalId": user_id},
-                        {"principalType": PrincipalType.PUBLIC.value, "principalId": None},
-                    ],
+                    "$or": or_clause,
                 },
                 session=session,
             ).to_list()

--- a/registry/src/registry/services/access_control_service.py
+++ b/registry/src/registry/services/access_control_service.py
@@ -284,12 +284,13 @@ class ACLService:
     async def search_principals(
         self,
         query: str,
-        limit: int = 30,
+        limit: int | None = 30,
         principal_types: list[str] | None = None,
     ) -> list[PermissionPrincipalOut]:
         """
         Search for principals (users, groups, agents) matching the query string.
         """
+        effective_limit = limit if limit is not None and limit > 0 else 30
         query = (query or "").strip()
         if not query or len(query) < 2:
             raise ValueError("Query string must be at least 2 characters long.")
@@ -309,10 +310,10 @@ class ACLService:
         users: list[Any] = []
         groups: list[Any] = []
         if not type_filters or PrincipalType.USER.value in type_filters:
-            users = await self.user_service.search_users(query, limit=limit)
+            users = await self.user_service.search_users(query, limit=effective_limit)
 
         if not type_filters or PrincipalType.GROUP.value in type_filters:
-            groups = await self.group_service.search_groups(query, limit=limit)
+            groups = await self.group_service.search_groups(query, limit=effective_limit)
 
         for idx in range(max(len(users), len(groups))):
             if idx < len(users):
@@ -320,7 +321,7 @@ class ACLService:
             if idx < len(groups):
                 results.append(self._principal_result_obj(PrincipalType.GROUP, groups[idx]))
 
-        return results[:limit]
+        return results[:effective_limit]
 
     async def get_resource_permissions(
         self,

--- a/registry/src/registry/services/access_control_service.py
+++ b/registry/src/registry/services/access_control_service.py
@@ -157,9 +157,9 @@ class ACLService:
     ) -> list[PydanticObjectId]:
         """Return MongoDB Group _id values for every group the user belongs to.
 
-        Raises on DB error — callers catch this and return empty permissions
-        (fail-closed: deny under uncertainty rather than silently grant access).
-        Returns [] for local users with no idOnTheSource.
+        Raises on DB error — callers are responsible for deciding whether to
+        propagate or absorb the failure. Returns [] for local users with no
+        idOnTheSource.
         """
         try:
             user = await User.get(user_id, session=session)

--- a/registry/src/registry/services/group_service.py
+++ b/registry/src/registry/services/group_service.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 class GroupService:
-    async def search_groups(self, query: str) -> list[Group]:
+    async def search_groups(self, query: str, limit: int = 30) -> list[Group]:
         """
         Search groups by name or email (case-insensitive substring match).
         Returns a list of Group instances representing matching groups (e.g., with id, name, email fields).
@@ -18,7 +18,7 @@ class GroupService:
                     {"email": {"$regex": query, "$options": "i"}},
                 ]
             }
-            results = await Group.find(search_query).to_list()
+            results = await Group.find(search_query).limit(limit).to_list()
             return results
         except Exception as e:
             logger.error(f"Error searching groups with query '{search_query}': {e}")

--- a/registry/src/registry/services/user_service.py
+++ b/registry/src/registry/services/user_service.py
@@ -65,7 +65,7 @@ class UserService:
             user = await User.find_one({"email": email})
         return user
 
-    async def search_users(self, query: str) -> list[User]:
+    async def search_users(self, query: str, limit: int = 30) -> list[User]:
         """
         Search users by name, email, or username. Returns User model objects.
         """
@@ -77,7 +77,7 @@ class UserService:
                     {"username": {"$regex": query, "$options": "i"}},
                 ]
             }
-            results = await User.find(search_query).to_list()
+            results = await User.find(search_query).limit(limit).to_list()
             return results
         except Exception as e:
             logger.error(f"Error searching users with query '{search_query}': {e}")

--- a/registry/tests/unit/services/test_access_control_service.py
+++ b/registry/tests/unit/services/test_access_control_service.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -6,11 +7,27 @@ from fastapi import HTTPException
 
 from registry.schemas.acl_schema import ResourcePermissions
 from registry.services.access_control_service import ACLService
+from registry.services.group_service import GroupService
+from registry.services.user_service import UserService
 from registry_pkgs.models import PrincipalType, ResourceType
 from registry_pkgs.models.enums import PermissionBits, RoleBits
 
 
 class TestACLService:
+    def _mock_sorted_acl_query(self, mock_acl_entry, entries):
+        mock_find_result = MagicMock()
+        mock_sort_result = MagicMock()
+        mock_sort_result.to_list = AsyncMock(return_value=entries)
+        mock_find_result.sort = MagicMock(return_value=mock_sort_result)
+        mock_acl_entry.find = MagicMock(return_value=mock_find_result)
+        return mock_find_result
+
+    def _assert_group_clause_present(self, query, group_id):
+        assert {
+            "principalType": PrincipalType.GROUP.value,
+            "principalId": {"$in": [group_id]},
+        } in query["$or"]
+
     @pytest.mark.asyncio
     @patch("registry.services.access_control_service.RegistryAclEntry")
     async def test_grant_permission_new_entry(self, mock_acl_entry):
@@ -133,6 +150,52 @@ class TestACLService:
         assert service.resolve_perm_bits_for_role(ResourceType.AGENT.value, role_id) is None
 
     @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.Group")
+    @patch("registry.services.access_control_service.User")
+    async def test_resolve_group_ids_user_with_entra_id(self, mock_user, mock_group):
+        user_id = PydanticObjectId()
+        group_a_id = PydanticObjectId()
+        group_b_id = PydanticObjectId()
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+
+        mock_user.get = AsyncMock(return_value=MagicMock(idOnTheSource="entra-uuid-123"))
+        mock_group.find.return_value.to_list = AsyncMock(
+            return_value=[
+                MagicMock(id=group_a_id),
+                MagicMock(id=group_b_id),
+            ]
+        )
+
+        result = await service._resolve_group_ids_for_user(user_id)
+
+        assert result == [group_a_id, group_b_id]
+        mock_group.find.assert_called_once_with({"memberIds": "entra-uuid-123"}, session=None)
+
+    @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.Group")
+    @patch("registry.services.access_control_service.User")
+    async def test_resolve_group_ids_local_user_returns_empty(self, mock_user, mock_group):
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+        mock_user.get = AsyncMock(return_value=MagicMock(idOnTheSource=None))
+
+        result = await service._resolve_group_ids_for_user(PydanticObjectId())
+
+        assert result == []
+        mock_group.find.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.Group")
+    @patch("registry.services.access_control_service.User")
+    async def test_resolve_group_ids_user_not_found_returns_empty(self, mock_user, mock_group):
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+        mock_user.get = AsyncMock(return_value=None)
+
+        result = await service._resolve_group_ids_for_user(PydanticObjectId())
+
+        assert result == []
+        mock_group.find.assert_not_called()
+
+    @pytest.mark.asyncio
     @patch("registry.services.access_control_service.RegistryAclEntry")
     async def test_delete_acl_entries_for_resource(self, mock_acl_entry):
         mock_session = AsyncMock()
@@ -171,6 +234,7 @@ class TestACLService:
         mock_sort_result.to_list = AsyncMock(return_value=[entry])
         mock_find_result.sort = MagicMock(return_value=mock_sort_result)
         mock_acl_entry.find = MagicMock(return_value=mock_find_result)
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[])
 
         perms = await service.get_user_permissions_for_resource(
             user_id=PydanticObjectId(),
@@ -182,6 +246,75 @@ class TestACLService:
         assert perms.EDIT is True
         assert perms.DELETE is False
         assert perms.SHARE is False
+
+    @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.RegistryAclEntry")
+    async def test_get_user_permissions_group_grant_only(self, mock_acl_entry):
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+        group_id = PydanticObjectId()
+        entry = MagicMock(
+            principalType=PrincipalType.GROUP.value,
+            principalId=group_id,
+            permBits=PermissionBits.VIEW,
+        )
+        self._mock_sorted_acl_query(mock_acl_entry, [entry])
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[group_id])
+
+        perms = await service.get_user_permissions_for_resource(
+            user_id=PydanticObjectId(),
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_id=PydanticObjectId(),
+        )
+
+        assert perms.VIEW is True
+        assert perms.EDIT is False
+        query = mock_acl_entry.find.call_args.args[0]
+        self._assert_group_clause_present(query, group_id)
+
+    @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.RegistryAclEntry")
+    async def test_get_user_permissions_group_grant_higher_than_user_grant(self, mock_acl_entry):
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+        group_id = PydanticObjectId()
+        user_entry = MagicMock(
+            principalType=PrincipalType.USER.value,
+            principalId=PydanticObjectId(),
+            permBits=PermissionBits.VIEW,
+        )
+        group_entry = MagicMock(
+            principalType=PrincipalType.GROUP.value,
+            principalId=group_id,
+            permBits=PermissionBits.EDIT,
+        )
+        self._mock_sorted_acl_query(mock_acl_entry, [group_entry, user_entry])
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[group_id])
+
+        perms = await service.get_user_permissions_for_resource(
+            user_id=PydanticObjectId(),
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_id=PydanticObjectId(),
+        )
+
+        assert perms.EDIT is True
+        query = mock_acl_entry.find.call_args.args[0]
+        self._assert_group_clause_present(query, group_id)
+
+    @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.RegistryAclEntry")
+    async def test_get_user_permissions_no_group_membership_skips_group_clause(self, mock_acl_entry):
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+        self._mock_sorted_acl_query(mock_acl_entry, [])
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[])
+
+        await service.get_user_permissions_for_resource(
+            user_id=PydanticObjectId(),
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_id=PydanticObjectId(),
+        )
+
+        query = mock_acl_entry.find.call_args.args[0]
+        assert len(query["$or"]) == 2
+        assert all(clause["principalType"] != PrincipalType.GROUP.value for clause in query["$or"])
 
     @pytest.mark.asyncio
     @patch("registry.services.access_control_service.RegistryAclEntry")
@@ -227,6 +360,7 @@ class TestACLService:
         mock_sort_result.to_list = AsyncMock(return_value=[entry])
         mock_find_result.sort = MagicMock(return_value=mock_sort_result)
         mock_acl_entry.find = MagicMock(return_value=mock_find_result)
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[])
 
         perms = await service.get_user_permissions_for_resource(
             user_id=PydanticObjectId(),
@@ -251,6 +385,7 @@ class TestACLService:
         mock_sort_result.to_list = AsyncMock(return_value=[])
         mock_find_result.sort = MagicMock(return_value=mock_sort_result)
         mock_acl_entry.find = MagicMock(return_value=mock_find_result)
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[])
 
         perms = await service.get_user_permissions_for_resource(
             user_id=PydanticObjectId(),
@@ -270,6 +405,7 @@ class TestACLService:
 
         # Mock find() to raise exception
         mock_acl_entry.find = MagicMock(side_effect=Exception("db error"))
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[])
 
         perms = await service.get_user_permissions_for_resource(
             user_id=PydanticObjectId(),
@@ -292,6 +428,7 @@ class TestACLService:
         mock_sort_result.to_list = AsyncMock(return_value=[entry])
         mock_find_result.sort = MagicMock(return_value=mock_sort_result)
         mock_acl_entry.find = MagicMock(return_value=mock_find_result)
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[])
 
         perms = await service.check_user_permission(
             user_id=PydanticObjectId(),
@@ -315,6 +452,7 @@ class TestACLService:
         mock_sort_result.to_list = AsyncMock(return_value=[entry])
         mock_find_result.sort = MagicMock(return_value=mock_sort_result)
         mock_acl_entry.find = MagicMock(return_value=mock_find_result)
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[])
 
         with pytest.raises(HTTPException) as exc_info:
             await service.check_user_permission(
@@ -337,6 +475,7 @@ class TestACLService:
         mock_sort_result.to_list = AsyncMock(return_value=[])
         mock_find_result.sort = MagicMock(return_value=mock_sort_result)
         mock_acl_entry.find = MagicMock(return_value=mock_find_result)
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[])
 
         with pytest.raises(HTTPException) as exc_info:
             await service.check_user_permission(
@@ -368,6 +507,7 @@ class TestACLService:
         entry_owner.resourceId = rid1  # duplicate of rid1
 
         mock_acl_entry.find.return_value.to_list = AsyncMock(return_value=[entry_view, entry_edit_only, entry_owner])
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[])
 
         result = await service.get_accessible_resource_ids(
             user_id=PydanticObjectId(),
@@ -378,10 +518,67 @@ class TestACLService:
 
     @pytest.mark.asyncio
     @patch("registry.services.access_control_service.RegistryAclEntry")
+    async def test_get_accessible_ids_includes_group_only_resource(self, mock_acl_entry):
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+        group_id = PydanticObjectId()
+        resource_id = PydanticObjectId()
+        entry = MagicMock(
+            principalType=PrincipalType.GROUP.value,
+            principalId=group_id,
+            resourceId=resource_id,
+            permBits=PermissionBits.VIEW,
+        )
+        mock_acl_entry.find.return_value.to_list = AsyncMock(return_value=[entry])
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[group_id])
+
+        result = await service.get_accessible_resource_ids(
+            user_id=PydanticObjectId(),
+            resource_type=ResourceType.MCPSERVER.value,
+        )
+
+        assert str(resource_id) in result
+        query = mock_acl_entry.find.call_args.args[0]
+        self._assert_group_clause_present(query, group_id)
+
+    @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.RegistryAclEntry")
+    async def test_get_accessible_ids_deduplicates_user_and_group_grant(self, mock_acl_entry):
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+        group_id = PydanticObjectId()
+        resource_id = PydanticObjectId()
+        entries = [
+            MagicMock(
+                principalType=PrincipalType.USER.value,
+                principalId=PydanticObjectId(),
+                resourceId=resource_id,
+                permBits=PermissionBits.VIEW,
+            ),
+            MagicMock(
+                principalType=PrincipalType.GROUP.value,
+                principalId=group_id,
+                resourceId=resource_id,
+                permBits=PermissionBits.VIEW,
+            ),
+        ]
+        mock_acl_entry.find.return_value.to_list = AsyncMock(return_value=entries)
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[group_id])
+
+        result = await service.get_accessible_resource_ids(
+            user_id=PydanticObjectId(),
+            resource_type=ResourceType.MCPSERVER.value,
+        )
+
+        assert result.count(str(resource_id)) == 1
+        query = mock_acl_entry.find.call_args.args[0]
+        self._assert_group_clause_present(query, group_id)
+
+    @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.RegistryAclEntry")
     async def test_get_accessible_resource_ids_exception(self, mock_acl_entry):
         """Exception should return empty list."""
         service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
         mock_acl_entry.find.return_value.to_list = AsyncMock(side_effect=Exception("fail"))
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[])
         result = await service.get_accessible_resource_ids(
             user_id=PydanticObjectId(),
             resource_type=ResourceType.MCPSERVER,
@@ -403,6 +600,7 @@ class TestACLService:
         mock_sort_result.to_list = AsyncMock(return_value=[entry_a, entry_b])
         mock_find_result.sort = MagicMock(return_value=mock_sort_result)
         mock_acl_entry.find = MagicMock(return_value=mock_find_result)
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[])
 
         result = await service.get_user_permissions_for_resources(
             user_id=PydanticObjectId(),
@@ -419,6 +617,143 @@ class TestACLService:
         assert result[rid_b].VIEW and not result[rid_b].EDIT
         # A resource with no ACL entry falls back to empty permissions (no KeyError).
         assert result[rid_missing] == ResourcePermissions()
+
+    @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.RegistryAclEntry")
+    async def test_batch_permissions_group_grant_populates_result(self, mock_acl_entry):
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+        group_id = PydanticObjectId()
+        resource_id_a = PydanticObjectId()
+        resource_id_b = PydanticObjectId()
+        entry = MagicMock(
+            principalType=PrincipalType.GROUP.value,
+            principalId=group_id,
+            resourceId=resource_id_a,
+            permBits=PermissionBits.VIEW,
+        )
+        self._mock_sorted_acl_query(mock_acl_entry, [entry])
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[group_id])
+
+        result = await service.get_user_permissions_for_resources(
+            user_id=PydanticObjectId(),
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_ids=[resource_id_a, resource_id_b],
+        )
+
+        assert result[resource_id_a].VIEW is True
+        assert result[resource_id_b] == ResourcePermissions()
+        query = mock_acl_entry.find.call_args.args[0]
+        self._assert_group_clause_present(query, group_id)
+
+    @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.Group")
+    @patch("registry.services.access_control_service.RegistryAclEntry")
+    async def test_get_resource_permissions_returns_group_principal(self, mock_acl_entry, mock_group):
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+        group_id = PydanticObjectId()
+        role_id = PydanticObjectId()
+        entry = MagicMock(
+            principalType=PrincipalType.GROUP.value,
+            principalId=group_id,
+            roleId=role_id,
+        )
+        group = SimpleNamespace(
+            id=group_id,
+            name="Engineering",
+            email="engineering@example.com",
+            avatar=None,
+            source="entra",
+            idOnTheSource="entra-group-1",
+        )
+        mock_acl_entry.find.return_value.to_list = AsyncMock(return_value=[entry])
+        mock_group.find.return_value.to_list = AsyncMock(return_value=[group])
+
+        result = await service.get_resource_permissions(
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_id=PydanticObjectId(),
+        )
+
+        assert result["principals"][0]["type"] == "group"
+        assert result["principals"][0]["name"] == "Engineering"
+        assert result["principals"][0]["email"] == "engineering@example.com"
+        assert result["principals"][0]["roleId"] == role_id
+
+    @pytest.mark.asyncio
+    @patch("registry.services.access_control_service.User")
+    @patch("registry.services.access_control_service.RegistryAclEntry")
+    async def test_get_resource_permissions_batch_fetch_not_n_plus_1(self, mock_acl_entry, mock_user):
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+        user_ids = [PydanticObjectId(), PydanticObjectId(), PydanticObjectId()]
+        role_id = PydanticObjectId()
+        entries = [
+            MagicMock(principalType=PrincipalType.USER.value, principalId=user_id, roleId=role_id)
+            for user_id in user_ids
+        ]
+        users = []
+        for idx, user_id in enumerate(user_ids):
+            user = SimpleNamespace(
+                id=user_id,
+                name=f"User {idx}",
+                email=f"user{idx}@example.com",
+                avatar=None,
+                source=None,
+                idOnTheSource=f"entra-user-{idx}",
+            )
+            users.append(user)
+        mock_acl_entry.find.return_value.to_list = AsyncMock(return_value=entries)
+        mock_user.find.return_value.to_list = AsyncMock(return_value=users)
+        mock_user.get = AsyncMock(side_effect=AssertionError("User.get must not be called"))
+
+        result = await service.get_resource_permissions(
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_id=PydanticObjectId(),
+        )
+
+        mock_user.find.assert_called_once()
+        mock_user.get.assert_not_called()
+        assert len(result["principals"]) == 3
+
+    @pytest.mark.asyncio
+    @patch("registry.services.group_service.Group")
+    async def test_search_groups_applies_limit(self, mock_group):
+        mock_group.find.return_value.limit.return_value.to_list = AsyncMock(return_value=[])
+
+        result = await GroupService().search_groups("alpha", limit=5)
+
+        assert result == []
+        mock_group.find.return_value.limit.assert_called_once_with(5)
+
+    @pytest.mark.asyncio
+    @patch("registry.services.user_service.User")
+    async def test_search_users_applies_limit(self, mock_user):
+        mock_user.find.return_value.limit.return_value.to_list = AsyncMock(return_value=[])
+
+        result = await UserService().search_users("alpha", limit=5)
+
+        assert result == []
+        mock_user.find.return_value.limit.assert_called_once_with(5)
+
+    @pytest.mark.asyncio
+    async def test_search_principals_groups_appear_when_users_fill_limit(self):
+        users = []
+        for idx in range(30):
+            user = SimpleNamespace(id=PydanticObjectId(), name=f"User {idx}", email=f"user{idx}@example.com")
+            users.append(user)
+        groups = [
+            SimpleNamespace(id=PydanticObjectId(), name="Alpha Group", email="alpha@example.com"),
+            SimpleNamespace(id=PydanticObjectId(), name="Beta Group", email="beta@example.com"),
+        ]
+        user_service = Mock()
+        user_service.search_users = AsyncMock(return_value=users)
+        group_service = Mock()
+        group_service.search_groups = AsyncMock(return_value=groups)
+        service = ACLService(user_service=user_service, group_service=group_service, role_cache={})
+
+        result = await service.search_principals(query="al", limit=30)
+
+        assert any(principal.principalType == PrincipalType.GROUP for principal in result)
+        user_service.search_users.assert_awaited_once_with("al", limit=30)
+        group_service.search_groups.assert_awaited_once_with("al", limit=30)
 
     @pytest.mark.asyncio
     @patch("registry.services.access_control_service.RegistryAclEntry")
@@ -443,6 +778,7 @@ class TestACLService:
         service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
         rid = PydanticObjectId()
         mock_acl_entry.find = MagicMock(side_effect=Exception("db error"))
+        service._resolve_group_ids_for_user = AsyncMock(return_value=[])
 
         result = await service.get_user_permissions_for_resources(
             user_id=PydanticObjectId(),

--- a/registry/tests/unit/services/test_access_control_service.py
+++ b/registry/tests/unit/services/test_access_control_service.py
@@ -756,6 +756,20 @@ class TestACLService:
         group_service.search_groups.assert_awaited_once_with("al", limit=30)
 
     @pytest.mark.asyncio
+    async def test_search_principals_none_limit_defaults_to_thirty(self):
+        user_service = Mock()
+        user_service.search_users = AsyncMock(return_value=[])
+        group_service = Mock()
+        group_service.search_groups = AsyncMock(return_value=[])
+        service = ACLService(user_service=user_service, group_service=group_service, role_cache={})
+
+        result = await service.search_principals(query="al", limit=None)
+
+        assert result == []
+        user_service.search_users.assert_awaited_once_with("al", limit=30)
+        group_service.search_groups.assert_awaited_once_with("al", limit=30)
+
+    @pytest.mark.asyncio
     @patch("registry.services.access_control_service.RegistryAclEntry")
     async def test_get_user_permissions_for_resources_empty_input_skips_query(self, mock_acl_entry):
         """Empty resource_ids short-circuits without touching the database."""

--- a/registry/tests/unit/services/test_access_control_service.py
+++ b/registry/tests/unit/services/test_access_control_service.py
@@ -646,6 +646,48 @@ class TestACLService:
         self._assert_group_clause_present(query, group_id)
 
     @pytest.mark.asyncio
+    async def test_get_user_permissions_for_resource_group_resolution_failure_denies_access(self):
+        """_resolve_group_ids_for_user raising causes fail-closed: empty permissions returned, no propagation."""
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+        service._resolve_group_ids_for_user = AsyncMock(side_effect=Exception("db error"))
+
+        perms = await service.get_user_permissions_for_resource(
+            user_id=PydanticObjectId(),
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_id=PydanticObjectId(),
+        )
+
+        assert perms == ResourcePermissions()
+
+    @pytest.mark.asyncio
+    async def test_get_user_permissions_for_resources_group_resolution_failure_denies_access(self):
+        """_resolve_group_ids_for_user raising causes fail-closed: empty permissions for all resources."""
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+        service._resolve_group_ids_for_user = AsyncMock(side_effect=Exception("db error"))
+        rid = PydanticObjectId()
+
+        result = await service.get_user_permissions_for_resources(
+            user_id=PydanticObjectId(),
+            resource_type=ResourceType.MCPSERVER.value,
+            resource_ids=[rid],
+        )
+
+        assert result == {rid: ResourcePermissions()}
+
+    @pytest.mark.asyncio
+    async def test_get_accessible_resource_ids_group_resolution_failure_returns_empty(self):
+        """_resolve_group_ids_for_user raising causes fail-closed: empty list returned, no propagation."""
+        service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
+        service._resolve_group_ids_for_user = AsyncMock(side_effect=Exception("db error"))
+
+        result = await service.get_accessible_resource_ids(
+            user_id=PydanticObjectId(),
+            resource_type=ResourceType.MCPSERVER.value,
+        )
+
+        assert result == []
+
+    @pytest.mark.asyncio
     @patch("registry.services.access_control_service.Group")
     @patch("registry.services.access_control_service.RegistryAclEntry")
     async def test_get_resource_permissions_returns_group_principal(self, mock_acl_entry, mock_group):
@@ -673,6 +715,7 @@ class TestACLService:
             resource_id=PydanticObjectId(),
         )
 
+        assert len(result["principals"]) == 1
         assert result["principals"][0]["type"] == "group"
         assert result["principals"][0]["name"] == "Engineering"
         assert result["principals"][0]["email"] == "engineering@example.com"


### PR DESCRIPTION
Enable group ACL grants in permission read paths by resolving a user's group memberships and including group principals in ACL queries. Also return group grants in permission details, batch principal lookups, cap principal search queries, and add regression coverage for group sharing behavior.