### PR TITLE
Feature: `initialInput` should be in all executor node prompts

### DIFF
--- a/registry-pkgs/src/registry_pkgs/workflows/compiler.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/compiler.py
@@ -36,6 +36,7 @@ from registry_pkgs.workflows.persistence import WorkflowRunSyncer
 from registry_pkgs.workflows.prompt import (
     ADDITIONAL_DATA_DEPENDENCY_NODE_NAMES,
     ADDITIONAL_DATA_DEPENDENCY_OBJECTIVES,
+    ADDITIONAL_DATA_INITIAL_INPUT,
     ADDITIONAL_DATA_STEP_OBJECTIVE,
     ADDITIONAL_DATA_WORKFLOW_DESCRIPTION,
 )
@@ -164,6 +165,7 @@ def _with_intention_data(
     node_by_name: dict[str, WorkflowNode],
     workflow_description: str | None,
     dependency_node_names: list[str],
+    initial_input: dict[str, Any] | None,
 ) -> StepExecutor:
     """Inject per-node intention into ``StepInput.additional_data`` before calling the executor.
 
@@ -180,6 +182,11 @@ def _with_intention_data(
     Keys written to ``additional_data`` are the constants defined in ``prompt.py``
     (``ADDITIONAL_DATA_*``).  ``build_prompt`` in ``helpers.py`` reads them back
     and calls ``render_step_prompt`` to assemble the final Markdown prompt.
+
+    ``initial_input`` is ``WorkflowRun.initial_input`` — the run's trigger payload —
+    forwarded to *every* node regardless of dependencies, so a downstream node can
+    reference a trigger field (e.g. a Slack member ID) directly instead of relying
+    on an upstream node to relay it through its own output.
     """
     dependency_objectives: dict[str, str] = {
         name: node_by_name[name].step_objective or "" for name in dependency_node_names if name in node_by_name
@@ -193,6 +200,7 @@ def _with_intention_data(
             ADDITIONAL_DATA_WORKFLOW_DESCRIPTION: workflow_description,
             ADDITIONAL_DATA_DEPENDENCY_NODE_NAMES: dependency_node_names,
             ADDITIONAL_DATA_DEPENDENCY_OBJECTIVES: dependency_objectives,
+            ADDITIONAL_DATA_INITIAL_INPUT: initial_input,
         }
         return await executor(enriched, session_state)
 
@@ -347,6 +355,7 @@ def compile_workflow(
                     node_by_name,
                     definition.description,
                     dependency_node_names,
+                    run.initial_input,
                 )
 
             # _with_input_capture snapshots the pre-injection StepInput, so it

--- a/registry-pkgs/src/registry_pkgs/workflows/helpers.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/helpers.py
@@ -135,7 +135,7 @@ def build_prompt(step_input: StepInput) -> str:
     dependency_node_names: list[str] = additional.get(ADDITIONAL_DATA_DEPENDENCY_NODE_NAMES) or []
     dependency_objectives: dict[str, str] = additional.get(ADDITIONAL_DATA_DEPENDENCY_OBJECTIVES) or {}
     trigger_input: dict[str, Any] | None = additional.get(ADDITIONAL_DATA_INITIAL_INPUT)
-    trigger_parameters = content_to_str(trigger_input) if trigger_input else None
+    trigger_parameters = _truncate(content_to_str(trigger_input)) if trigger_input else None
 
     previous = step_input.previous_step_outputs or {}
 

--- a/registry-pkgs/src/registry_pkgs/workflows/helpers.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/helpers.py
@@ -8,6 +8,7 @@ from agno.workflow import StepInput, StepOutput
 from registry_pkgs.workflows.prompt import (
     ADDITIONAL_DATA_DEPENDENCY_NODE_NAMES,
     ADDITIONAL_DATA_DEPENDENCY_OBJECTIVES,
+    ADDITIONAL_DATA_INITIAL_INPUT,
     ADDITIONAL_DATA_STEP_OBJECTIVE,
     ADDITIONAL_DATA_WORKFLOW_DESCRIPTION,
     DependencySpec,
@@ -133,6 +134,8 @@ def build_prompt(step_input: StepInput) -> str:
     workflow_description: str | None = additional.get(ADDITIONAL_DATA_WORKFLOW_DESCRIPTION)
     dependency_node_names: list[str] = additional.get(ADDITIONAL_DATA_DEPENDENCY_NODE_NAMES) or []
     dependency_objectives: dict[str, str] = additional.get(ADDITIONAL_DATA_DEPENDENCY_OBJECTIVES) or {}
+    trigger_input: dict[str, Any] | None = additional.get(ADDITIONAL_DATA_INITIAL_INPUT)
+    trigger_parameters = content_to_str(trigger_input) if trigger_input else None
 
     previous = step_input.previous_step_outputs or {}
 
@@ -164,4 +167,5 @@ def build_prompt(step_input: StepInput) -> str:
         workflow_description=workflow_description,
         dependencies=dependencies,
         initial_input=initial_input,
+        trigger_parameters=trigger_parameters,
     )

--- a/registry-pkgs/src/registry_pkgs/workflows/prompt.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/prompt.py
@@ -5,11 +5,11 @@ prompt that an MCP- or A2A-backed LLM actually receives.
 
 Architecture note
 -----------------
-Intention data (step_objective, workflow_description, dependency objectives and
-their runtime outputs) travels from the compiler into each executor call via
-``StepInput.additional_data``.  The compiler's ``_with_intention_data`` wrapper
-injects this data per-node; ``build_prompt`` in helpers.py reads it back and
-delegates to ``render_step_prompt`` here.
+Intention data (step_objective, workflow_description, the run's initial_input,
+dependency objectives and their runtime outputs) travels from the compiler into
+each executor call via ``StepInput.additional_data``.  The compiler's
+``_with_intention_data`` wrapper injects this data per-node; ``build_prompt`` in
+helpers.py reads it back and delegates to ``render_step_prompt`` here.
 
 ``render_step_prompt`` is the **only** place Markdown gets built.
 """
@@ -39,6 +39,7 @@ class DependencySpec:
 
 
 _GOAL_PREFIX = "**IMPORTANT: The goal of this step is to"
+_PARAMS_HEADER = "Workflow Trigger Parameters (fixed for this run; available to every step):"
 _WORKFLOW_CTX_PREFIX = "This step is part of a larger workflow:"
 _DEPS_HEADER = "Dependencies:"
 _INPUTS_HEADER = "Current Step Inputs:"
@@ -57,12 +58,17 @@ def render_step_prompt(
     workflow_description: str | None,
     dependencies: list[DependencySpec],
     initial_input: str | None,
+    trigger_parameters: str | None = None,
 ) -> str:
     """Assemble the Markdown prompt handed to an MCP/A2A executor's underlying LLM.
 
     Prompt structure (all sections separated by blank lines):
 
         **IMPORTANT: The goal of this step is to {step_objective}.**
+
+        Workflow Trigger Parameters (fixed for this run; available to every step):
+
+          <indented JSON>
 
         This step is part of a larger workflow: {workflow_description}
 
@@ -77,6 +83,9 @@ def render_step_prompt(
         [... one block per dependency that has produced output ...]
 
     Rules:
+    - ``trigger_parameters`` section omitted when falsy; otherwise rendered on
+      *every* node regardless of dependencies or graph position — unlike
+      ``initial_input`` below, it is not gated to entry nodes.
     - ``workflow_description`` section omitted when None.
     - ``Dependencies`` section always lists every declared dependency with its
       objective, even when content is not yet available (parallel branches).
@@ -85,8 +94,9 @@ def render_step_prompt(
       is not None), ``Current Step Inputs`` shows the original workflow trigger
       instead of dependency outputs.
     - A mid-graph STEP node with no ``referenced_node_names`` and no available
-      ``initial_input`` receives only the goal line — this is intentional
-      (explicit-over-clever: every cross-step dependency must be declared).
+      ``initial_input`` receives only the goal line (plus ``trigger_parameters``
+      when present) — this is intentional (explicit-over-clever: every
+      cross-step dependency must be declared).
 
     Args:
         step_objective:      Plain-language description of what this step must do.
@@ -97,22 +107,30 @@ def render_step_prompt(
                              is None when the node hasn't executed yet.
         initial_input:       The original workflow trigger text, passed only for
                              entry nodes (``previous_step_outputs`` empty).
+        trigger_parameters:  JSON-rendered ``WorkflowRun.initial_input``, shown to
+                             every node so any step can reference user-supplied
+                             trigger fields (e.g. a Slack member ID) without that
+                             data having to be relayed through upstream node output.
     """
     sections: list[str] = []
 
     # 1. Goal — always first and most prominent
     sections.append(f"{_GOAL_PREFIX} {step_objective}.**")
 
-    # 2. Workflow context — orientation without being prescriptive
+    # 2. Trigger parameters — global, run-scoped values available to every step
+    if trigger_parameters:
+        sections.append(f"{_PARAMS_HEADER}\n\n{_indented_block(trigger_parameters)}")
+
+    # 3. Workflow context — orientation without being prescriptive
     if workflow_description:
         sections.append(f"{_WORKFLOW_CTX_PREFIX} {workflow_description}")
 
     if dependencies:
-        # 3a. List every declared dependency and its objective (even if no output yet)
+        # 4a. List every declared dependency and its objective (even if no output yet)
         dep_lines = "\n".join(f'- "{d.name}": {d.objective}.' for d in dependencies)
         sections.append(f"{_DEPS_HEADER}\n{dep_lines}")
 
-        # 3b. Current Step Inputs — only dependencies that have produced output
+        # 4b. Current Step Inputs — only dependencies that have produced output
         with_content = [d for d in dependencies if d.content is not None]
         if with_content:
             input_blocks = "\n\n".join(
@@ -121,7 +139,7 @@ def render_step_prompt(
             sections.append(f"{_INPUTS_HEADER}\n{input_blocks}")
 
     elif initial_input:
-        # 3c. Entry node with no dependencies — show original trigger
+        # 4c. Entry node with no dependencies — show original trigger
         sections.append(f"{_INPUTS_HEADER}\n- {_TRIGGER_LABEL}:\n\n{_indented_block(initial_input)}")
 
     return "\n\n".join(sections)
@@ -138,3 +156,4 @@ ADDITIONAL_DATA_STEP_OBJECTIVE = "jarvis_step_objective"
 ADDITIONAL_DATA_WORKFLOW_DESCRIPTION = "jarvis_workflow_description"
 ADDITIONAL_DATA_DEPENDENCY_NODE_NAMES = "jarvis_dependency_node_names"
 ADDITIONAL_DATA_DEPENDENCY_OBJECTIVES = "jarvis_dependency_objectives"
+ADDITIONAL_DATA_INITIAL_INPUT = "jarvis_initial_input"

--- a/registry-pkgs/tests/unit/workflow/test_compiler.py
+++ b/registry-pkgs/tests/unit/workflow/test_compiler.py
@@ -19,6 +19,7 @@ from registry_pkgs.models.workflow import (
 from registry_pkgs.workflows import compiler
 from registry_pkgs.workflows.compiler import step_kwargs
 from registry_pkgs.workflows.helpers import build_prompt, step_output_to_prompt_text
+from registry_pkgs.workflows.serialization import content_to_str
 
 
 async def _executor(*args, **kwargs):
@@ -1492,6 +1493,36 @@ class TestIntentionData:
         await workflow.steps[0].executor(StepInput(input="task"), {})
 
         assert "Workflow Trigger Parameters" not in prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_oversized_initial_input_is_truncated_in_trigger_parameters(self):
+        """trigger_parameters gets the same 8000-char cap as dependency content (helpers._truncate)."""
+        node = _step_node("echo", "tool", "do the thing")
+        definition = _workflow_definition([node])
+        oversized_input = {"blob": "x" * 10_000}
+        run = WorkflowRun.model_construct(
+            id=PydanticObjectId(),
+            workflow_definition_id=PydanticObjectId(),
+            status=WorkflowRunStatus.RUNNING,
+            initial_input=oversized_input,
+        )
+        prompts: list[str] = []
+
+        async def capturing_executor(step_input, session_state=None):
+            prompts.append(build_prompt(step_input))
+            return SimpleNamespace(content="ok")
+
+        workflow = compiler.compile_workflow(definition, run, executor_registry={"tool": capturing_executor})
+        await workflow.steps[0].executor(StepInput(input="task"), {})
+
+        prompt = prompts[0]
+        full_json = content_to_str(oversized_input)
+        omitted = len(full_json) - 8000
+        # `_indented_block` reflows the truncated text's line-leading whitespace, so assert on
+        # the un-reflowable pieces: the full oversized run must not survive intact, and the
+        # truncation note must carry the exact omitted-char count.
+        assert "x" * 10_000 not in prompt
+        assert f"[truncated: {omitted} chars omitted]" in prompt
 
     def test_build_prompt_falls_back_without_additional_data(self):
         assert build_prompt(StepInput(input="hello")) == "hello"

--- a/registry-pkgs/tests/unit/workflow/test_compiler.py
+++ b/registry-pkgs/tests/unit/workflow/test_compiler.py
@@ -1375,6 +1375,7 @@ class TestIntentionData:
                 "jarvis_workflow_description": None,
                 "jarvis_dependency_node_names": [],
                 "jarvis_dependency_objectives": {},
+                "jarvis_initial_input": None,
             }
         ]
 
@@ -1417,6 +1418,80 @@ class TestIntentionData:
         await workflow.steps[0].executor(StepInput(input="task"), {})
 
         assert "This step is part of a larger workflow: coordinate a research workflow" in prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_run_initial_input_rendered_as_trigger_parameters_for_entry_node(self):
+        node = _step_node("github", "tool", "find the last merged PR")
+        definition = _workflow_definition([node])
+        run = WorkflowRun.model_construct(
+            id=PydanticObjectId(),
+            workflow_definition_id=PydanticObjectId(),
+            status=WorkflowRunStatus.RUNNING,
+            initial_input={"memberId": "U123", "displayName": "Kent"},
+        )
+        prompts: list[str] = []
+
+        async def capturing_executor(step_input, session_state=None):
+            prompts.append(build_prompt(step_input))
+            return SimpleNamespace(content="ok")
+
+        workflow = compiler.compile_workflow(definition, run, executor_registry={"tool": capturing_executor})
+        await workflow.steps[0].executor(StepInput(input="task"), {})
+
+        assert "Workflow Trigger Parameters" in prompts[0]
+        assert '"memberId": "U123"' in prompts[0]
+        assert '"displayName": "Kent"' in prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_run_initial_input_rendered_for_downstream_node_with_dependencies(self):
+        """A node with an (implicit or explicit) dependency still sees run.initial_input.
+
+        This is the github -> slack scenario: `slack` implicitly depends on `github`
+        as the previous step in the same sequence, so the old entry-node-only
+        `initial_input` never reached it — but trigger_parameters is unconditional.
+        """
+        github = _step_node("github", "tool", "find the last merged PR")
+        slack = _step_node("slack", "tool", "message the user from initial input")
+        definition = _workflow_definition([github, slack])
+        run = WorkflowRun.model_construct(
+            id=PydanticObjectId(),
+            workflow_definition_id=PydanticObjectId(),
+            status=WorkflowRunStatus.RUNNING,
+            initial_input={"memberId": "U123", "displayName": "Kent"},
+        )
+        prompts: list[str] = []
+
+        async def capturing_executor(step_input, session_state=None):
+            prompts.append(build_prompt(step_input))
+            return SimpleNamespace(content="ok")
+
+        workflow = compiler.compile_workflow(definition, run, executor_registry={"tool": capturing_executor})
+        previous = self._make_previous_outputs(**{"github": "PR #42: Fix the bug"})
+        await workflow.steps[1].executor(StepInput(input="task", previous_step_outputs=previous), {})
+
+        prompt = prompts[0]
+        assert "Workflow Trigger Parameters" in prompt
+        assert '"memberId": "U123"' in prompt
+        assert '"displayName": "Kent"' in prompt
+        # Still a genuine dependency, not the old entry-node-only trigger-input path.
+        assert 'Dependencies:\n- "github": find the last merged PR.' in prompt
+
+    @pytest.mark.asyncio
+    async def test_run_without_initial_input_omits_trigger_parameters(self):
+        node = _step_node("echo", "tool", "do the thing")
+        definition = _workflow_definition([node])
+        prompts: list[str] = []
+
+        async def capturing_executor(step_input, session_state=None):
+            prompts.append(build_prompt(step_input))
+            return SimpleNamespace(content="ok")
+
+        workflow = compiler.compile_workflow(
+            definition, _workflow_run(), executor_registry={"tool": capturing_executor}
+        )
+        await workflow.steps[0].executor(StepInput(input="task"), {})
+
+        assert "Workflow Trigger Parameters" not in prompts[0]
 
     def test_build_prompt_falls_back_without_additional_data(self):
         assert build_prompt(StepInput(input="hello")) == "hello"

--- a/registry-pkgs/tests/unit/workflow/test_prompt.py
+++ b/registry-pkgs/tests/unit/workflow/test_prompt.py
@@ -146,3 +146,42 @@ class TestRenderStepPrompt:
         dep = DependencySpec(name="A", objective="do A")
         with pytest.raises((AttributeError, TypeError)):
             dep.name = "B"  # type: ignore[misc]
+
+    def test_trigger_parameters_rendered_right_after_goal(self):
+        result = render_step_prompt(
+            step_objective="do it",
+            workflow_description="a multi-step research workflow",
+            dependencies=[],
+            initial_input=None,
+            trigger_parameters='{\n  "memberId": "U123"\n}',
+        )
+        assert "Workflow Trigger Parameters" in result
+        assert '"memberId": "U123"' in result
+        goal_idx = result.index("The goal of this step")
+        params_idx = result.index("Workflow Trigger Parameters")
+        description_idx = result.index("larger workflow")
+        assert goal_idx < params_idx < description_idx
+
+    def test_trigger_parameters_omitted_when_none(self):
+        result = render_step_prompt(
+            step_objective="do it",
+            workflow_description=None,
+            dependencies=[],
+            initial_input=None,
+            trigger_parameters=None,
+        )
+        assert "Workflow Trigger Parameters" not in result
+
+    def test_trigger_parameters_rendered_even_with_dependencies(self):
+        """Unlike `initial_input`, `trigger_parameters` is not gated on entry-node/no-deps."""
+        deps = [DependencySpec(name="Step A", objective="fetch data", content="some content")]
+        result = render_step_prompt(
+            step_objective="do it",
+            workflow_description=None,
+            dependencies=deps,
+            initial_input="should not appear",
+            trigger_parameters='{\n  "memberId": "U123"\n}',
+        )
+        assert "Workflow Trigger Parameters" in result
+        assert '"memberId": "U123"' in result
+        assert "should not appear" not in result


### PR DESCRIPTION
Expose `WorkflowRun.initial_input` to every workflow node's prompt as "Workflow Trigger Parameters," not just to the entry node.

Previously, trigger-supplied values (e.g. a Slack member ID or display name) were only visible to a node with zero dependencies — any downstream node (even an implicit same-sequence successor like `slack` following `github`) never saw them unless an upstream node happened to relay them through its own output. Since `WorkflowRun.initial_input` is already known at compile time, `_with_intention_data` now forwards it into every node's `additional_data` unconditionally, and `render_step_prompt` renders it as a dedicated Markdown section right after the goal line.

This lets workflow authors write step objectives like "get member ID from the workflow trigger parameters" instead of hardcoding per-user values, so a workflow shared with VIEWER permission can be customized per invocation via `initialInput`.

The pre-existing entry-node-only `initial_input` behavior is untouched.

Adds test coverage in `test_prompt.py` and `test_compiler.py`, including a regression test for the multi-node dependency case.