### PR TITLE
fix: AgentCore federation inbound auth config change detection

### DIFF
--- a/registry/src/registry/services/federation_sync_service.py
+++ b/registry/src/registry/services/federation_sync_service.py
@@ -4,10 +4,12 @@ from datetime import UTC, datetime
 from typing import Any
 
 from beanie import PydanticObjectId
+from pydantic import ValidationError
 from pymongo.asynchronous.client_session import AsyncClientSession
 
 from registry_pkgs.database.mongodb import MongoDB
 from registry_pkgs.models import A2AAgent, ExtendedMCPServer, PrincipalType, RegistryAccessRole, ResourceType
+from registry_pkgs.models.a2a_agent import AgentConfig
 from registry_pkgs.models.enums import (
     FederationJobPhase,
     FederationJobType,
@@ -18,6 +20,7 @@ from registry_pkgs.models.enums import (
 from registry_pkgs.models.extended_access_role import RegistryResourceType
 from registry_pkgs.models.extended_acl_entry import RegistryAclEntry
 from registry_pkgs.models.federation import (
+    AgentCoreRuntimeAccessConfig,
     Federation,
     FederationLastSync,
     FederationLastSyncSummary,
@@ -47,32 +50,49 @@ def _acl_key_part(value: Any) -> str:
     return str(_enum_value(value))
 
 
-def _runtime_access_mode(config: Any) -> str | None:
+def _normalize_runtime_access(
+    config: AgentConfig | dict[str, Any] | None,
+) -> AgentCoreRuntimeAccessConfig | None:
+    """Extract and parse a resource's config.runtimeAccess into a canonical model.
+
+    ExtendedMCPServer.config is an untyped dict (inherited from the codegen'd MCPServer base),
+    so its runtimeAccess arrives as a plain dict; A2AAgent.config is the typed AgentConfig, so
+    its runtimeAccess is already an AgentCoreRuntimeAccessConfig instance. Parsing both
+    representations into the same model type here means equality comparison covers every JWT
+    field (audiences, discoveryUrl, allowedClients, allowedScopes, customClaims) instead of just
+    mode, and is immune to default-key drift between differently-aged stored dicts.
+    """
     if not config:
         return None
 
     if isinstance(config, dict):
-        runtime_access = config.get("runtimeAccess")
+        raw_runtime_access = config.get("runtimeAccess")
     else:
-        runtime_access = getattr(config, "runtimeAccess", None)
+        raw_runtime_access = getattr(config, "runtimeAccess", None)
 
-    if runtime_access is None:
+    if raw_runtime_access is None:
         return None
 
-    if isinstance(runtime_access, dict):
-        mode = runtime_access.get("mode")
-    else:
-        mode = getattr(runtime_access, "mode", None)
+    if isinstance(raw_runtime_access, AgentCoreRuntimeAccessConfig):
+        return raw_runtime_access
 
-    if mode is None:
-        return None
-
-    normalized = str(_enum_value(mode)).strip().upper()
-    return normalized or None
+    return AgentCoreRuntimeAccessConfig(**raw_runtime_access)
 
 
-def _runtime_access_mode_changed(existing_config: Any, new_config: Any) -> bool:
-    return _runtime_access_mode(existing_config) != _runtime_access_mode(new_config)
+def _runtime_access_changed(
+    existing_config: AgentConfig | dict[str, Any] | None,
+    new_config: AgentConfig | dict[str, Any] | None,
+) -> bool:
+    try:
+        existing_runtime_access = _normalize_runtime_access(existing_config)
+        new_runtime_access = _normalize_runtime_access(new_config)
+    except (TypeError, ValidationError):
+        logger.warning(
+            "Failed to parse stored runtimeAccess for change detection; treating as changed",
+            exc_info=True,
+        )
+        return True
+    return existing_runtime_access != new_runtime_access
 
 
 @dataclass
@@ -635,7 +655,7 @@ class FederationSyncService:
                 apply_summary.createdMcpServers += 1
                 sync_plan.mcp_creates.append((item, remote_id))
             else:
-                runtime_access_changed = _runtime_access_mode_changed(
+                runtime_access_changed = _runtime_access_changed(
                     getattr(existing, "config", None),
                     getattr(item, "config", None),
                 )
@@ -733,7 +753,7 @@ class FederationSyncService:
                         f"(owned by federation {path_conflict.federationRefId or 'unknown'})"
                     )
                     continue
-                runtime_access_changed = _runtime_access_mode_changed(
+                runtime_access_changed = _runtime_access_changed(
                     getattr(existing, "config", None),
                     getattr(item, "config", None),
                 )

--- a/registry/tests/unit/services/test_federation_sync_service.py
+++ b/registry/tests/unit/services/test_federation_sync_service.py
@@ -17,6 +17,7 @@ from registry_pkgs.models import A2AAgent, ExtendedMCPServer, PrincipalType, Res
 from registry_pkgs.models.enums import FederationProviderType, FederationStatus, FederationSyncStatus, RoleBits
 from registry_pkgs.models.extended_access_role import RegistryResourceType
 from registry_pkgs.models.extended_acl_entry import RegistryAclEntry
+from registry_pkgs.models.federation import AgentCoreRuntimeAccessConfig, AgentCoreRuntimeJwtConfig
 from registry_pkgs.models.federation_sync_job import FederationApplySummary
 
 _DEFAULT_USER_OBJECT_ID = PydanticObjectId()
@@ -527,13 +528,13 @@ async def test_build_sync_plan_updates_a2a_when_only_runtime_access_mode_changes
         federationRefId=federation.id,
         federationMetadata={"runtimeArn": runtime_arn, "runtimeVersion": "1"},
         path=agent_path,
-        config=SimpleNamespace(type="jsonrpc", runtimeAccess=SimpleNamespace(mode="iam")),
+        config=SimpleNamespace(type="jsonrpc", runtimeAccess=AgentCoreRuntimeAccessConfig(mode="iam")),
     )
     discovered_a2a = SimpleNamespace(
         federationMetadata={"runtimeArn": runtime_arn, "runtimeVersion": "1"},
         path=agent_path,
         card=SimpleNamespace(name="auth-mode-a2a"),
-        config=SimpleNamespace(type="jsonrpc", runtimeAccess=SimpleNamespace(mode="jwt")),
+        config=SimpleNamespace(type="jsonrpc", runtimeAccess=AgentCoreRuntimeAccessConfig(mode="jwt")),
     )
 
     def _fake_mcp_find(query, session=None):
@@ -575,13 +576,13 @@ async def test_build_sync_plan_ignores_a2a_transport_type_only_change(
         federationRefId=federation.id,
         federationMetadata={"runtimeArn": runtime_arn, "runtimeVersion": "1"},
         path=agent_path,
-        config=SimpleNamespace(type="http_json", runtimeAccess=SimpleNamespace(mode="jwt")),
+        config=SimpleNamespace(type="http_json", runtimeAccess=AgentCoreRuntimeAccessConfig(mode="jwt")),
     )
     discovered_a2a = SimpleNamespace(
         federationMetadata={"runtimeArn": runtime_arn, "runtimeVersion": "1"},
         path=agent_path,
         card=SimpleNamespace(name="transport-only-a2a"),
-        config=SimpleNamespace(type="jsonrpc", runtimeAccess=SimpleNamespace(mode="jwt")),
+        config=SimpleNamespace(type="jsonrpc", runtimeAccess=AgentCoreRuntimeAccessConfig(mode="jwt")),
     )
 
     def _fake_mcp_find(query, session=None):
@@ -609,6 +610,158 @@ async def test_build_sync_plan_ignores_a2a_transport_type_only_change(
     assert sync_plan.summary.unchangedAgents == 1
     assert sync_plan.a2a_updates == []
     assert sync_plan.a2a_pre_existing_acl_targets == [existing_a2a.id]
+
+
+@pytest.mark.asyncio
+async def test_build_sync_plan_updates_mcp_when_only_jwt_audiences_change(
+    federation_sync_service: FederationSyncService,
+    monkeypatch,
+):
+    """Regression test: AWS rotating a JWT authorizer's allowedAudience (with mode and
+    runtimeVersion unchanged) must still be classified as an update, not silently dropped."""
+    federation = _make_federation(FederationProviderType.AWS_AGENTCORE, {"region": "us-east-1"})
+    runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123:runtime/audience-rotation-mcp"
+    existing_mcp = SimpleNamespace(
+        id=PydanticObjectId(),
+        federationRefId=federation.id,
+        federationMetadata={"runtimeArn": runtime_arn, "runtimeVersion": "1"},
+        serverName="audience-rotation-mcp",
+        config={"runtimeAccess": {"mode": "jwt", "jwt": {"audiences": ["jarvis-services"]}}},
+    )
+    discovered_mcp = SimpleNamespace(
+        federationMetadata={"runtimeArn": runtime_arn, "runtimeVersion": "1"},
+        serverName="audience-rotation-mcp",
+        config={"runtimeAccess": {"mode": "jwt", "jwt": {"audiences": ["jarvis-managed-agents"]}}},
+    )
+
+    def _fake_mcp_find(query, session=None):
+        if query == {"federationRefId": federation.id}:
+            return _FakeQuery([existing_mcp])
+        raise AssertionError(f"Unexpected MCP query: {query}")
+
+    def _fake_a2a_find(query, session=None):
+        if query == {"federationRefId": federation.id}:
+            return _FakeQuery([])
+        raise AssertionError(f"Unexpected A2A query: {query}")
+
+    monkeypatch.setattr("registry.services.federation_sync_service.ExtendedMCPServer.find", _fake_mcp_find)
+    monkeypatch.setattr("registry.services.federation_sync_service.A2AAgent.find", _fake_a2a_find)
+
+    sync_plan = await federation_sync_service._build_sync_plan(
+        federation=federation,
+        discovered_mcp=[discovered_mcp],
+        discovered_a2a=[],
+    )
+
+    assert sync_plan.summary.updatedMcpServers == 1
+    assert sync_plan.summary.unchangedMcpServers == 0
+    assert sync_plan.mcp_updates == [(existing_mcp, discovered_mcp, runtime_arn)]
+
+
+@pytest.mark.asyncio
+async def test_build_sync_plan_updates_a2a_when_only_jwt_audiences_change(
+    federation_sync_service: FederationSyncService,
+    monkeypatch,
+):
+    """Regression test: same audience-rotation scenario as the MCP case above, for A2A agents."""
+    federation = _make_federation(FederationProviderType.AWS_AGENTCORE, {"region": "us-east-1"})
+    runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123:runtime/audience-rotation-a2a"
+    agent_path = "/agentcore/a2a/audience-rotation-a2a"
+    existing_a2a = SimpleNamespace(
+        id=PydanticObjectId(),
+        federationRefId=federation.id,
+        federationMetadata={"runtimeArn": runtime_arn, "runtimeVersion": "1"},
+        path=agent_path,
+        config=SimpleNamespace(
+            type="jsonrpc",
+            runtimeAccess=AgentCoreRuntimeAccessConfig(
+                mode="jwt", jwt=AgentCoreRuntimeJwtConfig(audiences=["jarvis-services"])
+            ),
+        ),
+    )
+    discovered_a2a = SimpleNamespace(
+        federationMetadata={"runtimeArn": runtime_arn, "runtimeVersion": "1"},
+        path=agent_path,
+        card=SimpleNamespace(name="audience-rotation-a2a"),
+        config=SimpleNamespace(
+            type="jsonrpc",
+            runtimeAccess=AgentCoreRuntimeAccessConfig(
+                mode="jwt", jwt=AgentCoreRuntimeJwtConfig(audiences=["jarvis-managed-agents"])
+            ),
+        ),
+    )
+
+    def _fake_mcp_find(query, session=None):
+        if query == {"federationRefId": federation.id}:
+            return _FakeQuery([])
+        raise AssertionError(f"Unexpected MCP query: {query}")
+
+    def _fake_a2a_find(query, session=None):
+        if query == {"federationRefId": federation.id}:
+            return _FakeQuery([existing_a2a])
+        if query == {"path": {"$in": [agent_path]}}:
+            return _FakeQuery([existing_a2a])
+        raise AssertionError(f"Unexpected A2A query: {query}")
+
+    monkeypatch.setattr("registry.services.federation_sync_service.ExtendedMCPServer.find", _fake_mcp_find)
+    monkeypatch.setattr("registry.services.federation_sync_service.A2AAgent.find", _fake_a2a_find)
+
+    sync_plan = await federation_sync_service._build_sync_plan(
+        federation=federation,
+        discovered_mcp=[],
+        discovered_a2a=[discovered_a2a],
+    )
+
+    assert sync_plan.summary.updatedAgents == 1
+    assert sync_plan.summary.unchangedAgents == 0
+    assert sync_plan.a2a_updates == [(existing_a2a, discovered_a2a, runtime_arn)]
+
+
+@pytest.mark.asyncio
+async def test_build_sync_plan_treats_unparseable_existing_runtime_access_as_changed(
+    federation_sync_service: FederationSyncService,
+    monkeypatch,
+):
+    """Fail-open regression test: a stored runtimeAccess dict that no longer matches
+    AgentCoreRuntimeAccessConfig's schema must force an update (refresh from AWS), not
+    crash the sync or get silently treated as unchanged."""
+    federation = _make_federation(FederationProviderType.AWS_AGENTCORE, {"region": "us-east-1"})
+    runtime_arn = "arn:aws:bedrock-agentcore:us-east-1:123:runtime/malformed-runtime-access-mcp"
+    existing_mcp = SimpleNamespace(
+        id=PydanticObjectId(),
+        federationRefId=federation.id,
+        federationMetadata={"runtimeArn": runtime_arn, "runtimeVersion": "1"},
+        serverName="malformed-runtime-access-mcp",
+        config={"runtimeAccess": {"mode": "jwt", "jwt": "not-a-mapping"}},
+    )
+    discovered_mcp = SimpleNamespace(
+        federationMetadata={"runtimeArn": runtime_arn, "runtimeVersion": "1"},
+        serverName="malformed-runtime-access-mcp",
+        config={"runtimeAccess": {"mode": "jwt", "jwt": {"audiences": ["jarvis-services"]}}},
+    )
+
+    def _fake_mcp_find(query, session=None):
+        if query == {"federationRefId": federation.id}:
+            return _FakeQuery([existing_mcp])
+        raise AssertionError(f"Unexpected MCP query: {query}")
+
+    def _fake_a2a_find(query, session=None):
+        if query == {"federationRefId": federation.id}:
+            return _FakeQuery([])
+        raise AssertionError(f"Unexpected A2A query: {query}")
+
+    monkeypatch.setattr("registry.services.federation_sync_service.ExtendedMCPServer.find", _fake_mcp_find)
+    monkeypatch.setattr("registry.services.federation_sync_service.A2AAgent.find", _fake_a2a_find)
+
+    sync_plan = await federation_sync_service._build_sync_plan(
+        federation=federation,
+        discovered_mcp=[discovered_mcp],
+        discovered_a2a=[],
+    )
+
+    assert sync_plan.summary.updatedMcpServers == 1
+    assert sync_plan.summary.unchangedMcpServers == 0
+    assert sync_plan.mcp_updates == [(existing_mcp, discovered_mcp, runtime_arn)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Previously, our AgentCore federation code doesn't detect inbound auth changes unless the change is in "mode" (i.e. IAM <-> JWT). Fixed to detect inbound auth change properly, so that if `allowedAudiences` change for JWT inbound auth, it's correctly detected.

**Note**: This doesn't fix two other gaps identified in the process of making this PR.
1. The frontend doesn't implement really polling behavior for federation sync, because the supporting backend API is not in place. I will create two tickets to implement this—AS-1730 will be the backend ticket for this change.
2. If we encounter an exception when calling one MCP/A2A, it stops the entire MongoDB-to-Weaviate vector sync. For example, if one of three agents raised exception, the other two agents will update data correctly in MongoDB, but none has data synced to Weaviate. I'll create a ticket for this.