### PR TITLE
Extract shared AgentCore JWT signing

### DIFF
--- a/auth-server/src/auth_server/server.py
+++ b/auth-server/src/auth_server/server.py
@@ -122,7 +122,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=["*"],
-    expose_headers=["WWW-Authenticate", "X-User-Id", "X-Username", "X-Client-Id", "X-Scopes", "X-Jarvis-Auth"],
+    expose_headers=["WWW-Authenticate", "X-User-Id", "X-Username", "X-Client-Id", "X-Scopes"],
 )
 
 # Include .well-known routes at root level (for mcp-remote RFC 8414 compliance)

--- a/registry-pkgs/src/registry_pkgs/core/agentcore_jwt.py
+++ b/registry-pkgs/src/registry_pkgs/core/agentcore_jwt.py
@@ -90,7 +90,6 @@ def parse_agentcore_runtime_access(
 def sign_agentcore_jwt(
     runtime_jwt_config: AgentCoreRuntimeJwtConfig | None,
     *,
-    subject: str,
     signing: JwtSigningConfig,
     cache_key: str,
     redis_client: Any | None = None,
@@ -110,7 +109,7 @@ def sign_agentcore_jwt(
 
     token = mint_agentcore_runtime_jwt(
         runtime_jwt_config,
-        subject=subject,
+        subject=signing.registry_app_name,
         signing=signing,
         expires_in_seconds=_AGENTCORE_JWT_TTL_SECONDS,
     )

--- a/registry-pkgs/src/registry_pkgs/core/agentcore_jwt.py
+++ b/registry-pkgs/src/registry_pkgs/core/agentcore_jwt.py
@@ -4,6 +4,8 @@ import logging
 from typing import Any
 from urllib.parse import urlparse
 
+from redis import Redis
+
 from registry_pkgs.core.config import JwtSigningConfig
 from registry_pkgs.core.jwt_utils import build_jwt_payload, encode_jwt
 from registry_pkgs.models.federation import AgentCoreRuntimeAccessConfig, AgentCoreRuntimeJwtConfig
@@ -92,7 +94,7 @@ def sign_agentcore_jwt(
     *,
     signing: JwtSigningConfig,
     cache_key: str,
-    redis_client: Any | None = None,
+    redis_client: Redis | None = None,
 ) -> str:
     """Mint (or return a cached) AgentCore Runtime JWT.
 

--- a/registry-pkgs/src/registry_pkgs/core/agentcore_jwt.py
+++ b/registry-pkgs/src/registry_pkgs/core/agentcore_jwt.py
@@ -1,11 +1,14 @@
 """JWT minting helpers for AWS Bedrock AgentCore Runtime access."""
 
+import logging
 from typing import Any
 from urllib.parse import urlparse
 
 from registry_pkgs.core.config import JwtSigningConfig
 from registry_pkgs.core.jwt_utils import build_jwt_payload, encode_jwt
-from registry_pkgs.models.federation import AgentCoreRuntimeJwtConfig
+from registry_pkgs.models.federation import AgentCoreRuntimeAccessConfig, AgentCoreRuntimeJwtConfig
+
+logger = logging.getLogger(__name__)
 
 
 def _normalize_claim_value(value: Any) -> Any:
@@ -69,3 +72,57 @@ def mint_agentcore_runtime_jwt(
         extra_claims=extra_claims or None,
     )
     return encode_jwt(payload, signing.jwt_private_key, kid=signing.jwt_self_signed_kid)
+
+
+_AGENTCORE_JWT_TTL_SECONDS = 3600
+_AGENTCORE_JWT_LEEWAY_SECONDS = 60
+
+
+def parse_agentcore_runtime_access(
+    runtime_access: AgentCoreRuntimeAccessConfig | dict[str, Any],
+) -> AgentCoreRuntimeAccessConfig:
+    """Return a validated runtime-access model from stored MCP/A2A config."""
+    if isinstance(runtime_access, AgentCoreRuntimeAccessConfig):
+        return runtime_access
+    return AgentCoreRuntimeAccessConfig.model_validate(runtime_access)
+
+
+def sign_agentcore_jwt(
+    runtime_jwt_config: AgentCoreRuntimeJwtConfig | None,
+    *,
+    subject: str,
+    signing: JwtSigningConfig,
+    cache_key: str,
+    redis_client: Any | None = None,
+) -> str:
+    """Mint (or return a cached) AgentCore Runtime JWT.
+
+    This function is synchronous so it can be used inside agno's
+    ``MCPTools.header_provider`` callback, which is never awaited.
+    """
+    if redis_client is not None:
+        try:
+            cached = redis_client.get(cache_key)
+            if cached:
+                return cached.decode("utf-8") if isinstance(cached, bytes) else cached
+        except Exception:
+            logger.exception("Failed to read cached AgentCore JWT for %s", cache_key)
+
+    token = mint_agentcore_runtime_jwt(
+        runtime_jwt_config,
+        subject=subject,
+        signing=signing,
+        expires_in_seconds=_AGENTCORE_JWT_TTL_SECONDS,
+    )
+
+    if redis_client is not None:
+        try:
+            redis_client.setex(
+                cache_key,
+                _AGENTCORE_JWT_TTL_SECONDS - _AGENTCORE_JWT_LEEWAY_SECONDS,
+                token,
+            )
+        except Exception:
+            logger.exception("Failed to cache AgentCore JWT for %s", cache_key)
+
+    return token

--- a/registry-pkgs/src/registry_pkgs/core/config.py
+++ b/registry-pkgs/src/registry_pkgs/core/config.py
@@ -69,6 +69,10 @@ class JwtSigningConfig(BaseModel):
     jwt_issuer: str = Field(description="Issuer (`iss`) claim — the registry's public URL")
     jwt_self_signed_kid: str = Field(description="`kid` header for self-signed JWKS lookup")
     jwt_audience: str = Field(description="Default audience (`aud`) claim")
+    registry_app_name: str = Field(
+        default="jarvis-registry-client",
+        description="Application name used as JWT subject for service-to-service calls",
+    )
 
 
 class JwtTokenConfig(BaseModel):
@@ -282,6 +286,7 @@ class JarvisBaseSettings(BaseSettings):
             jwt_issuer=self.jwt_issuer,
             jwt_self_signed_kid=self.jwt_self_signed_kid,
             jwt_audience=self.jwt_audience,
+            registry_app_name=self.registry_app_name,
         )
 
     @cached_property

--- a/registry-pkgs/tests/unit/core/test_agentcore_jwt.py
+++ b/registry-pkgs/tests/unit/core/test_agentcore_jwt.py
@@ -102,7 +102,6 @@ def test_sign_agentcore_jwt_returns_cached_token_without_minting():
 
     token = sign_agentcore_jwt(
         None,
-        subject="jarvis-registry",
         signing=_signing_config(),
         cache_key="test:agentcore_jwt:server-1",
         redis_client=redis_client,
@@ -119,7 +118,6 @@ def test_sign_agentcore_jwt_mints_and_caches_on_miss():
 
     token = sign_agentcore_jwt(
         None,
-        subject="jarvis-registry",
         signing=_signing_config(),
         cache_key="test:agentcore_jwt:server-2",
         redis_client=redis_client,
@@ -140,7 +138,6 @@ def test_sign_agentcore_jwt_mints_and_caches_on_miss():
 def test_sign_agentcore_jwt_mints_uncached_when_no_redis_client():
     token = sign_agentcore_jwt(
         None,
-        subject="jarvis-registry",
         signing=_signing_config(),
         cache_key="test:agentcore_jwt:server-3",
         redis_client=None,
@@ -156,7 +153,6 @@ def test_sign_agentcore_jwt_falls_back_when_cache_read_fails():
 
     token = sign_agentcore_jwt(
         None,
-        subject="jarvis-registry",
         signing=_signing_config(),
         cache_key="test:agentcore_jwt:read-failure",
         redis_client=redis_client,
@@ -173,7 +169,6 @@ def test_sign_agentcore_jwt_returns_token_when_cache_write_fails():
 
     token = sign_agentcore_jwt(
         None,
-        subject="jarvis-registry",
         signing=_signing_config(),
         cache_key="test:agentcore_jwt:write-failure",
         redis_client=redis_client,

--- a/registry-pkgs/tests/unit/core/test_agentcore_jwt.py
+++ b/registry-pkgs/tests/unit/core/test_agentcore_jwt.py
@@ -1,7 +1,9 @@
+from unittest.mock import MagicMock
+
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-from registry_pkgs.core.agentcore_jwt import mint_agentcore_runtime_jwt
+from registry_pkgs.core.agentcore_jwt import mint_agentcore_runtime_jwt, sign_agentcore_jwt
 from registry_pkgs.core.config import JwtSigningConfig
 from registry_pkgs.core.jwt_utils import decode_jwt_unverified, get_token_unverified_header
 from registry_pkgs.models.federation import AgentCoreRuntimeJwtConfig
@@ -22,6 +24,7 @@ def _signing_config() -> JwtSigningConfig:
         jwt_issuer="https://registry.test",
         jwt_self_signed_kid=_KID,
         jwt_audience="jarvis-services",
+        registry_app_name="jarvis-registry",
     )
 
 
@@ -91,3 +94,90 @@ def test_adds_normalized_client_scope_and_custom_claims():
     assert claims["tenant"] == "prod"
     assert claims["nested"] == {"value": "trimmed"}
     assert claims["list"] == ["a", "b"]
+
+
+def test_sign_agentcore_jwt_returns_cached_token_without_minting():
+    redis_client = MagicMock()
+    redis_client.get.return_value = b"cached-token"
+
+    token = sign_agentcore_jwt(
+        None,
+        subject="jarvis-registry",
+        signing=_signing_config(),
+        cache_key="test:agentcore_jwt:server-1",
+        redis_client=redis_client,
+    )
+
+    assert token == "cached-token"
+    redis_client.get.assert_called_once_with("test:agentcore_jwt:server-1")
+    redis_client.setex.assert_not_called()
+
+
+def test_sign_agentcore_jwt_mints_and_caches_on_miss():
+    redis_client = MagicMock()
+    redis_client.get.return_value = None
+
+    token = sign_agentcore_jwt(
+        None,
+        subject="jarvis-registry",
+        signing=_signing_config(),
+        cache_key="test:agentcore_jwt:server-2",
+        redis_client=redis_client,
+    )
+
+    claims = decode_jwt_unverified(token)
+    assert claims["sub"] == "jarvis-registry"
+    assert claims["iss"] == "https://registry.test"
+    assert claims["aud"] == "jarvis-services"
+
+    redis_client.get.assert_called_once_with("test:agentcore_jwt:server-2")
+    redis_client.setex.assert_called_once()
+    _, ttl, cached_value = redis_client.setex.call_args.args
+    assert ttl == 3540
+    assert cached_value == token
+
+
+def test_sign_agentcore_jwt_mints_uncached_when_no_redis_client():
+    token = sign_agentcore_jwt(
+        None,
+        subject="jarvis-registry",
+        signing=_signing_config(),
+        cache_key="test:agentcore_jwt:server-3",
+        redis_client=None,
+    )
+
+    claims = decode_jwt_unverified(token)
+    assert claims["sub"] == "jarvis-registry"
+
+
+def test_sign_agentcore_jwt_falls_back_when_cache_read_fails():
+    redis_client = MagicMock()
+    redis_client.get.side_effect = ConnectionError("redis unavailable")
+
+    token = sign_agentcore_jwt(
+        None,
+        subject="jarvis-registry",
+        signing=_signing_config(),
+        cache_key="test:agentcore_jwt:read-failure",
+        redis_client=redis_client,
+    )
+
+    assert decode_jwt_unverified(token)["sub"] == "jarvis-registry"
+    redis_client.setex.assert_called_once()
+
+
+def test_sign_agentcore_jwt_returns_token_when_cache_write_fails():
+    redis_client = MagicMock()
+    redis_client.get.return_value = None
+    redis_client.setex.side_effect = ConnectionError("redis unavailable")
+
+    token = sign_agentcore_jwt(
+        None,
+        subject="jarvis-registry",
+        signing=_signing_config(),
+        cache_key="test:agentcore_jwt:write-failure",
+        redis_client=redis_client,
+    )
+
+    assert decode_jwt_unverified(token)["sub"] == "jarvis-registry"
+    redis_client.setex.assert_called_once()

--- a/registry/src/registry/core/config.py
+++ b/registry/src/registry/core/config.py
@@ -39,7 +39,6 @@ class Settings(JarvisBaseSettings):
 
     # ==================== Headers ====================
     auth_egress_header: str = "Authorization"
-    internal_auth_header: str = "X-Jarvis-Auth"
     csrf_header_name: str = "X-Jarvis-CSRF"
 
     # ==================== API ====================

--- a/registry/src/registry/services/server_service.py
+++ b/registry/src/registry/services/server_service.py
@@ -22,13 +22,12 @@ from beanie import PydanticObjectId
 from pymongo.asynchronous.client_session import AsyncClientSession
 from redis import Redis
 
-from registry_pkgs.core.agentcore_jwt import mint_agentcore_runtime_jwt
+from registry_pkgs.core.agentcore_jwt import parse_agentcore_runtime_access, sign_agentcore_jwt
 from registry_pkgs.models import (
     ExtendedMCPServer,
     Token,
 )
 from registry_pkgs.models.enums import AgentCoreRuntimeAccessMode
-from registry_pkgs.models.federation import AgentCoreRuntimeAccessConfig
 from registry_pkgs.vector.repositories.mcp_server_repository import MCPServerRepository
 
 from ..auth.oauth.types import StateMetadata
@@ -45,7 +44,7 @@ from ..schemas.server_api_schemas import (
     ServerCreateRequest,
     ServerUpdateRequest,
 )
-from ..utils.crypto_utils import decrypt_auth_fields, encrypt_auth_fields, generate_service_jwt
+from ..utils.crypto_utils import decrypt_auth_fields, encrypt_auth_fields
 from ..utils.schema_converter import convert_dict_keys_to_snake
 from ..utils.utils import generate_server_name_from_title, normalize_headers
 from .oauth.oauth_service import MCPOAuthService
@@ -129,12 +128,6 @@ async def build_complete_headers_for_server(
         "User-Agent": settings.registry_app_name,
     }
 
-    # Always add internal service JWT if user_id is provided
-    if user_id:
-        service_jwt = generate_service_jwt(user_id)
-        headers[settings.internal_auth_header] = f"Bearer {service_jwt}"
-        logger.debug(f"Added internal service JWT to {settings.internal_auth_header} header for user {user_id}")
-
     # 1. Add custom headers FIRST (lowest priority)
     custom_headers = normalize_headers(decrypted_config.get("headers"))
     logger.info(f"custom headers: {custom_headers}")
@@ -148,53 +141,20 @@ async def build_complete_headers_for_server(
         # AgentCore Runtime server with runtimeAccess configuration
         try:
             # Parse runtime access config
-            if isinstance(runtime_access_config, dict):
-                access_config = AgentCoreRuntimeAccessConfig(**runtime_access_config)
-            else:
-                access_config = runtime_access_config
+            access_config = parse_agentcore_runtime_access(runtime_access_config)
 
             # Only handle JWT mode for now (IAM support can be added later if needed)
             if access_config.mode == AgentCoreRuntimeAccessMode.JWT:
                 logger.info(f"Building JWT token for AgentCore Runtime server {server.serverName}")
 
-                # Generate cache key for JWT token
                 cache_key = f"{settings.redis_key_prefix}:agentcore_jwt:{server.id}"
-
-                # Try to get cached JWT token
-                cached_token = None
-                if redis_client:
-                    try:
-                        cached_value = redis_client.get(cache_key)
-                        if cached_value:
-                            cached_token = (
-                                cached_value.decode("utf-8") if isinstance(cached_value, bytes) else cached_value
-                            )
-                            logger.debug(f"Using cached JWT token for {server.serverName}")
-                    except Exception:
-                        logger.exception(f"Failed to get cached JWT for {server.serverName}")
-
-                # Use cached token if available
-                if cached_token:
-                    headers["Authorization"] = f"Bearer {cached_token}"
-                    logger.info(f"Added cached AgentCore Runtime JWT for {server.serverName}")
-                    return headers
-
-                token = mint_agentcore_runtime_jwt(
+                token = sign_agentcore_jwt(
                     access_config.jwt,
                     subject=settings.registry_app_name,
                     signing=settings.jwt_signing_config,
-                    expires_in_seconds=300,
+                    cache_key=cache_key,
+                    redis_client=redis_client,
                 )
-
-                # Cache the JWT token (270 seconds = 300s token TTL - 30s buffer)
-                if redis_client:
-                    try:
-                        redis_client.setex(cache_key, 270, token)
-                        logger.debug(f"Cached JWT token for {server.serverName} (TTL: 270s)")
-                    except Exception:
-                        logger.exception(f"Failed to cache JWT for {server.serverName}")
-
-                # Set Authorization header
                 headers["Authorization"] = f"Bearer {token}"
                 logger.info(f"Added AgentCore Runtime JWT for {server.serverName}")
                 return headers

--- a/registry/src/registry/services/server_service.py
+++ b/registry/src/registry/services/server_service.py
@@ -150,7 +150,6 @@ async def build_complete_headers_for_server(
                 cache_key = f"{settings.redis_key_prefix}:agentcore_jwt:{server.id}"
                 token = sign_agentcore_jwt(
                     access_config.jwt,
-                    subject=settings.registry_app_name,
                     signing=settings.jwt_signing_config,
                     cache_key=cache_key,
                     redis_client=redis_client,

--- a/registry/tests/unit/servers/test_server_service.py
+++ b/registry/tests/unit/servers/test_server_service.py
@@ -415,9 +415,9 @@ class TestBuildCompleteHeaders:
     """Test suite for build_complete_headers_for_server function."""
 
     @pytest.fixture(autouse=True)
-    def mock_generate_service_jwt(self):
-        """Patch generate_service_jwt so tests don't need a real RSA private key."""
-        with patch("registry.services.server_service.generate_service_jwt", return_value="mock-service-jwt"):
+    def mock_sign_agentcore_jwt(self):
+        """Patch sign_agentcore_jwt so tests without explicit override don't need a real RSA private key."""
+        with patch("registry.services.server_service.sign_agentcore_jwt", return_value="mock-agentcore-jwt"):
             yield
 
     @pytest.fixture
@@ -520,6 +520,7 @@ class TestBuildCompleteHeaders:
             jwt_issuer="https://registry.example.com",
             jwt_self_signed_kid="server-service-test-key",
             jwt_audience="jarvis-services",
+            registry_app_name="jarvis-registry",
         )
 
     @pytest.mark.asyncio
@@ -529,7 +530,10 @@ class TestBuildCompleteHeaders:
         jwt_signing_config,
     ):
         """AgentCore MCP proxy JWT derives iss/aud from the specific server config."""
+        from unittest.mock import patch
+
         from registry.services.server_service import build_complete_headers_for_server
+        from registry_pkgs.core.agentcore_jwt import mint_agentcore_runtime_jwt
         from registry_pkgs.core.jwt_utils import decode_jwt_unverified
 
         with (
@@ -537,11 +541,17 @@ class TestBuildCompleteHeaders:
                 "registry.services.server_service.decrypt_auth_fields", return_value=mock_agentcore_jwt_server.config
             ),
             patch("registry.services.server_service.settings") as mock_settings,
+            patch("registry.services.server_service.sign_agentcore_jwt") as mock_sign,
         ):
             mock_settings.registry_app_name = "jarvis-registry"
             mock_settings.redis_key_prefix = "test-registry"
             mock_settings.jwt_signing_config = jwt_signing_config
-            mock_settings.internal_auth_header = "X-Internal-Authorization"
+            mock_sign.side_effect = lambda *args, **kwargs: mint_agentcore_runtime_jwt(
+                kwargs.get("runtime_jwt_config") or (args[0] if args else None),
+                subject=kwargs.get("subject", "jarvis-registry"),
+                signing=kwargs.get("signing", jwt_signing_config),
+                expires_in_seconds=3600,
+            )
 
             headers = await build_complete_headers_for_server(Mock(), mock_agentcore_jwt_server, None)
 

--- a/registry/tests/unit/servers/test_server_service.py
+++ b/registry/tests/unit/servers/test_server_service.py
@@ -548,7 +548,7 @@ class TestBuildCompleteHeaders:
             mock_settings.jwt_signing_config = jwt_signing_config
             mock_sign.side_effect = lambda *args, **kwargs: mint_agentcore_runtime_jwt(
                 kwargs.get("runtime_jwt_config") or (args[0] if args else None),
-                subject=kwargs.get("subject", "jarvis-registry"),
+                subject=kwargs.get("signing", jwt_signing_config).registry_app_name,
                 signing=kwargs.get("signing", jwt_signing_config),
                 expires_in_seconds=3600,
             )

--- a/registry/tests/unit/servers/test_server_service.py
+++ b/registry/tests/unit/servers/test_server_service.py
@@ -530,8 +530,6 @@ class TestBuildCompleteHeaders:
         jwt_signing_config,
     ):
         """AgentCore MCP proxy JWT derives iss/aud from the specific server config."""
-        from unittest.mock import patch
-
         from registry.services.server_service import build_complete_headers_for_server
         from registry_pkgs.core.agentcore_jwt import mint_agentcore_runtime_jwt
         from registry_pkgs.core.jwt_utils import decode_jwt_unverified


### PR DESCRIPTION
## What changed

- extract shared synchronous AgentCore JWT signing into `registry-pkgs`
- reuse the signer from server header construction
- cache runtime JWTs in Redis with a 60-second expiry leeway
- remove the unused `X-Jarvis-Auth` response header

## Why

AS-1741 needs one AgentCore JWT implementation that can be reused by both registry services and workflow MCP executors. This prerequisite PR centralizes signing and caching without changing workflow execution yet.

## Impact

AgentCore JWTs now use the shared one-hour lifetime and 3540-second cache TTL. Redis failures continue to fall back to local signing.