### PR TITLE
Fix/as 1752 Fix AnyIO cancel-scope errors in registry middleware

### DIFF
--- a/registry/src/registry/middleware/auth.py
+++ b/registry/src/registry/middleware/auth.py
@@ -3,8 +3,8 @@ import re
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.routing import compile_path, get_route_path
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from registry_pkgs.core.jwt_tokens import verify_managed_agent_token
 from registry_pkgs.core.jwt_utils import ExpiredSignatureError, InvalidTokenError
@@ -35,7 +35,7 @@ def _parse_bearer_token(request: Request) -> str | None:
     return token.strip() or None
 
 
-class UnifiedAuthMiddleware(BaseHTTPMiddleware):
+class UnifiedAuthMiddleware:
     """
     A unified authentication middleware that encapsulates the functionality of `enhanced_auth` and `nginx_proxied_auth`.
 
@@ -60,8 +60,8 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
         * "/health" - Health check endpoint (public)
     """
 
-    def __init__(self, app):
-        super().__init__(app)
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
         self.public_paths_compiled = self._compile_patterns(
             [
                 "/",
@@ -107,7 +107,12 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
                 logger.error(f"Failed to compile pattern '{pattern}': {e}")
         return compiled
 
-    async def dispatch(self, request: Request, call_next):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope, receive=receive)
         # Use get_route_path to strip the root_path prefix (set by uvicorn --root-path).
         # request.url.path reads scope["path"] directly, which includes the prefix when
         # uvicorn is started with --root-path. get_route_path strips it, matching what
@@ -117,7 +122,8 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
         # Check authenticated paths first (these override public patterns)
         if self._match_path(path, self.public_paths_compiled):
             logger.debug(f"Public path: {path}")
-            return await call_next(request)
+            await self.app(scope, receive, send)
+            return
         else:
             logger.debug(f"Authenticated path: {path}")
             # Continue to authentication logic below
@@ -158,14 +164,18 @@ class UnifiedAuthMiddleware(BaseHTTPMiddleware):
                 # handles a bare 401 by redirecting to login — so we deliberately advertise no
                 # (misleading) Bearer challenge here.
 
-                return JSONResponse(status_code=401, content={"detail": str(e)}, headers=headers)
+                response = JSONResponse(status_code=401, content={"detail": str(e)}, headers=headers)
+                await response(scope, receive, send)
+                return
 
             except Exception as e:
                 auth_ctx.set_success(False)
                 logger.exception(f"Auth error for {path}: {e}")
-                return JSONResponse(status_code=500, content={"detail": "Authentication error"})
+                response = JSONResponse(status_code=500, content={"detail": "Authentication error"})
+                await response(scope, receive, send)
+                return
 
-        return await call_next(request)
+        await self.app(scope, receive, send)
 
     def _match_path(self, path: str, compiled_patterns: list[tuple]) -> bool:
         """

--- a/registry/src/registry/middleware/csrf.py
+++ b/registry/src/registry/middleware/csrf.py
@@ -1,11 +1,10 @@
 import hmac
 import logging
-from collections.abc import Awaitable, Callable
 
-from fastapi import Request, Response
+from fastapi import Request
 from fastapi.responses import JSONResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.routing import get_route_path
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from ..core.config import settings
 from ..utils.csrf import compute_csrf_token
@@ -15,31 +14,42 @@ logger = logging.getLogger(__name__)
 SAFE_METHODS = {"GET", "HEAD", "OPTIONS", "TRACE"}
 
 
-class CSRFMiddleware(BaseHTTPMiddleware):
+class CSRFMiddleware:
     """Enforce HMAC double-submit CSRF protection for browser session requests."""
 
-    async def dispatch(
-        self,
-        request: Request,
-        call_next: Callable[[Request], Awaitable[Response]],
-    ) -> Response:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope, receive=receive)
+
         if request.method.upper() in SAFE_METHODS:
-            return await call_next(request)
+            await self.app(scope, receive, send)
+            return
 
         session_cookie = request.cookies.get(settings.session_cookie_name)
         if not session_cookie:
-            return await call_next(request)
+            await self.app(scope, receive, send)
+            return
 
         header_value = request.headers.get(settings.csrf_header_name)
         if not header_value:
             path = get_route_path(request.scope)
             logger.warning("CSRF token missing for %s %s", request.method, path)
-            return JSONResponse(status_code=403, content={"detail": "CSRF token missing"})
+            response = JSONResponse(status_code=403, content={"detail": "CSRF token missing"})
+            await response(scope, receive, send)
+            return
 
         expected = compute_csrf_token(session_cookie)
         if not hmac.compare_digest(expected, header_value):
             path = get_route_path(request.scope)
             logger.warning("CSRF token invalid for %s %s", request.method, path)
-            return JSONResponse(status_code=403, content={"detail": "CSRF token invalid"})
+            response = JSONResponse(status_code=403, content={"detail": "CSRF token invalid"})
+            await response(scope, receive, send)
+            return
 
-        return await call_next(request)
+        await self.app(scope, receive, send)

--- a/registry/src/registry/middleware/rbac.py
+++ b/registry/src/registry/middleware/rbac.py
@@ -5,8 +5,8 @@ from typing import Any
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.routing import compile_path, get_route_path
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from ..auth.dependencies import effective_scopes_from_context
 from ..core.config import settings
@@ -63,7 +63,7 @@ def _parse_methods(method_value: str) -> set[str] | None:
     return set(parts)
 
 
-class ScopePermissionMiddleware(BaseHTTPMiddleware):
+class ScopePermissionMiddleware:
     """
     Enforce endpoint/method permissions based on scopes.yml.
 
@@ -78,8 +78,8 @@ class ScopePermissionMiddleware(BaseHTTPMiddleware):
         reaching this middleware should be checked for permissions.
     """
 
-    def __init__(self, app):
-        super().__init__(app)
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
         self._rules: list[dict[str, Any]] = []
         # Load rules at initialization instead of lazily
         self._load_rules()
@@ -185,16 +185,23 @@ class ScopePermissionMiddleware(BaseHTTPMiddleware):
         logger.warning("No rules match path=%s, method=%s - denying", path, method)
         return False
 
-    async def dispatch(self, request: Request, call_next):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Enforce scope permissions for authenticated requests.
 
         Since auth middleware already filters public paths, any authenticated
         request reaching this middleware should be checked for permissions.
         """
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope, receive=receive)
+
         # If auth middleware didn't set user, allow through (public routes).
         if not getattr(request.state, "is_authenticated", False):
-            return await call_next(request)
+            await self.app(scope, receive, send)
+            return
 
         method = request.method.upper()
         normalized_path = _normalize_path(get_route_path(request.scope))
@@ -204,9 +211,13 @@ class ScopePermissionMiddleware(BaseHTTPMiddleware):
         user_scopes = effective_scopes_from_context(user_context)
 
         if not user_scopes:
-            return JSONResponse(status_code=403, content={"detail": "Insufficient permissions"})
+            response = JSONResponse(status_code=403, content={"detail": "Insufficient permissions"})
+            await response(scope, receive, send)
+            return
 
         if self._has_permission(user_scopes, normalized_path, method):
-            return await call_next(request)
+            await self.app(scope, receive, send)
+            return
 
-        return JSONResponse(status_code=403, content={"detail": "Insufficient permissions"})
+        response = JSONResponse(status_code=403, content={"detail": "Insufficient permissions"})
+        await response(scope, receive, send)

--- a/registry/tests/unit/middleware/test_auth_dispatch.py
+++ b/registry/tests/unit/middleware/test_auth_dispatch.py
@@ -1,7 +1,10 @@
+from unittest.mock import AsyncMock
+
 import pytest
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from starlette.testclient import TestClient
+from starlette.types import Receive, Scope, Send
 
 from registry.core.config import settings
 from registry.middleware.auth import UnifiedAuthMiddleware
@@ -222,3 +225,23 @@ def test_all_proxy_router_paths_classify_as_proxy():
 def test_crud_paths_classify_as_non_proxy(path):
     mw = UnifiedAuthMiddleware(FastAPI())
     assert mw._is_proxy_route(path) is False
+
+
+def test_lifespan_scope_passes_through_without_error():
+    with TestClient(_build_app()):
+        pass
+
+
+async def test_non_http_scope_forwarded_to_app_unchanged():
+    calls: list[Scope] = []
+
+    async def stub_app(scope: Scope, receive: Receive, send: Send) -> None:
+        del receive, send
+        calls.append(scope)
+
+    middleware = UnifiedAuthMiddleware(stub_app)
+    scope: Scope = {"type": "websocket", "path": "/ws"}
+
+    await middleware(scope, AsyncMock(), AsyncMock())
+
+    assert calls == [scope]

--- a/registry/tests/unit/middleware/test_csrf.py
+++ b/registry/tests/unit/middleware/test_csrf.py
@@ -1,7 +1,10 @@
+from unittest.mock import AsyncMock
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.testclient import TestClient
+from starlette.types import Receive, Scope, Send
 
 from registry.app_factory import _configure_middleware
 from registry.core.config import settings
@@ -103,3 +106,23 @@ def test_configured_middleware_order_runs_cors_then_csrf_then_auth():
         UnifiedAuthMiddleware,
         ScopePermissionMiddleware,
     ]
+
+
+def test_lifespan_scope_passes_through_without_error():
+    with TestClient(_build_app()):
+        pass
+
+
+async def test_non_http_scope_forwarded_to_app_unchanged():
+    calls: list[Scope] = []
+
+    async def stub_app(scope: Scope, receive: Receive, send: Send) -> None:
+        del receive, send
+        calls.append(scope)
+
+    middleware = CSRFMiddleware(stub_app)
+    scope: Scope = {"type": "websocket", "path": "/ws"}
+
+    await middleware(scope, AsyncMock(), AsyncMock())
+
+    assert calls == [scope]

--- a/registry/tests/unit/middleware/test_middleware_chain.py
+++ b/registry/tests/unit/middleware/test_middleware_chain.py
@@ -6,10 +6,13 @@ restore the real implementation and use production middleware ordering to verify
 CSRF short-circuiting and Auth-to-RBAC request.state handoff.
 """
 
+import asyncio
+
 import pytest
-from fastapi import FastAPI
-from fastapi.responses import JSONResponse
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response
 from starlette.testclient import TestClient
+from starlette.types import Message, Scope
 
 from registry.app_factory import _configure_middleware
 from registry.core.config import settings
@@ -33,7 +36,10 @@ def _widgets_scopes_config(monkeypatch: pytest.MonkeyPatch) -> None:
         settings,
         "scopes_config",
         {
-            "widgets-read": [{"endpoint": "/widgets", "method": "GET"}],
+            "widgets-read": [
+                {"endpoint": "/widgets", "method": "GET"},
+                {"endpoint": "/widgets/disconnect", "method": "GET"},
+            ],
             "widgets-write": [{"endpoint": "/widgets", "method": "POST"}],
         },
     )
@@ -70,6 +76,27 @@ def _session_cookie(scopes: list[str]) -> str:
         auth_method="oauth2",
         provider="entra",
     )
+
+
+def _disconnect_scope(session_cookie: str) -> Scope:
+    path = f"/api/{settings.api_version}/widgets/disconnect"
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"host", b"testserver"),
+            (b"cookie", f"{_COOKIE}={session_cookie}".encode()),
+        ],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+    }
 
 
 def test_get_with_valid_cookie_and_matching_scope_returns_200(client: TestClient) -> None:
@@ -118,3 +145,49 @@ def test_get_without_cookie_is_rejected_by_auth_despite_safe_method(client: Test
     response = client.get(f"/api/{settings.api_version}/widgets")
 
     assert response.status_code == 401
+
+
+async def test_client_disconnect_does_not_raise_cancel_scope_runtime_error() -> None:
+    app = _build_app()
+    waiting_for_disconnect = asyncio.Event()
+    disconnect = asyncio.Event()
+    sent_messages: list[Message] = []
+    receive_count = 0
+
+    @app.get(f"/api/{settings.api_version}/widgets/disconnect")
+    async def wait_for_disconnect(request: Request) -> Response:
+        while (await request.receive())["type"] != "http.disconnect":
+            pass
+        return Response(status_code=204)
+
+    session_cookie = _session_cookie(["widgets-read"])
+    scope = _disconnect_scope(session_cookie)
+
+    async def receive() -> Message:
+        nonlocal receive_count
+        receive_count += 1
+        if receive_count == 1:
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        waiting_for_disconnect.set()
+        await disconnect.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: Message) -> None:
+        sent_messages.append(message)
+
+    request_task = asyncio.create_task(app(scope, receive, send))
+    try:
+        await asyncio.wait_for(waiting_for_disconnect.wait(), timeout=1)
+        disconnect.set()
+        await asyncio.wait_for(request_task, timeout=1)
+    finally:
+        if not request_task.done():
+            request_task.cancel()
+            try:
+                await request_task
+            except asyncio.CancelledError:
+                pass
+
+    response_start = next(message for message in sent_messages if message["type"] == "http.response.start")
+    assert response_start["status"] == 204

--- a/registry/tests/unit/middleware/test_middleware_chain.py
+++ b/registry/tests/unit/middleware/test_middleware_chain.py
@@ -9,7 +9,7 @@ CSRF short-circuiting and Auth-to-RBAC request.state handoff.
 import asyncio
 
 import pytest
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 from fastapi.responses import JSONResponse, Response
 from starlette.testclient import TestClient
 from starlette.types import Message, Scope
@@ -148,47 +148,31 @@ def test_get_without_cookie_is_rejected_by_auth_despite_safe_method(client: Test
 
 
 async def test_client_disconnect_does_not_raise_cancel_scope_runtime_error() -> None:
+    """A real client disconnect cancels the running request task. With no anyio ``TaskGroup``
+    left in the custom middleware stack (CSRF/Auth/RBAC), that cancellation must propagate as a
+    plain ``CancelledError`` — never the ``RuntimeError`` this migration fixes.
+    """
     app = _build_app()
-    waiting_for_disconnect = asyncio.Event()
-    disconnect = asyncio.Event()
-    sent_messages: list[Message] = []
-    receive_count = 0
+    task_running = asyncio.Event()
 
     @app.get(f"/api/{settings.api_version}/widgets/disconnect")
-    async def wait_for_disconnect(request: Request) -> Response:
-        while (await request.receive())["type"] != "http.disconnect":
-            pass
-        return Response(status_code=204)
+    async def wait_for_disconnect() -> Response:
+        task_running.set()
+        await asyncio.sleep(10)  # suspended mid-request; cancellation interrupts this
+        return Response(status_code=204)  # pragma: no cover - never reached
 
     session_cookie = _session_cookie(["widgets-read"])
     scope = _disconnect_scope(session_cookie)
 
     async def receive() -> Message:
-        nonlocal receive_count
-        receive_count += 1
-        if receive_count == 1:
-            return {"type": "http.request", "body": b"", "more_body": False}
-
-        waiting_for_disconnect.set()
-        await disconnect.wait()
-        return {"type": "http.disconnect"}
+        return {"type": "http.request", "body": b"", "more_body": False}
 
     async def send(message: Message) -> None:
-        sent_messages.append(message)
+        pass
 
     request_task = asyncio.create_task(app(scope, receive, send))
-    try:
-        await asyncio.wait_for(waiting_for_disconnect.wait(), timeout=1)
-        disconnect.set()
-        await asyncio.wait_for(request_task, timeout=1)
-    finally:
-        if not request_task.done():
-            request_task.cancel()
-            try:
-                await request_task
-            except asyncio.CancelledError:
-                # Expected when awaiting a task cancelled during test cleanup.
-                pass
+    await asyncio.wait_for(task_running.wait(), timeout=1)
 
-    response_start = next(message for message in sent_messages if message["type"] == "http.response.start")
-    assert response_start["status"] == 204
+    request_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await request_task

--- a/registry/tests/unit/middleware/test_middleware_chain.py
+++ b/registry/tests/unit/middleware/test_middleware_chain.py
@@ -1,0 +1,120 @@
+"""
+Unit tests chaining all three registry security middlewares together.
+
+The wider integration suite globally bypasses RBAC permission checks. These tests
+restore the real implementation and use production middleware ordering to verify
+CSRF short-circuiting and Auth-to-RBAC request.state handoff.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from starlette.testclient import TestClient
+
+from registry.app_factory import _configure_middleware
+from registry.core.config import settings
+from registry.middleware.rbac import ScopePermissionMiddleware
+from registry.utils.crypto_utils import generate_access_token
+from registry.utils.csrf import compute_csrf_token
+
+_COOKIE = settings.session_cookie_name
+_original_has_permission = ScopePermissionMiddleware._has_permission
+
+
+@pytest.fixture(autouse=True)
+def restore_rbac_for_chain_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restore real RBAC permission checking for this module."""
+    monkeypatch.setattr(ScopePermissionMiddleware, "_has_permission", _original_has_permission)
+
+
+@pytest.fixture(autouse=True)
+def _widgets_scopes_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        settings,
+        "scopes_config",
+        {
+            "widgets-read": [{"endpoint": "/widgets", "method": "GET"}],
+            "widgets-write": [{"endpoint": "/widgets", "method": "POST"}],
+        },
+    )
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    _configure_middleware(app)
+
+    @app.get(f"/api/{settings.api_version}/widgets")
+    async def list_widgets() -> JSONResponse:
+        return JSONResponse({"ok": "list"})
+
+    @app.post(f"/api/{settings.api_version}/widgets")
+    async def create_widget() -> JSONResponse:
+        return JSONResponse({"ok": "create"})
+
+    return app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(_build_app())
+
+
+def _session_cookie(scopes: list[str]) -> str:
+    return generate_access_token(
+        user_id="u1",
+        username="alice",
+        email="alice@example.com",
+        groups=["g1"],
+        scopes=scopes,
+        role="user",
+        auth_method="oauth2",
+        provider="entra",
+    )
+
+
+def test_get_with_valid_cookie_and_matching_scope_returns_200(client: TestClient) -> None:
+    client.cookies.set(_COOKIE, _session_cookie(["widgets-read"]))
+
+    response = client.get(f"/api/{settings.api_version}/widgets")
+
+    assert response.status_code == 200
+
+
+def test_post_without_csrf_header_is_blocked_before_auth_or_rbac(client: TestClient) -> None:
+    client.cookies.set(_COOKIE, _session_cookie(["widgets-write"]))
+
+    response = client.post(f"/api/{settings.api_version}/widgets")
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "CSRF token missing"}
+
+
+def test_post_with_csrf_header_and_matching_scope_returns_200(client: TestClient) -> None:
+    session_cookie = _session_cookie(["widgets-write"])
+    client.cookies.set(_COOKIE, session_cookie)
+
+    response = client.post(
+        f"/api/{settings.api_version}/widgets",
+        headers={settings.csrf_header_name: compute_csrf_token(session_cookie)},
+    )
+
+    assert response.status_code == 200
+
+
+def test_post_with_csrf_header_but_wrong_scope_returns_403(client: TestClient) -> None:
+    session_cookie = _session_cookie(["widgets-read"])
+    client.cookies.set(_COOKIE, session_cookie)
+
+    response = client.post(
+        f"/api/{settings.api_version}/widgets",
+        headers={settings.csrf_header_name: compute_csrf_token(session_cookie)},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Insufficient permissions"}
+
+
+def test_get_without_cookie_is_rejected_by_auth_despite_safe_method(client: TestClient) -> None:
+    response = client.get(f"/api/{settings.api_version}/widgets")
+
+    assert response.status_code == 401

--- a/registry/tests/unit/middleware/test_middleware_chain.py
+++ b/registry/tests/unit/middleware/test_middleware_chain.py
@@ -187,6 +187,7 @@ async def test_client_disconnect_does_not_raise_cancel_scope_runtime_error() -> 
             try:
                 await request_task
             except asyncio.CancelledError:
+                # Expected when awaiting a task cancelled during test cleanup.
                 pass
 
     response_start = next(message for message in sent_messages if message["type"] == "http.response.start")

--- a/registry/tests/unit/middleware/test_rbac.py
+++ b/registry/tests/unit/middleware/test_rbac.py
@@ -10,11 +10,12 @@ Tests cover:
 """
 
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from starlette.types import Receive, Scope, Send
 
 from registry.middleware.rbac import (
     ScopePermissionMiddleware,
@@ -33,6 +34,29 @@ def restore_rbac_for_rbac_tests(monkeypatch):
     # Restore the original _has_permission method
     monkeypatch.setattr(ScopePermissionMiddleware, "_has_permission", _original_has_permission)
     yield
+
+
+def test_lifespan_scope_passes_through_without_error():
+    app = FastAPI()
+    app.add_middleware(ScopePermissionMiddleware)
+
+    with TestClient(app):
+        pass
+
+
+async def test_non_http_scope_forwarded_to_app_unchanged():
+    calls: list[Scope] = []
+
+    async def stub_app(scope: Scope, receive: Receive, send: Send) -> None:
+        del receive, send
+        calls.append(scope)
+
+    middleware = ScopePermissionMiddleware(stub_app)
+    scope: Scope = {"type": "websocket", "path": "/ws"}
+
+    await middleware(scope, AsyncMock(), AsyncMock())
+
+    assert calls == [scope]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Migrates Auth, RBAC, and CSRF middleware from BaseHTTPMiddleware to pure ASGI middleware. Adds non-HTTP scope, middleware chain, and client-disconnect regression tests. All tests and concurrent disconnect verification passed.