### PR TITLE
Hotfix: increase Nginx response header buffer size to 64k

### DIFF
--- a/frontend/nginx_http_only.conf
+++ b/frontend/nginx_http_only.conf
@@ -11,6 +11,13 @@ server {
     # Accommodates large request headers and cookies
     large_client_header_buffers 16 64k;
 
+    # Accommodates large response headers/cookies from the backend (e.g. Set-Cookie
+    # session/refresh tokens for users with many IdP groups) — without this, nginx's
+    # default buffer (4-8k) overflows and returns 502 "upstream sent too big header".
+    proxy_buffer_size 64k;
+    proxy_buffers 8 64k;
+    proxy_busy_buffers_size 64k;
+
     # Frontend static files served under BASE_PATH
     location ${NGINX_BASE_PATH}/ {
         alias /usr/share/nginx/html/;


### PR DESCRIPTION
Otherwise, big response header causes Nginx (`frontend` pod) to return 502.