### PR TITLE
Feature/as 1721 Fix login redirect return path

### DIFF
--- a/auth-server/src/auth_server/core/config.py
+++ b/auth-server/src/auth_server/core/config.py
@@ -14,6 +14,10 @@ from registry_pkgs.core.config import JarvisBaseSettings, RedisConfig
 class AuthSettings(JarvisBaseSettings):
     """Auth server settings with environment variable support."""
 
+    # ==================== Cookies ====================
+    oauth2_temp_session_cookie_name: str = "oauth2_temp_session"
+    oauth2_consent_nonce_cookie_name: str = "oauth2_consent_nonce"
+
     # ==================== Core Settings ====================
     # JWT Settings
     max_token_lifetime_hours: int = 24

--- a/auth-server/src/auth_server/routes/oauth_flow.py
+++ b/auth-server/src/auth_server/routes/oauth_flow.py
@@ -74,7 +74,6 @@ JWT_SELF_SIGNED_KID = settings.jwt_self_signed_kid
 JWT_TOKEN_CONFIG = settings.jwt_token_config
 
 _OIDC_TOKEN_ALGORITHMS = ["RS256"]
-CONSENT_NONCE_COOKIE = "oauth2_consent_nonce"
 
 
 def oauth_error_response(error: str, error_description: str | None = None, status_code: int = 400) -> JSONResponse:
@@ -276,7 +275,7 @@ def _finish_oauth2_callback(
     logger.info("OAuth2 login successful, redirecting to %s...", redirect_url)
 
     response = RedirectResponse(url=redirect_url, status_code=302)
-    response.delete_cookie("oauth2_temp_session")
+    response.delete_cookie(settings.oauth2_temp_session_cookie_name)
     return response
 
 
@@ -887,7 +886,7 @@ async def oauth2_login(
 
         response = RedirectResponse(url=auth_url, status_code=302)
         response.set_cookie(
-            key="oauth2_temp_session",
+            key=settings.oauth2_temp_session_cookie_name,
             value=temp_session,
             max_age=settings.oauth_session_ttl_seconds,
             httponly=True,
@@ -904,7 +903,7 @@ async def oauth2_login(
 @router.get("/oauth2/consent", response_class=HTMLResponse)
 async def consent_page(
     nonce: str | None = None,
-    oauth2_consent_nonce: str | None = Cookie(None),
+    oauth2_consent_nonce: str | None = Cookie(None, alias=settings.oauth2_consent_nonce_cookie_name),
     store: OAuthStateStoreProtocol = Depends(get_oauth_state_store),
     pending_store: PendingConsentStore = Depends(get_pending_consent_store),
 ) -> HTMLResponse:
@@ -940,7 +939,7 @@ async def consent_page(
 @router.post("/oauth2/consent/approve")
 async def approve_consent(
     nonce: str = Form(...),
-    oauth2_consent_nonce: str | None = Cookie(None),
+    oauth2_consent_nonce: str | None = Cookie(None, alias=settings.oauth2_consent_nonce_cookie_name),
     store: OAuthStateStoreProtocol = Depends(get_oauth_state_store),
     consent_store: ConsentStore = Depends(get_consent_store),
     pending_store: PendingConsentStore = Depends(get_pending_consent_store),
@@ -970,7 +969,7 @@ async def approve_consent(
             pending["resolved_scopes"],
             store,
         )
-        response.delete_cookie(CONSENT_NONCE_COOKIE)
+        response.delete_cookie(settings.oauth2_consent_nonce_cookie_name)
         return response
     except HTTPException:
         raise
@@ -988,7 +987,7 @@ async def deny_consent(
         pending_store.consume(nonce)
         params = {"error": "access_denied", "error_description": "User denied the authorization request"}
         response = RedirectResponse(url=f"{settings.registry_error_redirect}?{urlencode(params)}", status_code=302)
-        response.delete_cookie(CONSENT_NONCE_COOKIE)
+        response.delete_cookie(settings.oauth2_consent_nonce_cookie_name)
         return response
     except HTTPException:
         raise
@@ -1003,7 +1002,7 @@ async def oauth2_callback(
     code: str | None = None,
     state: str | None = None,
     error: str | None = None,
-    oauth2_temp_session: str | None = Cookie(None),
+    oauth2_temp_session: str | None = Cookie(None, alias=settings.oauth2_temp_session_cookie_name),
     oauth2_config: OAuth2Config = Depends(get_oauth2_config),
     user_service: UserService = Depends(get_user_service),
     signer: URLSafeTimedSerializer = Depends(get_signer),
@@ -1138,7 +1137,7 @@ async def oauth2_callback(
                     f"requested={requested_scopes}, available={default_user_scopes}"
                 )
                 response = RedirectResponse(url=redirect_url, status_code=302)
-                response.delete_cookie("oauth2_temp_session")
+                response.delete_cookie(settings.oauth2_temp_session_cookie_name)
                 return response
 
             logger.info(
@@ -1166,14 +1165,14 @@ async def oauth2_callback(
             consent_url = f"{_auth_server_external_url('/oauth2/consent')}?nonce={nonce}"
             response = RedirectResponse(url=consent_url, status_code=302)
             response.set_cookie(
-                key=CONSENT_NONCE_COOKIE,
+                key=settings.oauth2_consent_nonce_cookie_name,
                 value=nonce,
                 max_age=PENDING_CONSENT_TTL_SECONDS,
                 httponly=True,
                 secure=settings.session_cookie_secure and is_https,
                 samesite="lax",
             )
-            response.delete_cookie("oauth2_temp_session")
+            response.delete_cookie(settings.oauth2_temp_session_cookie_name)
             return response
 
         return _finish_oauth2_callback(token_data, mapped_user, session_data, resolved_scopes, store)

--- a/auth-server/tests/integration/test_oauth_callback_token_flow.py
+++ b/auth-server/tests/integration/test_oauth_callback_token_flow.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi.testclient import TestClient
 from itsdangerous import URLSafeTimedSerializer
 
+from auth_server.core.config import settings
 from auth_server.deps import get_auth_provider, get_oauth2_config, get_oauth_state_store, get_signer, get_user_service
 from auth_server.server import app
 from registry_pkgs.core.jwt_utils import InvalidSignatureError, InvalidTokenError
@@ -96,6 +97,8 @@ class TestOAuth2CallbackStandardFlow:
             mock_settings.auth_server_url = "http://localhost:8888"
             mock_settings.oauth_session_ttl_seconds = 600
             mock_settings.secret_key = "test-secret-key"
+            mock_settings.oauth2_temp_session_cookie_name = settings.oauth2_temp_session_cookie_name
+            mock_settings.oauth2_consent_nonce_cookie_name = settings.oauth2_consent_nonce_cookie_name
 
             test_signer = URLSafeTimedSerializer("test-secret-key")
 
@@ -126,7 +129,7 @@ class TestOAuth2CallbackStandardFlow:
             response = test_client.get(
                 f"{API_PREFIX}/oauth2/callback/keycloak",
                 params={"code": "provider_auth_code", "state": "test-state-123"},
-                cookies={"oauth2_temp_session": temp_session},
+                cookies={settings.oauth2_temp_session_cookie_name: temp_session},
                 follow_redirects=False,
             )
 
@@ -212,6 +215,8 @@ class TestOAuth2CallbackStandardFlow:
             mock_settings.auth_server_url = "http://localhost:8888"
             mock_settings.oauth_session_ttl_seconds = 600
             mock_settings.secret_key = "test-secret-key"
+            mock_settings.oauth2_temp_session_cookie_name = settings.oauth2_temp_session_cookie_name
+            mock_settings.oauth2_consent_nonce_cookie_name = settings.oauth2_consent_nonce_cookie_name
 
             test_signer = URLSafeTimedSerializer("test-secret-key")
 
@@ -241,7 +246,7 @@ class TestOAuth2CallbackStandardFlow:
             response = test_client.get(
                 f"{API_PREFIX}/oauth2/callback/keycloak",
                 params={"code": "provider_auth_code", "state": "test-state-456"},
-                cookies={"oauth2_temp_session": temp_session},
+                cookies={settings.oauth2_temp_session_cookie_name: temp_session},
                 follow_redirects=False,
             )
 
@@ -303,6 +308,8 @@ class TestOAuth2CallbackStandardFlow:
             mock_settings.auth_server_url = "http://localhost:8888"
             mock_settings.oauth_session_ttl_seconds = 600
             mock_settings.secret_key = "test-secret-key"
+            mock_settings.oauth2_temp_session_cookie_name = settings.oauth2_temp_session_cookie_name
+            mock_settings.oauth2_consent_nonce_cookie_name = settings.oauth2_consent_nonce_cookie_name
 
             test_signer = URLSafeTimedSerializer("test-secret-key")
 
@@ -331,7 +338,7 @@ class TestOAuth2CallbackStandardFlow:
             response = test_client.get(
                 f"{API_PREFIX}/oauth2/callback/keycloak",
                 params={"code": "keycloak_code", "state": "test-state-789"},
-                cookies={"oauth2_temp_session": temp_session},
+                cookies={settings.oauth2_temp_session_cookie_name: temp_session},
                 follow_redirects=False,
             )
 
@@ -391,6 +398,8 @@ class TestOAuth2CallbackStandardFlow:
             mock_settings.auth_server_url = "http://localhost:8888"
             mock_settings.oauth_session_ttl_seconds = 600
             mock_settings.secret_key = "test-secret-key"
+            mock_settings.oauth2_temp_session_cookie_name = settings.oauth2_temp_session_cookie_name
+            mock_settings.oauth2_consent_nonce_cookie_name = settings.oauth2_consent_nonce_cookie_name
 
             test_signer = URLSafeTimedSerializer("test-secret-key")
             app.dependency_overrides = {}
@@ -416,7 +425,7 @@ class TestOAuth2CallbackStandardFlow:
             response = test_client.get(
                 f"{API_PREFIX}/oauth2/callback/keycloak",
                 params={"code": "keycloak_code", "state": "test-state-invalid-signature"},
-                cookies={"oauth2_temp_session": temp_session},
+                cookies={settings.oauth2_temp_session_cookie_name: temp_session},
                 follow_redirects=False,
             )
 
@@ -461,6 +470,8 @@ class TestOAuth2CallbackStandardFlow:
             mock_settings.auth_server_url = "http://localhost:8888"
             mock_settings.oauth_session_ttl_seconds = 600
             mock_settings.secret_key = "test-secret-key"
+            mock_settings.oauth2_temp_session_cookie_name = settings.oauth2_temp_session_cookie_name
+            mock_settings.oauth2_consent_nonce_cookie_name = settings.oauth2_consent_nonce_cookie_name
 
             test_signer = URLSafeTimedSerializer("test-secret-key")
             app.dependency_overrides = {}
@@ -486,7 +497,7 @@ class TestOAuth2CallbackStandardFlow:
             response = test_client.get(
                 f"{API_PREFIX}/oauth2/callback/entra",
                 params={"code": "entra_code", "state": "test-state-entra-invalid-sig"},
-                cookies={"oauth2_temp_session": temp_session},
+                cookies={settings.oauth2_temp_session_cookie_name: temp_session},
                 follow_redirects=False,
             )
 
@@ -538,6 +549,8 @@ class TestOAuth2CallbackStandardFlow:
             mock_settings.auth_server_url = "http://localhost:8888"
             mock_settings.oauth_session_ttl_seconds = 600
             mock_settings.secret_key = "test-secret-key"
+            mock_settings.oauth2_temp_session_cookie_name = settings.oauth2_temp_session_cookie_name
+            mock_settings.oauth2_consent_nonce_cookie_name = settings.oauth2_consent_nonce_cookie_name
 
             test_signer = URLSafeTimedSerializer("test-secret-key")
             app.dependency_overrides = {}
@@ -563,7 +576,7 @@ class TestOAuth2CallbackStandardFlow:
             response = test_client.get(
                 f"{API_PREFIX}/oauth2/callback/keycloak",
                 params={"code": "keycloak_code", "state": "test-state-access-token-only"},
-                cookies={"oauth2_temp_session": temp_session},
+                cookies={settings.oauth2_temp_session_cookie_name: temp_session},
                 follow_redirects=False,
             )
 
@@ -625,6 +638,8 @@ class TestOAuth2CallbackStandardFlow:
             mock_settings.auth_server_url = "http://localhost:8888"
             mock_settings.oauth_session_ttl_seconds = 600
             mock_settings.secret_key = "test-secret-key"
+            mock_settings.oauth2_temp_session_cookie_name = settings.oauth2_temp_session_cookie_name
+            mock_settings.oauth2_consent_nonce_cookie_name = settings.oauth2_consent_nonce_cookie_name
 
             test_signer = URLSafeTimedSerializer("test-secret-key")
 
@@ -656,7 +671,7 @@ class TestOAuth2CallbackStandardFlow:
             response = test_client.get(
                 f"{API_PREFIX}/oauth2/callback/keycloak",
                 params={"code": "code", "state": "test-state"},
-                cookies={"oauth2_temp_session": temp_session},
+                cookies={settings.oauth2_temp_session_cookie_name: temp_session},
                 follow_redirects=False,
             )
 

--- a/auth-server/tests/integration/test_oauth_scoping_and_rotation.py
+++ b/auth-server/tests/integration/test_oauth_scoping_and_rotation.py
@@ -14,6 +14,7 @@ import pytest
 from authlib.oauth2.rfc7636 import create_s256_code_challenge
 from fastapi.testclient import TestClient
 
+from auth_server.core.config import settings
 from auth_server.deps import get_auth_provider, get_oauth2_config, get_oauth_state_store, get_signer, get_user_service
 from auth_server.server import app
 from registry_pkgs.core.jwt_utils import decode_jwt_unverified
@@ -231,6 +232,8 @@ class TestAccessTokenScoping:
             mock_settings.auth_server_external_url = "http://localhost:8888"
             mock_settings.oauth_session_ttl_seconds = 600
             mock_settings.secret_key = "test-secret-key"
+            mock_settings.oauth2_temp_session_cookie_name = settings.oauth2_temp_session_cookie_name
+            mock_settings.oauth2_consent_nonce_cookie_name = settings.oauth2_consent_nonce_cookie_name
 
             test_signer = URLSafeTimedSerializer("test-secret-key")
 
@@ -261,7 +264,7 @@ class TestAccessTokenScoping:
             response = test_client.get(
                 f"{API_PREFIX}/oauth2/callback/keycloak",
                 params={"code": "auth_code_123", "state": "test_state"},
-                cookies={"oauth2_temp_session": oauth2_temp_session},
+                cookies={settings.oauth2_temp_session_cookie_name: oauth2_temp_session},
                 follow_redirects=False,
             )
 
@@ -361,6 +364,8 @@ class TestAccessTokenScoping:
             mock_settings.auth_server_external_url = "http://localhost:8888"
             mock_settings.oauth_session_ttl_seconds = 600
             mock_settings.secret_key = "test-secret-key"
+            mock_settings.oauth2_temp_session_cookie_name = settings.oauth2_temp_session_cookie_name
+            mock_settings.oauth2_consent_nonce_cookie_name = settings.oauth2_consent_nonce_cookie_name
 
             test_signer = URLSafeTimedSerializer("test-secret-key")
 
@@ -391,7 +396,7 @@ class TestAccessTokenScoping:
             response = test_client.get(
                 f"{API_PREFIX}/oauth2/callback/keycloak",
                 params={"code": "auth_code_456", "state": "test_state"},
-                cookies={"oauth2_temp_session": oauth2_temp_session},
+                cookies={settings.oauth2_temp_session_cookie_name: oauth2_temp_session},
                 follow_redirects=False,
             )
 

--- a/auth-server/tests/unit/test_consent_routes.py
+++ b/auth-server/tests/unit/test_consent_routes.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from itsdangerous import URLSafeTimedSerializer
 
+from auth_server.core.config import settings
 from auth_server.deps import (
     get_auth_provider,
     get_consent_store,
@@ -17,7 +18,7 @@ from auth_server.deps import (
     get_signer,
     get_user_service,
 )
-from auth_server.routes.oauth_flow import CONSENT_NONCE_COOKIE, router
+from auth_server.routes.oauth_flow import router
 from tests.support.oauth_state_store import InMemoryOAuthStateStore
 
 
@@ -129,7 +130,7 @@ def test_consent_page_requires_query_and_cookie_nonce_match() -> None:
     response = client.get(
         "/auth/oauth2/consent",
         params={"nonce": "nonce-1"},
-        cookies={CONSENT_NONCE_COOKIE: "different"},
+        cookies={settings.oauth2_consent_nonce_cookie_name: "different"},
     )
 
     assert response.status_code == 400
@@ -143,7 +144,7 @@ def test_consent_page_renders_client_metadata_and_post_forms() -> None:
     response = client.get(
         "/auth/oauth2/consent",
         params={"nonce": "nonce-1"},
-        cookies={CONSENT_NONCE_COOKIE: "nonce-1"},
+        cookies={settings.oauth2_consent_nonce_cookie_name: "nonce-1"},
     )
 
     assert response.status_code == 200
@@ -159,7 +160,7 @@ def test_approve_consent_rejects_form_cookie_nonce_mismatch() -> None:
     response = client.post(
         "/auth/oauth2/consent/approve",
         data={"nonce": "nonce-1"},
-        cookies={CONSENT_NONCE_COOKIE: "different"},
+        cookies={settings.oauth2_consent_nonce_cookie_name: "different"},
     )
 
     assert response.status_code == 400
@@ -174,7 +175,7 @@ def test_approve_consent_grants_and_finishes_oauth_callback() -> None:
     response = client.post(
         "/auth/oauth2/consent/approve",
         data={"nonce": "nonce-1"},
-        cookies={CONSENT_NONCE_COOKIE: "nonce-1"},
+        cookies={settings.oauth2_consent_nonce_cookie_name: "nonce-1"},
         follow_redirects=False,
     )
 
@@ -239,7 +240,7 @@ def test_oauth_callback_without_client_consent_redirects_to_consent(
     response = client.get(
         "/auth/oauth2/callback/keycloak",
         params={"code": "idp-code", "state": "internal-state"},
-        cookies={"oauth2_temp_session": signer.dumps(session_data)},
+        cookies={settings.oauth2_temp_session_cookie_name: signer.dumps(session_data)},
         follow_redirects=False,
     )
 
@@ -291,7 +292,7 @@ def test_oauth_callback_with_cached_client_consent_skips_consent(
     response = client.get(
         "/auth/oauth2/callback/keycloak",
         params={"code": "idp-code", "state": "internal-state"},
-        cookies={"oauth2_temp_session": signer.dumps(session_data)},
+        cookies={settings.oauth2_temp_session_cookie_name: signer.dumps(session_data)},
         follow_redirects=False,
     )
 
@@ -342,7 +343,7 @@ def test_oauth_callback_registry_client_skips_consent(
     response = client.get(
         "/auth/oauth2/callback/keycloak",
         params={"code": "idp-code", "state": "internal-state"},
-        cookies={"oauth2_temp_session": signer.dumps(session_data)},
+        cookies={settings.oauth2_temp_session_cookie_name: signer.dumps(session_data)},
         follow_redirects=False,
     )
 

--- a/auth-server/tests/unit/test_oauth_callback_session.py
+++ b/auth-server/tests/unit/test_oauth_callback_session.py
@@ -12,6 +12,7 @@ import pytest
 from fastapi.testclient import TestClient
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 
+from auth_server.core.config import settings
 from auth_server.deps import get_oauth2_config, get_oauth_state_store, get_signer
 from auth_server.server import app
 from tests.support.oauth_state_store import test_oauth_state_store
@@ -96,7 +97,7 @@ class TestStateEncoding:
         # Verify resource is preserved
         assert "nonce" in state_decoded
 
-        temp_session_cookie = response.cookies.get("oauth2_temp_session")
+        temp_session_cookie = response.cookies.get(settings.oauth2_temp_session_cookie_name)
         assert temp_session_cookie is not None
 
         session_data = mock_signer.loads(temp_session_cookie, max_age=10 * 60)
@@ -153,7 +154,7 @@ class TestStateEncoding:
         assert "nonce" in state_decoded
 
         # Resource should be None
-        temp_session_cookie = response.cookies.get("oauth2_temp_session")
+        temp_session_cookie = response.cookies.get(settings.oauth2_temp_session_cookie_name)
         assert temp_session_cookie is not None
 
         session_data = mock_signer.loads(temp_session_cookie, max_age=10 * 60)
@@ -182,7 +183,7 @@ class TestSessionExpiration:
         response = test_client.get(
             "/auth/oauth2/callback/entra",
             params={"code": "fake_code", "state": state},
-            cookies={"oauth2_temp_session": "expired_session"},
+            cookies={settings.oauth2_temp_session_cookie_name: "expired_session"},
         )
 
         # Should return 401
@@ -216,7 +217,7 @@ class TestSessionExpiration:
         response = test_client.get(
             "/auth/oauth2/callback/entra",
             params={"code": "fake_code", "state": state},
-            cookies={"oauth2_temp_session": "invalid_session"},
+            cookies={settings.oauth2_temp_session_cookie_name: "invalid_session"},
         )
 
         # Should return 401 (not 400)
@@ -248,7 +249,7 @@ class TestMissingParameters:
         response = test_client.get(
             "/auth/oauth2/callback/entra",
             params={"state": "test_state"},
-            cookies={"oauth2_temp_session": "test_session"},
+            cookies={settings.oauth2_temp_session_cookie_name: "test_session"},
         )
 
         assert response.status_code == 400
@@ -266,7 +267,7 @@ class TestMissingParameters:
         response = test_client.get(
             "/auth/oauth2/callback/entra",
             params={"code": "test_code"},
-            cookies={"oauth2_temp_session": "test_session"},
+            cookies={settings.oauth2_temp_session_cookie_name: "test_session"},
         )
 
         assert response.status_code == 400

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,4 +1,5 @@
 import { Navigate } from 'react-router-dom';
+import { captureReturnPath } from '../config';
 import { useAuth } from '../contexts/AuthContext';
 
 interface ProtectedRouteProps {
@@ -17,7 +18,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   }
 
   if (!user) {
-    return <Navigate to='/login' replace />;
+    return <Navigate to={`/login?next=${encodeURIComponent(captureReturnPath())}`} replace />;
   }
 
   return <>{children}</>;

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -35,3 +35,17 @@ export const getBasePathForUrl = (): string => {
   const basePath = getBasePath();
   return basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
 };
+
+/**
+ * Capture the current in-app SPA path so login can return the user to it.
+ * The returned path intentionally omits BASE_PATH because the backend appends
+ * it to REGISTRY_CLIENT_URL, which may already include "/gateway".
+ */
+export const captureReturnPath = (): string => {
+  const basePath = getBasePathForUrl();
+  const pathname = window.location.pathname;
+  const hasBasePath = basePath !== '' && (pathname === basePath || pathname.startsWith(`${basePath}/`));
+  const appPath = hasBasePath ? pathname.slice(basePath.length) || '/' : pathname;
+
+  return `${appPath}${window.location.search}`;
+};

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,9 +1,9 @@
-import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { ExclamationTriangleIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
 import type React from 'react';
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import SERVICES from '@/services';
-import { getBasePath } from '../config';
+import { getBasePath, getBasePathForUrl } from '../config';
 
 interface OAuthProvider {
   name: string;
@@ -18,6 +18,12 @@ const Login: React.FC = () => {
   const [loginInProgress, setLoginInProgress] = useState<string | null>(null);
   const [searchParams] = useSearchParams();
   const nextParam = searchParams.get('next') || '';
+  // Mirrors the shape checks in the backend's `_sanitize_return_path` — the backend remains the
+  // authoritative sanitizer; this only decides whether `nextParam` is worth previewing to the
+  // user, so we don't show a destination the backend would actually reject and fall back from.
+  const isSameOriginReturnPath = nextParam.startsWith('/') && !nextParam.startsWith('//') && nextParam[1] !== '\\';
+  const showReturnPathNotice = isSameOriginReturnPath && nextParam !== '/';
+  const returnPathDisplayUrl = `${window.location.origin}${getBasePathForUrl()}${nextParam}`;
 
   useEffect(() => {
     console.log('[Login] Component mounted, fetching OAuth providers...');
@@ -82,6 +88,16 @@ const Login: React.FC = () => {
 
       <div className='mt-8 sm:mx-auto sm:w-full sm:max-w-md'>
         <div className='card p-8'>
+          {showReturnPathNotice && (
+            <div className='mb-6 p-4 text-sm bg-[var(--jarvis-info-soft)] border border-[color:var(--jarvis-blue)] text-[var(--jarvis-info-text)] rounded-lg flex items-start space-x-2'>
+              <InformationCircleIcon className='h-5 w-5 flex-shrink-0 mt-0.5' />
+              <span>
+                You'll be redirected to <span className='font-mono break-all'>{returnPathDisplayUrl}</span> after
+                signing in.
+              </span>
+            </div>
+          )}
+
           {error && (
             <div className='mb-6 p-4 text-sm text-[var(--jarvis-danger-text)] bg-[var(--jarvis-danger-soft)] border border-[color:var(--jarvis-danger-soft)] rounded-lg bg-[var(--jarvis-danger-soft)] text-[var(--jarvis-danger-text)] border-[color:var(--jarvis-danger-soft)] flex items-start space-x-2'>
               <ExclamationTriangleIcon className='h-5 w-5 flex-shrink-0 mt-0.5' />

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -17,6 +17,7 @@ const Login: React.FC = () => {
   const [loadingProviders, setLoadingProviders] = useState(true);
   const [loginInProgress, setLoginInProgress] = useState<string | null>(null);
   const [searchParams] = useSearchParams();
+  const nextParam = searchParams.get('next') || '';
 
   useEffect(() => {
     console.log('[Login] Component mounted, fetching OAuth providers...');
@@ -53,7 +54,8 @@ const Login: React.FC = () => {
 
   const handleOAuthLogin = (provider: string) => {
     setLoginInProgress(provider);
-    window.location.href = `${getBasePath()}/redirect/${provider}`;
+    const query = nextParam ? `?next=${encodeURIComponent(nextParam)}` : '';
+    window.location.href = `${getBasePath()}/redirect/${provider}${query}`;
   };
 
   const LoadingSpinner = () => (

--- a/frontend/src/services/request.ts
+++ b/frontend/src/services/request.ts
@@ -1,6 +1,6 @@
 import axios, { type AxiosError, type AxiosRequestConfig } from 'axios';
 
-import { getBasePath } from '@/config';
+import { captureReturnPath, getBasePath } from '@/config';
 import API from '@/services/api';
 import type { GetTokenResponse } from './auth/type';
 
@@ -83,7 +83,7 @@ service.interceptors.response.use(
                 // ignore logout error
               }
               if (typeof window !== 'undefined') {
-                window.location.href = `${getBasePath()}/login`;
+                window.location.href = `${getBasePath()}/login?next=${encodeURIComponent(captureReturnPath())}`;
               }
             }
             throw {

--- a/registry/src/registry/api/redirect_routes.py
+++ b/registry/src/registry/api/redirect_routes.py
@@ -37,6 +37,8 @@ router = APIRouter()
 
 ACCESS_TOKEN_COOKIE_MAX_AGE_SECONDS = 86400
 SESSION_STARTED_AT_CLOCK_SKEW_SECONDS = 300
+MAX_RETURN_PATH_LENGTH = 2048
+OAUTH2_STATE_NONCE_COOKIE_NAME = "registry_oauth2_state_nonce"
 
 
 def _set_csrf_cookie(response: Response, access_token: str, cookie_secure: bool) -> None:
@@ -55,6 +57,23 @@ def _delete_auth_cookies(response: Response) -> None:
     response.delete_cookie(key=settings.session_cookie_name, path="/")
     response.delete_cookie(key=settings.refresh_cookie_name, path="/")
     response.delete_cookie(key=settings.csrf_cookie_name, path="/")
+
+
+def _delete_oauth2_login_cookies(response: Response) -> None:
+    response.delete_cookie("registry_oauth2_code_verifier")
+    response.delete_cookie(OAUTH2_STATE_NONCE_COOKIE_NAME)
+
+
+def _oauth2_login_error_response(
+    error_code: str,
+    clear_oauth2_login_cookies: bool = False,
+    quote_error: bool = False,
+) -> RedirectResponse:
+    error_value = quote(error_code) if quote_error else error_code
+    response = RedirectResponse(url=f"{settings.registry_client_url}/login?error={error_value}", status_code=302)
+    if clear_oauth2_login_cookies:
+        _delete_oauth2_login_cookies(response)
+    return response
 
 
 def _parse_session_started_at(raw_value: object, now: int) -> int | None:
@@ -124,6 +143,19 @@ def _sanitize_return_path(raw: object) -> str:
     return raw
 
 
+def _prepare_return_path_for_state(raw: str | None) -> str | None:
+    """Return a bounded safe return path for OAuth state, or None if unusable."""
+    sanitized = _sanitize_return_path(raw)
+    if not sanitized or len(sanitized) > MAX_RETURN_PATH_LENGTH:
+        return None
+    return sanitized
+
+
+def _is_valid_oauth2_state(client_state: dict[str, Any], expected_nonce: str | None) -> bool:
+    nonce = client_state.get("nonce")
+    return isinstance(nonce, str) and bool(expected_nonce) and secrets.compare_digest(nonce, expected_nonce)
+
+
 async def get_oauth2_providers():
     """Fetch available OAuth2 providers from auth server"""
     try:
@@ -156,7 +188,8 @@ async def oauth2_login_redirect(
         # Therefore the redirect URI should be a route on Registry backend.
         registry_url = settings.registry_url
         auth_external_url = settings.auth_server_external_url
-        state_data = {"nonce": secrets.token_urlsafe(24), "next": next_path}
+        state_nonce = secrets.token_urlsafe(24)
+        state_data = {"nonce": state_nonce, "next": _prepare_return_path_for_state(next_path)}
         client_state = base64.urlsafe_b64encode(json.dumps(state_data).encode()).decode().rstrip("=")
         code_verifier = secrets.token_urlsafe(32)
         code_challenge = create_s256_code_challenge(code_verifier)
@@ -181,6 +214,14 @@ async def oauth2_login_redirect(
             secure=settings.session_cookie_secure and is_https,
             samesite="lax",
         )
+        resp.set_cookie(
+            key=OAUTH2_STATE_NONCE_COOKIE_NAME,
+            value=state_nonce,
+            max_age=settings.oauth_session_ttl_seconds,
+            httponly=True,
+            secure=settings.session_cookie_secure and is_https,
+            samesite="lax",
+        )
         return resp
     except Exception as e:
         logger.error(f"Error redirecting to OAuth2 login for {provider}: {e}")
@@ -195,6 +236,7 @@ async def oauth2_callback(
     error: str | None = None,
     details: str | None = None,
     registry_oauth2_code_verifier: str | None = Cookie(None),
+    registry_oauth2_state_nonce: str | None = Cookie(None),
     user_service: UserService = Depends(get_user_service),
     group_service: GroupService = Depends(get_group_service),
     is_https: bool = Depends(check_if_https),
@@ -203,7 +245,14 @@ async def oauth2_callback(
     This endpoint receives an authorization code and exchanges it for a JWT access token.
     The user_id has already been resolved by auth_server from MongoDB and included in the JWT.
     """
+    state_verified = False
     try:
+        client_state = _decode_client_state(state)
+        if not _is_valid_oauth2_state(client_state, registry_oauth2_state_nonce):
+            logger.warning("OAuth2 callback received invalid or missing state nonce")
+            return _oauth2_login_error_response("oauth2_invalid_state", clear_oauth2_login_cookies=True)
+        state_verified = True
+
         if error:
             logger.warning(f"OAuth2 callback received error: {error}, details: {details}")
             error_message = "Authentication failed"
@@ -214,19 +263,20 @@ async def oauth2_callback(
             elif error == "oauth2_callback_failed":
                 error_message = "OAuth2 authentication failed"
 
-            return RedirectResponse(
-                url=f"{settings.registry_client_url}/login?error={quote(error_message)}", status_code=302
+            return _oauth2_login_error_response(
+                error_message,
+                clear_oauth2_login_cookies=True,
+                quote_error=True,
             )
 
         if not code:
             logger.error("Missing authorization code in OAuth2 callback")
-            return RedirectResponse(
-                url=f"{settings.registry_client_url}/login?error=oauth2_missing_code", status_code=302
-            )
+            return _oauth2_login_error_response("oauth2_missing_code", clear_oauth2_login_cookies=True)
 
         if registry_oauth2_code_verifier is None:
-            return RedirectResponse(
-                url=f"{settings.registry_client_url}/login?error=oauth2_missing_code_verifier", status_code=302
+            return _oauth2_login_error_response(
+                "oauth2_missing_code_verifier",
+                clear_oauth2_login_cookies=True,
             )
 
         try:
@@ -234,8 +284,9 @@ async def oauth2_callback(
         except Exception:
             logger.exception("failed to decrypt registry_oauth2_code_verifier cookie.")
 
-            return RedirectResponse(
-                url=f"{settings.registry_client_url}/login?error=oauth2_missing_code_verifier", status_code=302
+            return _oauth2_login_error_response(
+                "oauth2_missing_code_verifier",
+                clear_oauth2_login_cookies=True,
             )
 
         # Exchange authorization code for JWT access token (standard OAuth2 flow)
@@ -256,8 +307,9 @@ async def oauth2_callback(
 
                 if response.status_code != 200:
                     logger.error(f"Failed to exchange code for token: {response.status_code} - {response.text}")
-                    return RedirectResponse(
-                        url=f"{settings.registry_client_url}/login?error=oauth2_token_exchange_failed", status_code=302
+                    return _oauth2_login_error_response(
+                        "oauth2_token_exchange_failed",
+                        clear_oauth2_login_cookies=True,
                     )
 
                 token_response = response.json()
@@ -265,8 +317,9 @@ async def oauth2_callback(
 
                 if not access_token:
                     logger.error("No access_token returned from auth server")
-                    return RedirectResponse(
-                        url=f"{settings.registry_client_url}/login?error=oauth2_invalid_response", status_code=302
+                    return _oauth2_login_error_response(
+                        "oauth2_invalid_response",
+                        clear_oauth2_login_cookies=True,
                     )
 
                 user_claims = decode_jwt(access_token, settings.jwt_public_key, settings.jwt_issuer)
@@ -275,13 +328,11 @@ async def oauth2_callback(
 
         except httpx.TimeoutException:
             logger.error("Timeout exchanging authorization code with auth server")
-            return RedirectResponse(url=f"{settings.registry_client_url}/login?error=oauth2_timeout", status_code=302)
+            return _oauth2_login_error_response("oauth2_timeout", clear_oauth2_login_cookies=True)
         except Exception:
             logger.exception("Failed to exchange authorization code for token")
 
-            return RedirectResponse(
-                url=f"{settings.registry_client_url}/login?error=oauth2_exchange_error", status_code=302
-            )
+            return _oauth2_login_error_response("oauth2_exchange_error", clear_oauth2_login_cookies=True)
 
         if not user_claims.get("user_id"):
             logger.warning(f"User {user_claims.get('sub')} has no user_id - not found in MongoDB. Creating new user.")
@@ -291,8 +342,9 @@ async def oauth2_callback(
 
         if not user_obj:
             logger.error(f"Failed to find or create user for claims: {user_claims}")
-            return RedirectResponse(
-                url=f"{settings.registry_client_url}/login?error=User+not+found+in+registry", status_code=302
+            return _oauth2_login_error_response(
+                "User+not+found+in+registry",
+                clear_oauth2_login_cookies=True,
             )
 
         try:
@@ -327,11 +379,11 @@ async def oauth2_callback(
         # Generate JWT access and refresh tokens, honoring OAuth token timing
         access_token, refresh_token = generate_token_pair(user_info=user_info)
 
-        next_path = _sanitize_return_path(_decode_client_state(state).get("next"))
+        next_path = _sanitize_return_path(client_state.get("next"))
         resp = RedirectResponse(url=f"{settings.registry_client_url.rstrip('/')}{next_path}", status_code=302)
 
-        # Delete ephemeral cookie that holds PKCE code_verifier.
-        resp.delete_cookie("registry_oauth2_code_verifier")
+        # Delete ephemeral cookies that bind this OAuth login attempt.
+        _delete_oauth2_login_cookies(resp)
 
         # Determine cookie security settings
         cookie_secure = settings.session_cookie_secure and is_https
@@ -367,8 +419,9 @@ async def oauth2_callback(
 
     except Exception as e:
         logger.error(f"Error in OAuth2 callback: {e}")
-        return RedirectResponse(
-            url=f"{settings.registry_client_url}/login?error=oauth2_callback_error", status_code=302
+        return _oauth2_login_error_response(
+            "oauth2_callback_error",
+            clear_oauth2_login_cookies=state_verified,
         )
 
 

--- a/registry/src/registry/api/redirect_routes.py
+++ b/registry/src/registry/api/redirect_routes.py
@@ -1,14 +1,15 @@
 import base64
+import binascii
 import json
 import logging
 import secrets
 from datetime import UTC, datetime
 from typing import Annotated, Any
-from urllib.parse import quote, urlencode
+from urllib.parse import quote, urlencode, urlparse
 
 import httpx
 from authlib.oauth2.rfc7636 import create_s256_code_challenge
-from fastapi import APIRouter, Cookie, Depends, Request, status
+from fastapi import APIRouter, Cookie, Depends, Query, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse, Response
 
 from registry_pkgs.core.jwt_utils import decode_jwt
@@ -94,6 +95,35 @@ def _get_string_list_claim(claims: dict[str, Any], claim_name: str) -> list[str]
     return [item.strip() for item in value if isinstance(item, str) and item.strip()]
 
 
+def _decode_client_state(raw: str | None) -> dict[str, Any]:
+    """Decode base64-JSON client state round-tripped through auth-server."""
+    if not raw:
+        return {}
+    try:
+        padded = raw + "=" * (-len(raw) % 4)
+        decoded = json.loads(base64.urlsafe_b64decode(padded))
+    except (binascii.Error, json.JSONDecodeError, TypeError, UnicodeDecodeError):
+        logger.warning("Failed to decode OAuth2 client_state")
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _sanitize_return_path(raw: object) -> str:
+    """Return a safe same-origin SPA path, or an empty string if absent or unsafe."""
+    if not isinstance(raw, str) or not raw:
+        return ""
+    if "\r" in raw or "\n" in raw:
+        return ""
+    if not raw.startswith("/") or raw[1:2] in ("/", "\\"):
+        return ""
+
+    parsed = urlparse(raw)
+    if parsed.scheme or parsed.netloc:
+        return ""
+
+    return raw
+
+
 async def get_oauth2_providers():
     """Fetch available OAuth2 providers from auth server"""
     try:
@@ -115,14 +145,18 @@ async def get_oauth2_providers():
 
 # OAuth2 login redirect avoid /auth/ route collision with auth server
 @router.get("/redirect/{provider}")
-async def oauth2_login_redirect(provider: str, is_https: bool = Depends(check_if_https)):
+async def oauth2_login_redirect(
+    provider: str,
+    next_path: Annotated[str | None, Query(alias="next")] = None,
+    is_https: bool = Depends(check_if_https),
+):
     """Redirect to auth server for OAuth2 login"""
     try:
         # Registry backend receives `code` from auth-server, and calls the /token endpoint of auth-server.
         # Therefore the redirect URI should be a route on Registry backend.
         registry_url = settings.registry_url
         auth_external_url = settings.auth_server_external_url
-        state_data = {"nonce": secrets.token_urlsafe(24)}
+        state_data = {"nonce": secrets.token_urlsafe(24), "next": next_path}
         client_state = base64.urlsafe_b64encode(json.dumps(state_data).encode()).decode().rstrip("=")
         code_verifier = secrets.token_urlsafe(32)
         code_challenge = create_s256_code_challenge(code_verifier)
@@ -157,6 +191,7 @@ async def oauth2_login_redirect(provider: str, is_https: bool = Depends(check_if
 async def oauth2_callback(
     request: Request,
     code: str | None = None,
+    state: str | None = None,
     error: str | None = None,
     details: str | None = None,
     registry_oauth2_code_verifier: str | None = Cookie(None),
@@ -292,7 +327,8 @@ async def oauth2_callback(
         # Generate JWT access and refresh tokens, honoring OAuth token timing
         access_token, refresh_token = generate_token_pair(user_info=user_info)
 
-        resp = RedirectResponse(url=settings.registry_client_url.rstrip("/"), status_code=302)
+        next_path = _sanitize_return_path(_decode_client_state(state).get("next"))
+        resp = RedirectResponse(url=f"{settings.registry_client_url.rstrip('/')}{next_path}", status_code=302)
 
         # Delete ephemeral cookie that holds PKCE code_verifier.
         resp.delete_cookie("registry_oauth2_code_verifier")

--- a/registry/src/registry/api/redirect_routes.py
+++ b/registry/src/registry/api/redirect_routes.py
@@ -131,7 +131,7 @@ def _sanitize_return_path(raw: object) -> str:
     """Return a safe same-origin SPA path, or an empty string if absent or unsafe."""
     if not isinstance(raw, str) or not raw:
         return ""
-    if "\r" in raw or "\n" in raw:
+    if any(ord(c) < 0x20 for c in raw):
         return ""
     if not raw.startswith("/") or raw[1:2] in ("/", "\\"):
         return ""

--- a/registry/src/registry/api/redirect_routes.py
+++ b/registry/src/registry/api/redirect_routes.py
@@ -38,7 +38,6 @@ router = APIRouter()
 ACCESS_TOKEN_COOKIE_MAX_AGE_SECONDS = 86400
 SESSION_STARTED_AT_CLOCK_SKEW_SECONDS = 300
 MAX_RETURN_PATH_LENGTH = 2048
-OAUTH2_STATE_NONCE_COOKIE_NAME = "registry_oauth2_state_nonce"
 
 
 def _set_csrf_cookie(response: Response, access_token: str, cookie_secure: bool) -> None:
@@ -60,8 +59,8 @@ def _delete_auth_cookies(response: Response) -> None:
 
 
 def _delete_oauth2_login_cookies(response: Response) -> None:
-    response.delete_cookie("registry_oauth2_code_verifier")
-    response.delete_cookie(OAUTH2_STATE_NONCE_COOKIE_NAME)
+    response.delete_cookie(settings.oauth2_code_verifier_cookie_name)
+    response.delete_cookie(settings.oauth2_state_nonce_cookie_name)
 
 
 def _oauth2_login_error_response(
@@ -207,7 +206,7 @@ async def oauth2_login_redirect(
         logger.info(f"Redirecting to OAuth2 login for provider {provider}: {auth_url}")
         resp = RedirectResponse(url=auth_url, status_code=302)
         resp.set_cookie(
-            key="registry_oauth2_code_verifier",
+            key=settings.oauth2_code_verifier_cookie_name,
             value=encrypt_value(code_verifier),
             max_age=settings.oauth_session_ttl_seconds,
             httponly=True,
@@ -215,7 +214,7 @@ async def oauth2_login_redirect(
             samesite="lax",
         )
         resp.set_cookie(
-            key=OAUTH2_STATE_NONCE_COOKIE_NAME,
+            key=settings.oauth2_state_nonce_cookie_name,
             value=state_nonce,
             max_age=settings.oauth_session_ttl_seconds,
             httponly=True,
@@ -235,8 +234,8 @@ async def oauth2_callback(
     state: str | None = None,
     error: str | None = None,
     details: str | None = None,
-    registry_oauth2_code_verifier: str | None = Cookie(None),
-    registry_oauth2_state_nonce: str | None = Cookie(None),
+    registry_oauth2_code_verifier: str | None = Cookie(None, alias=settings.oauth2_code_verifier_cookie_name),
+    registry_oauth2_state_nonce: str | None = Cookie(None, alias=settings.oauth2_state_nonce_cookie_name),
     user_service: UserService = Depends(get_user_service),
     group_service: GroupService = Depends(get_group_service),
     is_https: bool = Depends(check_if_https),
@@ -410,9 +409,6 @@ async def oauth2_callback(
             secure=cookie_secure,
             path="/",
         )
-
-        # Clean up temporary cookies
-        resp.delete_cookie("oauth2_temp_session")
 
         logger.info(f"OAuth2 login successful for user {user_obj.username}, JWT tokens set in httpOnly cookies")
         return resp

--- a/registry/src/registry/core/config.py
+++ b/registry/src/registry/core/config.py
@@ -31,6 +31,8 @@ class Settings(JarvisBaseSettings):
     csrf_cookie_name: str = "jarvis_registry_csrf"
     session_max_age_seconds: int = 60 * 60 * 8
     session_cookie_domain: str | None = None
+    oauth2_code_verifier_cookie_name: str = "registry_oauth2_code_verifier"
+    oauth2_state_nonce_cookie_name: str = "registry_oauth2_state_nonce"
 
     # ==================== Service URLs ====================
     registry_internal_url: str = "http://localhost:7860"

--- a/registry/tests/unit/api/test_redirect_routes.py
+++ b/registry/tests/unit/api/test_redirect_routes.py
@@ -11,12 +11,12 @@ from fastapi.responses import RedirectResponse
 
 from registry.api.redirect_routes import (
     MAX_RETURN_PATH_LENGTH,
-    OAUTH2_STATE_NONCE_COOKIE_NAME,
     _decode_client_state,
     _prepare_return_path_for_state,
     _sanitize_return_path,
     oauth2_callback,
     oauth2_login_redirect,
+    settings,
 )
 
 
@@ -53,6 +53,8 @@ def mock_settings():
         settings.jwt_issuer = "test-issuer"
         settings.jwt_public_key = "test-public-key"
         settings.oauth_session_ttl_seconds = 600
+        settings.oauth2_code_verifier_cookie_name = "registry_oauth2_code_verifier"
+        settings.oauth2_state_nonce_cookie_name = "registry_oauth2_state_nonce"
         settings.refresh_cookie_name = "refresh"
         settings.registry_app_name = "jarvis-registry-client"
         settings.registry_client_secret = "test-secret"
@@ -137,7 +139,7 @@ async def test_oauth2_login_redirect_carries_next_in_state(mock_settings) -> Non
     assert decoded["next"] == "/consent/server?nonce=abc"
     assert decoded["nonce"]
     set_cookie_headers = [value.decode() for key, value in response.raw_headers if key == b"set-cookie"]
-    assert any(OAUTH2_STATE_NONCE_COOKIE_NAME in header for header in set_cookie_headers)
+    assert any(mock_settings.oauth2_state_nonce_cookie_name in header for header in set_cookie_headers)
 
 
 @pytest.mark.unit
@@ -263,8 +265,8 @@ async def test_oauth2_callback_clears_login_cookies_after_valid_state_error(mock
 
     cookies = _cookies_from_response(response)
     assert response.headers["location"].endswith("/login?error=oauth2_missing_code_verifier")
-    assert cookies["registry_oauth2_code_verifier"]["max-age"] == "0"
-    assert cookies[OAUTH2_STATE_NONCE_COOKIE_NAME]["max-age"] == "0"
+    assert cookies[settings.oauth2_code_verifier_cookie_name]["max-age"] == "0"
+    assert cookies[settings.oauth2_state_nonce_cookie_name]["max-age"] == "0"
 
 
 @pytest.mark.unit
@@ -293,5 +295,5 @@ async def test_oauth2_callback_clears_login_cookies_on_early_valid_state_errors(
 
     cookies = _cookies_from_response(response)
     assert expected_error in response.headers["location"]
-    assert cookies["registry_oauth2_code_verifier"]["max-age"] == "0"
-    assert cookies[OAUTH2_STATE_NONCE_COOKIE_NAME]["max-age"] == "0"
+    assert cookies[settings.oauth2_code_verifier_cookie_name]["max-age"] == "0"
+    assert cookies[settings.oauth2_state_nonce_cookie_name]["max-age"] == "0"

--- a/registry/tests/unit/api/test_redirect_routes.py
+++ b/registry/tests/unit/api/test_redirect_routes.py
@@ -98,6 +98,7 @@ def test_sanitize_return_path_allows_same_origin_paths(raw: str) -> None:
         "/\\evil.com/x",
         "https://evil.com",
         "/x\r\nSet-Cookie: a=b",
+        "/\t\\evil.com",
     ],
 )
 def test_sanitize_return_path_rejects_unsafe_values(raw: object) -> None:

--- a/registry/tests/unit/api/test_redirect_routes.py
+++ b/registry/tests/unit/api/test_redirect_routes.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+from http.cookies import SimpleCookie
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -9,7 +10,10 @@ from fastapi import Request
 from fastapi.responses import RedirectResponse
 
 from registry.api.redirect_routes import (
+    MAX_RETURN_PATH_LENGTH,
+    OAUTH2_STATE_NONCE_COOKIE_NAME,
     _decode_client_state,
+    _prepare_return_path_for_state,
     _sanitize_return_path,
     oauth2_callback,
     oauth2_login_redirect,
@@ -18,6 +22,14 @@ from registry.api.redirect_routes import (
 
 def _encode_state(data: object) -> str:
     return base64.urlsafe_b64encode(json.dumps(data).encode("utf-8")).decode("utf-8").rstrip("=")
+
+
+def _cookies_from_response(response: RedirectResponse) -> SimpleCookie:
+    cookies = SimpleCookie()
+    for key, value in response.raw_headers:
+        if key == b"set-cookie":
+            cookies.load(value.decode())
+    return cookies
 
 
 @pytest.fixture
@@ -93,6 +105,11 @@ def test_sanitize_return_path_rejects_unsafe_values(raw: object) -> None:
 
 
 @pytest.mark.unit
+def test_prepare_return_path_for_state_rejects_oversized_path() -> None:
+    assert _prepare_return_path_for_state("/a" * MAX_RETURN_PATH_LENGTH) is None
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
@@ -117,6 +134,20 @@ async def test_oauth2_login_redirect_carries_next_in_state(mock_settings) -> Non
     state = location.split("state=", 1)[1].split("&", 1)[0]
     decoded = _decode_client_state(state)
     assert decoded["next"] == "/consent/server?nonce=abc"
+    assert decoded["nonce"]
+    set_cookie_headers = [value.decode() for key, value in response.raw_headers if key == b"set-cookie"]
+    assert any(OAUTH2_STATE_NONCE_COOKIE_NAME in header for header in set_cookie_headers)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_oauth2_login_redirect_drops_unsafe_next_from_state(mock_settings) -> None:
+    response = await oauth2_login_redirect("entra", next_path="https://evil.com")
+
+    location = response.headers["location"]
+    state = location.split("state=", 1)[1].split("&", 1)[0]
+    decoded = _decode_client_state(state)
+    assert decoded["next"] is None
 
 
 async def _successful_callback(
@@ -124,6 +155,7 @@ async def _successful_callback(
     mock_request: Mock,
     mock_user: Mock,
     state: str | None,
+    state_nonce: str | None = "state-nonce",
 ) -> RedirectResponse:
     token_response = Mock()
     token_response.status_code = 200
@@ -151,6 +183,7 @@ async def _successful_callback(
             code="test-auth-code",
             state=state,
             registry_oauth2_code_verifier="a-cookie",
+            registry_oauth2_state_nonce=state_nonce,
             user_service=user_service,
             group_service=group_service,
         )
@@ -161,7 +194,7 @@ async def _successful_callback(
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_oauth2_callback_redirects_to_safe_next_path(mock_request, mock_settings, mock_user) -> None:
-    state = _encode_state({"nonce": "abc", "next": "/consent/server?nonce=abc"})
+    state = _encode_state({"nonce": "state-nonce", "next": "/consent/server?nonce=abc"})
 
     response = await _successful_callback(mock_request=mock_request, mock_user=mock_user, state=state)
 
@@ -173,9 +206,8 @@ async def test_oauth2_callback_redirects_to_safe_next_path(mock_request, mock_se
 @pytest.mark.parametrize(
     "state",
     [
-        None,
-        _encode_state({"nonce": "abc"}),
-        _encode_state({"nonce": "abc", "next": "https://evil.com"}),
+        _encode_state({"nonce": "state-nonce"}),
+        _encode_state({"nonce": "state-nonce", "next": "https://evil.com"}),
     ],
 )
 async def test_oauth2_callback_falls_back_to_registry_client_url(
@@ -187,3 +219,78 @@ async def test_oauth2_callback_falls_back_to_registry_client_url(
     response = await _successful_callback(mock_request=mock_request, mock_user=mock_user, state=state)
 
     assert response.headers["location"] == mock_settings.registry_client_url
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "state_nonce"),
+    [
+        (None, "state-nonce"),
+        (_encode_state({"nonce": "state-nonce", "next": "/server-registry"}), None),
+        (_encode_state({"nonce": "state-nonce", "next": "/server-registry"}), "wrong-nonce"),
+    ],
+)
+async def test_oauth2_callback_rejects_invalid_state_nonce(
+    mock_request,
+    mock_user,
+    state: str | None,
+    state_nonce: str | None,
+) -> None:
+    response = await _successful_callback(
+        mock_request=mock_request,
+        mock_user=mock_user,
+        state=state,
+        state_nonce=state_nonce,
+    )
+
+    assert response.headers["location"].endswith("/login?error=oauth2_invalid_state")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_oauth2_callback_clears_login_cookies_after_valid_state_error(mock_request) -> None:
+    state = _encode_state({"nonce": "state-nonce", "next": "/server-registry"})
+
+    response = await oauth2_callback(
+        mock_request,
+        code="test-auth-code",
+        state=state,
+        registry_oauth2_state_nonce="state-nonce",
+        user_service=Mock(),
+    )
+
+    cookies = _cookies_from_response(response)
+    assert response.headers["location"].endswith("/login?error=oauth2_missing_code_verifier")
+    assert cookies["registry_oauth2_code_verifier"]["max-age"] == "0"
+    assert cookies[OAUTH2_STATE_NONCE_COOKIE_NAME]["max-age"] == "0"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("callback_kwargs", "expected_error"),
+    [
+        ({"error": "oauth2_error", "details": "Provider error"}, "OAuth2%20provider%20error"),
+        ({}, "oauth2_missing_code"),
+    ],
+)
+async def test_oauth2_callback_clears_login_cookies_on_early_valid_state_errors(
+    mock_request,
+    callback_kwargs: dict[str, str],
+    expected_error: str,
+) -> None:
+    state = _encode_state({"nonce": "state-nonce", "next": "/server-registry"})
+
+    response = await oauth2_callback(
+        mock_request,
+        state=state,
+        registry_oauth2_state_nonce="state-nonce",
+        user_service=Mock(),
+        **callback_kwargs,
+    )
+
+    cookies = _cookies_from_response(response)
+    assert expected_error in response.headers["location"]
+    assert cookies["registry_oauth2_code_verifier"]["max-age"] == "0"
+    assert cookies[OAUTH2_STATE_NONCE_COOKIE_NAME]["max-age"] == "0"

--- a/registry/tests/unit/api/test_redirect_routes.py
+++ b/registry/tests/unit/api/test_redirect_routes.py
@@ -1,0 +1,189 @@
+"""Unit tests for OAuth redirect return-path handling."""
+
+import base64
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import Request
+from fastapi.responses import RedirectResponse
+
+from registry.api.redirect_routes import (
+    _decode_client_state,
+    _sanitize_return_path,
+    oauth2_callback,
+    oauth2_login_redirect,
+)
+
+
+def _encode_state(data: object) -> str:
+    return base64.urlsafe_b64encode(json.dumps(data).encode("utf-8")).decode("utf-8").rstrip("=")
+
+
+@pytest.fixture
+def mock_request() -> Mock:
+    request = Mock(spec=Request)
+    request.base_url = "http://localhost:8000/"
+    request.cookies = {}
+    request.headers = {}
+    request.url = Mock()
+    request.url.scheme = "http"
+    return request
+
+
+@pytest.fixture
+def mock_settings():
+    with patch("registry.api.redirect_routes.settings") as settings:
+        settings.auth_server_url = "http://auth.example.com"
+        settings.auth_server_external_url = "http://auth.example.com"
+        settings.csrf_cookie_name = "csrf"
+        settings.entra_group_sync_enabled = False
+        settings.jwt_issuer = "test-issuer"
+        settings.jwt_public_key = "test-public-key"
+        settings.oauth_session_ttl_seconds = 600
+        settings.refresh_cookie_name = "refresh"
+        settings.registry_app_name = "jarvis-registry-client"
+        settings.registry_client_secret = "test-secret"
+        settings.registry_client_url = "http://localhost:80/gateway"
+        settings.registry_redirect_uri = "http://localhost:7860/redirect"
+        settings.registry_url = "http://localhost:7860"
+        settings.scopes_file_config = {}
+        settings.session_cookie_name = "session"
+        settings.session_cookie_secure = False
+        yield settings
+
+
+@pytest.fixture
+def mock_user() -> Mock:
+    user = Mock()
+    user.id = "12345"
+    user.username = "testuser"
+    user.email = "test@example.com"
+    user.role = "user"
+    return user
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "/consent/server?nonce=abc",
+        "/",
+    ],
+)
+def test_sanitize_return_path_allows_same_origin_paths(raw: str) -> None:
+    assert _sanitize_return_path(raw) == raw
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw",
+    [
+        None,
+        "",
+        "login",
+        "//evil.com/x",
+        "/\\evil.com/x",
+        "https://evil.com",
+        "/x\r\nSet-Cookie: a=b",
+    ],
+)
+def test_sanitize_return_path_rejects_unsafe_values(raw: object) -> None:
+    assert _sanitize_return_path(raw) == ""
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (_encode_state({"nonce": "abc", "next": "/server-registry"}), {"nonce": "abc", "next": "/server-registry"}),
+        ("", {}),
+        ("not base64", {}),
+        (_encode_state(["not", "a", "dict"]), {}),
+    ],
+)
+def test_decode_client_state(raw: str, expected: dict[str, object]) -> None:
+    assert _decode_client_state(raw) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_oauth2_login_redirect_carries_next_in_state(mock_settings) -> None:
+    response = await oauth2_login_redirect("entra", next_path="/consent/server?nonce=abc")
+
+    assert isinstance(response, RedirectResponse)
+
+    location = response.headers["location"]
+    state = location.split("state=", 1)[1].split("&", 1)[0]
+    decoded = _decode_client_state(state)
+    assert decoded["next"] == "/consent/server?nonce=abc"
+
+
+async def _successful_callback(
+    *,
+    mock_request: Mock,
+    mock_user: Mock,
+    state: str | None,
+) -> RedirectResponse:
+    token_response = Mock()
+    token_response.status_code = 200
+    token_response.json.return_value = {"access_token": "test-access-token"}
+
+    user_service = Mock()
+    user_service.get_user_by_user_id = AsyncMock(return_value=mock_user)
+
+    group_service = Mock()
+    group_service.sync_user_group_memberships = AsyncMock()
+
+    with (
+        patch("registry.api.redirect_routes.httpx.AsyncClient") as mock_client,
+        patch("registry.api.redirect_routes.decrypt_value", return_value="verifier"),
+        patch("registry.api.redirect_routes.decode_jwt", return_value={"sub": "someone", "user_id": "12345"}),
+        patch("registry.api.redirect_routes.filter_known_groups", return_value=[]),
+        patch(
+            "registry.api.redirect_routes.generate_token_pair",
+            return_value=("mock-access-token", "mock-refresh-token"),
+        ),
+    ):
+        mock_client.return_value.__aenter__.return_value.post = AsyncMock(return_value=token_response)
+        response = await oauth2_callback(
+            mock_request,
+            code="test-auth-code",
+            state=state,
+            registry_oauth2_code_verifier="a-cookie",
+            user_service=user_service,
+            group_service=group_service,
+        )
+
+    return response
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_oauth2_callback_redirects_to_safe_next_path(mock_request, mock_settings, mock_user) -> None:
+    state = _encode_state({"nonce": "abc", "next": "/consent/server?nonce=abc"})
+
+    response = await _successful_callback(mock_request=mock_request, mock_user=mock_user, state=state)
+
+    assert response.headers["location"] == f"{mock_settings.registry_client_url}/consent/server?nonce=abc"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    [
+        None,
+        _encode_state({"nonce": "abc"}),
+        _encode_state({"nonce": "abc", "next": "https://evil.com"}),
+    ],
+)
+async def test_oauth2_callback_falls_back_to_registry_client_url(
+    mock_request,
+    mock_settings,
+    mock_user,
+    state: str | None,
+) -> None:
+    response = await _successful_callback(mock_request=mock_request, mock_user=mock_user, state=state)
+
+    assert response.headers["location"] == mock_settings.registry_client_url

--- a/registry/tests/unit/auth/test_auth_routes.py
+++ b/registry/tests/unit/auth/test_auth_routes.py
@@ -84,6 +84,8 @@ class TestAuthRoutes:
             mock_settings.session_cookie_name = "session"
             mock_settings.refresh_cookie_name = "refresh"
             mock_settings.csrf_cookie_name = "csrf"
+            mock_settings.oauth2_code_verifier_cookie_name = "registry_oauth2_code_verifier"
+            mock_settings.oauth2_state_nonce_cookie_name = "registry_oauth2_state_nonce"
             mock_settings.session_max_age_seconds = 3600
             mock_settings.session_cookie_secure = False
             mock_settings.templates_dir = "/templates"

--- a/registry/tests/unit/auth/test_auth_routes.py
+++ b/registry/tests/unit/auth/test_auth_routes.py
@@ -2,6 +2,8 @@
 Unit tests for authentication routes.
 """
 
+import base64
+import json
 import time
 from http.cookies import SimpleCookie
 from typing import Any
@@ -23,6 +25,16 @@ from registry.api.redirect_routes import (
 from registry.utils.crypto_utils import REFRESH_TOKEN_EXPIRES_SECONDS
 from registry.utils.csrf import compute_csrf_token
 from registry_pkgs.core.jwt_utils import InvalidSignatureError
+
+_TEST_STATE_NONCE = "test-state-nonce"
+
+
+def _encode_oauth2_state(data: object) -> str:
+    return base64.urlsafe_b64encode(json.dumps(data).encode("utf-8")).decode("utf-8").rstrip("=")
+
+
+def _valid_oauth2_state() -> str:
+    return _encode_oauth2_state({"nonce": _TEST_STATE_NONCE})
 
 
 def _cookies_from_response(response: Response) -> SimpleCookie:
@@ -229,7 +241,9 @@ class TestAuthRoutes:
             response = await oauth2_callback(
                 mock_request,
                 code=mock_code,
+                state=_valid_oauth2_state(),
                 registry_oauth2_code_verifier="a-cookie",
+                registry_oauth2_state_nonce=_TEST_STATE_NONCE,
                 user_service=mock_user_service,
             )
 
@@ -267,7 +281,9 @@ class TestAuthRoutes:
             response = await oauth2_callback(
                 mock_request,
                 code=mock_code,
+                state=_valid_oauth2_state(),
                 registry_oauth2_code_verifier="a-cookie",
+                registry_oauth2_state_nonce=_TEST_STATE_NONCE,
                 user_service=mock_user_service,
             )
 
@@ -320,7 +336,9 @@ class TestAuthRoutes:
             response = await oauth2_callback(
                 mock_request,
                 code=mock_code,
+                state=_valid_oauth2_state(),
                 registry_oauth2_code_verifier="a-cookie",
+                registry_oauth2_state_nonce=_TEST_STATE_NONCE,
                 user_service=mock_user_service,
             )
 
@@ -333,8 +351,10 @@ class TestAuthRoutes:
         """Test OAuth2 callback with error parameter."""
         response = await oauth2_callback(
             mock_request,
+            state=_valid_oauth2_state(),
             error="oauth2_error",
             details="Provider error",
+            registry_oauth2_state_nonce=_TEST_STATE_NONCE,
             user_service=Mock(),
         )
 
@@ -348,7 +368,9 @@ class TestAuthRoutes:
         """Test OAuth2 callback with init failed error."""
         response = await oauth2_callback(
             mock_request,
+            state=_valid_oauth2_state(),
             error="oauth2_init_failed",
+            registry_oauth2_state_nonce=_TEST_STATE_NONCE,
             user_service=Mock(),
         )
 
@@ -361,7 +383,9 @@ class TestAuthRoutes:
         """Test OAuth2 callback with callback failed error."""
         response = await oauth2_callback(
             mock_request,
+            state=_valid_oauth2_state(),
             error="oauth2_callback_failed",
+            registry_oauth2_state_nonce=_TEST_STATE_NONCE,
             user_service=Mock(),
         )
 
@@ -390,6 +414,9 @@ class TestAuthRoutes:
                 response = await oauth2_callback(
                     mock_request,
                     code=mock_code,
+                    state=_valid_oauth2_state(),
+                    registry_oauth2_code_verifier="a-cookie",
+                    registry_oauth2_state_nonce=_TEST_STATE_NONCE,
                     user_service=Mock(),
                 )
 
@@ -899,7 +926,9 @@ class TestAuthRoutes:
             await oauth2_callback(
                 mock_request,
                 code=mock_code,
+                state=_valid_oauth2_state(),
                 registry_oauth2_code_verifier="a-cookie",
+                registry_oauth2_state_nonce=_TEST_STATE_NONCE,
                 user_service=mock_user_service,
             )
 
@@ -961,7 +990,9 @@ class TestAuthRoutes:
             response = await oauth2_callback(
                 mock_request,
                 code=mock_code,
+                state=_valid_oauth2_state(),
                 registry_oauth2_code_verifier="a-cookie",
+                registry_oauth2_state_nonce=_TEST_STATE_NONCE,
                 user_service=mock_user_service,
             )
 


### PR DESCRIPTION
Preserve the interrupted SPA route through OAuth login and safely redirect back after authentication.