### PR TITLE
Fix/as 1768

### DIFF
--- a/registry-pkgs/src/registry_pkgs/models/federation.py
+++ b/registry-pkgs/src/registry_pkgs/models/federation.py
@@ -159,6 +159,8 @@ class FederationLastSyncSummary(BaseModel):
     skippedAgents: int = 0
     vectorSyncFailedMcpServers: int = 0
     vectorSyncFailedAgents: int = 0
+    mongoApplyFailedMcpServers: int = 0
+    mongoApplyFailedAgents: int = 0
 
     errors: int = 0
     errorMessages: list[str] = Field(default_factory=list)

--- a/registry-pkgs/src/registry_pkgs/models/federation_sync_job.py
+++ b/registry-pkgs/src/registry_pkgs/models/federation_sync_job.py
@@ -34,6 +34,8 @@ class FederationApplySummary(BaseModel):
     skippedAgents: int = 0
     vectorSyncFailedMcpServers: int = 0
     vectorSyncFailedAgents: int = 0
+    mongoApplyFailedMcpServers: int = 0
+    mongoApplyFailedAgents: int = 0
     errors: int = 0
     errorMessages: list[str] = Field(default_factory=list)
 

--- a/registry/src/registry/api/v1/federation/federation_routes.py
+++ b/registry/src/registry/api/v1/federation/federation_routes.py
@@ -173,6 +173,8 @@ def _to_last_sync_response(last_sync) -> FederationLastSyncResponse | None:
             skippedAgents=int(getattr(summary, "skippedAgents", 0) or 0),
             vectorSyncFailedMcpServers=int(getattr(summary, "vectorSyncFailedMcpServers", 0) or 0),
             vectorSyncFailedAgents=int(getattr(summary, "vectorSyncFailedAgents", 0) or 0),
+            mongoApplyFailedMcpServers=int(getattr(summary, "mongoApplyFailedMcpServers", 0) or 0),
+            mongoApplyFailedAgents=int(getattr(summary, "mongoApplyFailedAgents", 0) or 0),
             errors=int(getattr(summary, "errors", 0) or 0),
             errorMessages=list(getattr(summary, "errorMessages", []) or []),
         )

--- a/registry/src/registry/schemas/federation_api_schemas.py
+++ b/registry/src/registry/schemas/federation_api_schemas.py
@@ -69,6 +69,8 @@ class FederationLastSyncSummaryResponse(BaseModel):
     skippedAgents: int = 0
     vectorSyncFailedMcpServers: int = 0
     vectorSyncFailedAgents: int = 0
+    mongoApplyFailedMcpServers: int = 0
+    mongoApplyFailedAgents: int = 0
 
     errors: int = 0
     errorMessages: list[str] = Field(default_factory=list)

--- a/registry/src/registry/services/federation_sync_service.py
+++ b/registry/src/registry/services/federation_sync_service.py
@@ -300,30 +300,36 @@ class FederationSyncService:
         """
         Sync execution follows a fixed flow:
             1. discover remote resources
-            2. apply federation/job/resource mutations in one transaction
-            3. rebuild vector indexes outside the Mongo transaction
-            4. finalize federation/job stats, lastSync, and status from the
-               combined apply + vector-sync outcome
+            2. bookkeeping (phase markers, discovery summary, sync plan) — atomic transaction
+            3. apply per-resource writes — outside the transaction, failures isolated
+            4. rebuild vector indexes — best-effort, per-resource
+            5. finalize federation/job stats, lastSync, and status
 
-        Mongo remains the source of truth, so the vector rebuild still happens after
-        the transaction commits. Vector sync runs in a best-effort sub-step: per-resource
-        failures are captured in a ``VectorSyncOutcome`` instead of raised. Stats and
-        lastSync are only built by ``_finalize_sync_status`` once this outcome is known,
-        so they can never disagree about a vector-sync failure. The job is reported as
-        successful as long as at least one resource fully completes the pipeline (or
-        nothing was discovered at all).
+        The Mongo transaction only covers bookkeeping (step 2) so that a single
+        resource's write failure in step 3 does not roll back the entire batch.
+        Each resource write is individually atomic (single-document).  Per-resource
+        failures are captured in ``FederationApplySummary`` counters and the loop
+        continues.  Vector sync (step 4) already isolates failures via
+        ``VectorSyncOutcome``.  The job is reported as successful as long as at
+        least one resource fully completes the pipeline (or nothing was discovered).
         """
         try:
             discovered = await self._discover_entities(federation, author_id=author_id)
+
             async with MongoDB.get_client().start_session() as mongo_session:
                 async with await mongo_session.start_transaction():
-                    mutation_result = await self._commit_sync_transaction(
+                    sync_plan = await self._commit_bookkeeping_transaction(
                         federation=federation,
                         job=job,
                         discovered=discovered,
                         session=mongo_session,
                     )
+
+            mutation_result = await self._apply_sync_plan(sync_plan)
+
+            await self.federation_job_service.update_apply_summary(job, mutation_result.summary)
             await self.federation_job_service.mark_syncing(job, FederationJobPhase.SYNCING_VECTORS)
+
             try:
                 vector_sync_outcome = await self._sync_vector_index_after_commit(
                     federation=federation,
@@ -494,15 +500,21 @@ class FederationSyncService:
         )
         return federation, job
 
-    async def _commit_sync_transaction(
+    async def _commit_bookkeeping_transaction(
         self,
         *,
         federation: Federation,
         job: FederationSyncJob,
         discovered: dict[str, list[Any]],
         session: AsyncClientSession,
-    ) -> FederationSyncMutationResult:
-        """Apply the discovered federation state in one Mongo transaction."""
+    ) -> FederationSyncPlan:
+        """Run bookkeeping updates and build the sync plan inside a Mongo transaction.
+
+        The transaction ensures that the Federation and FederationSyncJob documents
+        stay mutually consistent (phase markers, discovery summary).  The actual
+        per-resource writes happen *outside* this transaction so that individual
+        failures can be isolated without rolling back the entire batch.
+        """
         discovered_mcp = discovered.get("mcp_servers", [])
         discovered_a2a = discovered.get("a2a_agents", [])
 
@@ -525,9 +537,7 @@ class FederationSyncService:
             discovered_a2a=discovered_a2a,
             session=session,
         )
-        mutation_result = await self._apply_sync_plan(sync_plan, session=session)
-        await self.federation_job_service.update_apply_summary(job, mutation_result.summary, session=session)
-        return mutation_result
+        return sync_plan
 
     async def update_federation_and_create_resync_job(
         self,
@@ -1090,23 +1100,33 @@ class FederationSyncService:
     async def _apply_sync_plan(
         self,
         sync_plan: FederationSyncPlan,
-        session: AsyncClientSession,
     ) -> FederationSyncMutationResult:
-        """Apply a previously computed sync plan inside the current transaction."""
-        mutation_result = FederationSyncMutationResult(summary=sync_plan.summary)
+        """Apply a previously computed sync plan with per-resource failure isolation.
 
-        # Query Federation ACL entries once for batch inheritance
+        Each resource write runs outside any multi-document transaction so that a
+        single failure does not roll back the entire batch.  Failures are recorded
+        in the plan's ``FederationApplySummary`` and the loop continues.
+        """
+        summary = sync_plan.summary
+        mutation_result = FederationSyncMutationResult(summary=summary)
+
+        # Query Federation ACL entries once for batch inheritance.
+        # Degrade gracefully if the query fails — resources are still written.
         federation_acl_entries, acl_query_success = await self._get_federation_acl_entries(
             sync_plan.federation_id,
-            session=session,
         )
 
         if not acl_query_success:
             logger.error(
-                "Failed to query Federation ACL entries for federation %s",
+                "Failed to query Federation ACL entries for federation %s — "
+                "resources will be written without ACL inheritance",
                 sync_plan.federation_id,
             )
-            raise RuntimeError(f"ACL inheritance failed: could not query federation ACL for {sync_plan.federation_id}")
+            self._record_apply_error(
+                summary,
+                f"ACL query failed for federation {sync_plan.federation_id}: resources written without ACL inheritance",
+            )
+            federation_acl_entries = []
 
         # Track all resources that need ACL inheritance
         resources_for_acl_inheritance: list[tuple[str, Any]] = []
@@ -1117,70 +1137,152 @@ class FederationSyncService:
             (ResourceType.REMOTE_AGENT, resource_id) for resource_id in sync_plan.a2a_pre_existing_acl_targets
         )
 
-        # Deletes run first so that unique-indexed fields (serverName, path) are freed
+        # --- Deletes ---
+        # Run first so that unique-indexed fields (serverName, path) are freed
         # before new docs with the same name/path are inserted.
+        # Delete failures are logged but do NOT increment mongoApplyFailed*
+        # because deletes are not part of imported_total.
         for stale, stale_runtime_arn in sync_plan.mcp_deletes:
-            await stale.delete(session=session)
-            if stale_runtime_arn:
-                mutation_result.changed_mcp_runtime_arns.add(stale_runtime_arn)
+            try:
+                await stale.delete()
+                if stale_runtime_arn:
+                    mutation_result.changed_mcp_runtime_arns.add(stale_runtime_arn)
+            except Exception as exc:
+                logger.exception(
+                    "Failed to delete MCP server: federation_id=%s runtime_arn=%s",
+                    sync_plan.federation_id,
+                    stale_runtime_arn,
+                )
+                self._record_apply_error(
+                    summary,
+                    f"MCP server delete failed (runtime_arn={stale_runtime_arn}): {exc}",
+                )
 
         for stale, stale_runtime_arn in sync_plan.a2a_deletes:
-            await stale.delete(session=session)
-            if stale_runtime_arn:
-                mutation_result.changed_a2a_runtime_arns.add(stale_runtime_arn)
+            try:
+                await stale.delete()
+                if stale_runtime_arn:
+                    mutation_result.changed_a2a_runtime_arns.add(stale_runtime_arn)
+            except Exception as exc:
+                logger.exception(
+                    "Failed to delete A2A agent: federation_id=%s runtime_arn=%s",
+                    sync_plan.federation_id,
+                    stale_runtime_arn,
+                )
+                self._record_apply_error(
+                    summary,
+                    f"A2A agent delete failed (runtime_arn={stale_runtime_arn}): {exc}",
+                )
 
+        # --- Creates ---
         for server, remote_id in sync_plan.mcp_creates:
-            server.federationRefId = sync_plan.federation_id
-            await server.insert(session=session)
-            mutation_result.changed_mcp_runtime_arns.add(remote_id)
-            resources_for_acl_inheritance.append((ResourceType.MCPSERVER, server.id))
+            try:
+                server.federationRefId = sync_plan.federation_id
+                await server.insert()
+                mutation_result.changed_mcp_runtime_arns.add(remote_id)
+                resources_for_acl_inheritance.append((ResourceType.MCPSERVER, server.id))
+            except Exception as exc:
+                logger.exception(
+                    "Failed to create MCP server: federation_id=%s remote_id=%s",
+                    sync_plan.federation_id,
+                    remote_id,
+                )
+                self._record_apply_error(
+                    summary,
+                    f"MCP server create failed (remote_id={remote_id}): {exc}",
+                )
+                summary.mongoApplyFailedMcpServers += 1
 
         for agent, remote_id in sync_plan.a2a_creates:
-            agent.federationRefId = sync_plan.federation_id
-            await agent.insert(session=session)
-            mutation_result.changed_a2a_runtime_arns.add(remote_id)
-            resources_for_acl_inheritance.append((ResourceType.REMOTE_AGENT, agent.id))
+            try:
+                agent.federationRefId = sync_plan.federation_id
+                await agent.insert()
+                mutation_result.changed_a2a_runtime_arns.add(remote_id)
+                resources_for_acl_inheritance.append((ResourceType.REMOTE_AGENT, agent.id))
+            except Exception as exc:
+                logger.exception(
+                    "Failed to create A2A agent: federation_id=%s remote_id=%s",
+                    sync_plan.federation_id,
+                    remote_id,
+                )
+                self._record_apply_error(
+                    summary,
+                    f"A2A agent create failed (remote_id={remote_id}): {exc}",
+                )
+                summary.mongoApplyFailedAgents += 1
 
+        # --- Updates ---
         for existing, item, remote_id in sync_plan.mcp_updates:
-            existing.serverName = item.serverName
-            existing.path = item.path
-            existing.tags = list(item.tags or [])
-            existing.config = dict(item.config or {})
-            existing.numTools = item.numTools
-            existing.federationMetadata = item.federationMetadata
-            await existing.save(session=session)
-            mutation_result.changed_mcp_runtime_arns.add(remote_id)
-            resources_for_acl_inheritance.append((ResourceType.MCPSERVER, existing.id))
+            try:
+                existing.serverName = item.serverName
+                existing.path = item.path
+                existing.tags = list(item.tags or [])
+                existing.config = dict(item.config or {})
+                existing.numTools = item.numTools
+                existing.federationMetadata = item.federationMetadata
+                await existing.save()
+                mutation_result.changed_mcp_runtime_arns.add(remote_id)
+                resources_for_acl_inheritance.append((ResourceType.MCPSERVER, existing.id))
+            except Exception as exc:
+                logger.exception(
+                    "Failed to update MCP server: federation_id=%s remote_id=%s",
+                    sync_plan.federation_id,
+                    remote_id,
+                )
+                self._record_apply_error(
+                    summary,
+                    f"MCP server update failed (remote_id={remote_id}): {exc}",
+                )
+                summary.mongoApplyFailedMcpServers += 1
 
         for existing, item, remote_id in sync_plan.a2a_updates:
-            existing.path = item.path
-            existing.card = item.card
-            existing.tags = list(item.tags or [])
-            existing.wellKnown = item.wellKnown
-            existing.federationMetadata = item.federationMetadata
-            if item.config and existing.config:
-                # For an A2AAgent document created via Federation, the two fields `type` and `runtimeAccess` of `A2AAgent.config: AgentConfig`
-                # should both be set according to data retrieved during the discovery process—`type` represents the A2A agent's actual
-                # preferred protocol binding on its agent card; `runtimeAccess` tells us how to satisfy authentication requirements
-                # when actually invoking it.
-                if hasattr(item.config, "type"):
-                    existing.config.type = item.config.type
-                if hasattr(item.config, "runtimeAccess"):
-                    existing.config.runtimeAccess = item.config.runtimeAccess
-                existing.config.enabled = item.config.enabled
-            elif item.config:
-                existing.config = item.config
-            await existing.save(session=session)
-            mutation_result.changed_a2a_runtime_arns.add(remote_id)
-            resources_for_acl_inheritance.append((ResourceType.REMOTE_AGENT, existing.id))
+            try:
+                existing.path = item.path
+                existing.card = item.card
+                existing.tags = list(item.tags or [])
+                existing.wellKnown = item.wellKnown
+                existing.federationMetadata = item.federationMetadata
+                if item.config and existing.config:
+                    if hasattr(item.config, "type"):
+                        existing.config.type = item.config.type
+                    if hasattr(item.config, "runtimeAccess"):
+                        existing.config.runtimeAccess = item.config.runtimeAccess
+                    existing.config.enabled = item.config.enabled
+                elif item.config:
+                    existing.config = item.config
+                await existing.save()
+                mutation_result.changed_a2a_runtime_arns.add(remote_id)
+                resources_for_acl_inheritance.append((ResourceType.REMOTE_AGENT, existing.id))
+            except Exception as exc:
+                logger.exception(
+                    "Failed to update A2A agent: federation_id=%s remote_id=%s",
+                    sync_plan.federation_id,
+                    remote_id,
+                )
+                self._record_apply_error(
+                    summary,
+                    f"A2A agent update failed (remote_id={remote_id}): {exc}",
+                )
+                summary.mongoApplyFailedAgents += 1
 
-        # Batch inherit Federation ACL to all synced resources
+        # --- ACL inheritance ---
+        # Degrade gracefully if ACL inheritance fails — resources are already
+        # persisted and ACL can be re-applied on the next sync (INSERT-only idempotent).
         if federation_acl_entries and resources_for_acl_inheritance:
-            await self._batch_inherit_federation_acl(
-                federation_acl_entries=federation_acl_entries,
-                resources=resources_for_acl_inheritance,
-                session=session,
-            )
+            try:
+                await self._batch_inherit_federation_acl(
+                    federation_acl_entries=federation_acl_entries,
+                    resources=resources_for_acl_inheritance,
+                )
+            except Exception as exc:
+                logger.exception(
+                    "ACL inheritance failed, continuing without ACL: federation_id=%s",
+                    sync_plan.federation_id,
+                )
+                self._record_apply_error(
+                    summary,
+                    f"ACL inheritance failed for {len(resources_for_acl_inheritance)} resources: {exc}",
+                )
         elif not federation_acl_entries and resources_for_acl_inheritance:
             logger.info(
                 "No ACL entries found on Federation %s, skipping ACL inheritance for %d resources",
@@ -1558,10 +1660,12 @@ class FederationSyncService:
             + apply_summary.updatedMcpServers
             + apply_summary.unchangedMcpServers
             - apply_summary.vectorSyncFailedMcpServers
+            - apply_summary.mongoApplyFailedMcpServers
             + apply_summary.createdAgents
             + apply_summary.updatedAgents
             + apply_summary.unchangedAgents
             - apply_summary.vectorSyncFailedAgents
+            - apply_summary.mongoApplyFailedAgents
         )
         unimported_total = (mcp_server_count + agent_count) - imported_total
 

--- a/registry/src/registry/services/federation_sync_service.py
+++ b/registry/src/registry/services/federation_sync_service.py
@@ -1299,10 +1299,12 @@ class FederationSyncService:
     async def _get_federation_acl_entries(
         self,
         federation_id: Any,
-        session: AsyncClientSession | None = None,
     ) -> tuple[list[RegistryAclEntry], bool]:
         """
         Get all ACL entries for a Federation (query once, use multiple times).
+
+        Only called from ``_apply_sync_plan``, which runs with no active Mongo
+        transaction — this never participates in one.
 
         Returns:
             Tuple of (entries, query_success):
@@ -1317,7 +1319,6 @@ class FederationSyncService:
                     "principalType": {"$ne": PrincipalType.PUBLIC.value},
                     "principalId": {"$ne": None},
                 },
-                session=session,
             ).to_list()
 
             logger.debug("Found %d ACL entries for federation %s", len(entries), federation_id)
@@ -1334,7 +1335,6 @@ class FederationSyncService:
         self,
         federation_acl_entries: list[RegistryAclEntry],
         resources: list[tuple[str, Any]],
-        session: AsyncClientSession | None = None,
     ) -> None:
         """
         Batch inherit Federation ACL to multiple resources using INSERT-only logic.
@@ -1350,6 +1350,9 @@ class FederationSyncService:
         - If NOT exists → INSERT new ACL entry with same permission
         - If EXISTS → DO NOTHING (keep existing permission, never UPDATE)
         - Users not in Federation ACL are not affected
+
+        Only called from ``_apply_sync_plan``, which runs with no active Mongo
+        transaction — this never participates in one.
 
         Args:
             federation_acl_entries: Pre-fetched Federation ACL entries (excluding PUBLIC)
@@ -1381,7 +1384,6 @@ class FederationSyncService:
                     "resourceType": {"$in": resource_types_in_scope},
                     "resourceId": {"$in": [resource_id for _, resource_id in resources]},
                 },
-                session=session,
             ).to_list()
             # The MongoDB query above pre-filters by resourceType and resourceId using separate
             # $in clauses, but those are evaluated independently — it can return an entry whose
@@ -1414,7 +1416,6 @@ class FederationSyncService:
             target_resource_types = {_acl_key_part(resource_type) for resource_type, _ in resources}
             target_roles = await RegistryAccessRole.find(
                 {"resourceType": {"$in": sorted(target_resource_types)}},
-                session=session,
             ).to_list()
             role_id_lookup: dict[tuple[str, int], PydanticObjectId] = {
                 (_acl_key_part(role.resourceType), role.permBits): role.id for role in target_roles
@@ -1470,7 +1471,7 @@ class FederationSyncService:
             if new_acl_entries:
                 for i in range(0, len(new_acl_entries), ACL_INHERITANCE_BATCH_SIZE):
                     batch = new_acl_entries[i : i + ACL_INHERITANCE_BATCH_SIZE]
-                    await RegistryAclEntry.insert_many(batch, session=session, ordered=False)
+                    await RegistryAclEntry.insert_many(batch, ordered=False)
                     stats["inserted_count"] += len(batch)
 
                 logger.info(

--- a/registry/src/registry/services/federation_sync_service.py
+++ b/registry/src/registry/services/federation_sync_service.py
@@ -130,6 +130,8 @@ class FederationSyncMutationResult:
     summary: FederationApplySummary
     changed_mcp_runtime_arns: set[str] = field(default_factory=set)
     changed_a2a_runtime_arns: set[str] = field(default_factory=set)
+    deleted_mcp_runtime_arns: set[str] = field(default_factory=set)
+    deleted_a2a_runtime_arns: set[str] = field(default_factory=set)
 
 
 @dataclass
@@ -1147,6 +1149,7 @@ class FederationSyncService:
                 await stale.delete()
                 if stale_runtime_arn:
                     mutation_result.changed_mcp_runtime_arns.add(stale_runtime_arn)
+                    mutation_result.deleted_mcp_runtime_arns.add(stale_runtime_arn)
             except Exception as exc:
                 logger.exception(
                     "Failed to delete MCP server: federation_id=%s runtime_arn=%s",
@@ -1163,6 +1166,7 @@ class FederationSyncService:
                 await stale.delete()
                 if stale_runtime_arn:
                     mutation_result.changed_a2a_runtime_arns.add(stale_runtime_arn)
+                    mutation_result.deleted_a2a_runtime_arns.add(stale_runtime_arn)
             except Exception as exc:
                 logger.exception(
                     "Failed to delete A2A agent: federation_id=%s runtime_arn=%s",
@@ -1562,7 +1566,9 @@ class FederationSyncService:
                 )
                 error_msg = f"mcp runtime rebuild failed:{federation.id}:{runtime_arn}:{exc}"
                 outcome.error_messages.append(error_msg)
-                if runtime_arn in mutation_result.changed_mcp_runtime_arns:
+                is_changed = runtime_arn in mutation_result.changed_mcp_runtime_arns
+                is_delete = runtime_arn in mutation_result.deleted_mcp_runtime_arns
+                if is_changed and not is_delete:
                     outcome.failed_changed_mcp_runtime_arns.add(runtime_arn)
                 else:
                     outcome.failed_repair_only_runtime_arns.add(runtime_arn)
@@ -1579,7 +1585,9 @@ class FederationSyncService:
                 )
                 error_msg = f"a2a runtime rebuild failed:{federation.id}:{runtime_arn}:{exc}"
                 outcome.error_messages.append(error_msg)
-                if runtime_arn in mutation_result.changed_a2a_runtime_arns:
+                is_changed = runtime_arn in mutation_result.changed_a2a_runtime_arns
+                is_delete = runtime_arn in mutation_result.deleted_a2a_runtime_arns
+                if is_changed and not is_delete:
                     outcome.failed_changed_a2a_runtime_arns.add(runtime_arn)
                 else:
                     outcome.failed_repair_only_runtime_arns.add(runtime_arn)

--- a/registry/src/registry/services/federation_sync_service.py
+++ b/registry/src/registry/services/federation_sync_service.py
@@ -1798,6 +1798,8 @@ class FederationSyncService:
                 skippedAgents=apply_summary.skippedAgents,
                 vectorSyncFailedMcpServers=apply_summary.vectorSyncFailedMcpServers,
                 vectorSyncFailedAgents=apply_summary.vectorSyncFailedAgents,
+                mongoApplyFailedMcpServers=apply_summary.mongoApplyFailedMcpServers,
+                mongoApplyFailedAgents=apply_summary.mongoApplyFailedAgents,
                 errors=apply_summary.errors,
                 errorMessages=list(apply_summary.errorMessages or []),
             ),

--- a/registry/tests/unit/api/v1/test_federation_routes.py
+++ b/registry/tests/unit/api/v1/test_federation_routes.py
@@ -767,6 +767,8 @@ async def test_list_federations_includes_last_sync(sample_federation, sample_use
                     updatedAgents=0,
                     deletedAgents=0,
                     unchangedAgents=0,
+                    mongoApplyFailedMcpServers=1,
+                    mongoApplyFailedAgents=0,
                     errors=0,
                     errorMessages=[],
                 ),
@@ -798,6 +800,8 @@ async def test_list_federations_includes_last_sync(sample_federation, sample_use
     assert result.federations[0].lastSync.status == FederationSyncStatus.SUCCESS
     assert result.federations[0].lastSync.summary is not None
     assert result.federations[0].lastSync.summary.discoveredMcpServers == 2
+    assert result.federations[0].lastSync.summary.mongoApplyFailedMcpServers == 1
+    assert result.federations[0].lastSync.summary.mongoApplyFailedAgents == 0
 
 
 @pytest.mark.asyncio

--- a/registry/tests/unit/services/test_federation_sync_acl.py
+++ b/registry/tests/unit/services/test_federation_sync_acl.py
@@ -444,12 +444,13 @@ async def test_apply_sync_plan_degrades_when_federation_acl_query_fails(
 
 
 @pytest.mark.asyncio
-async def test_get_federation_acl_entries_uses_current_transaction_session(
+async def test_get_federation_acl_entries_queries_without_a_session(
     federation_sync_service: FederationSyncService,
     monkeypatch,
 ):
+    """_get_federation_acl_entries is only called from _apply_sync_plan, which runs with
+    no active Mongo transaction/session — it must not pass a session to the query."""
     federation_id = PydanticObjectId()
-    session = object()
     find_calls = []
 
     def mock_find(query, **kwargs):
@@ -458,7 +459,7 @@ async def test_get_federation_acl_entries_uses_current_transaction_session(
 
     monkeypatch.setattr("registry.services.federation_sync_service.RegistryAclEntry.find", mock_find)
 
-    entries, query_success = await federation_sync_service._get_federation_acl_entries(federation_id, session=session)
+    entries, query_success = await federation_sync_service._get_federation_acl_entries(federation_id)
 
     assert entries == []
     assert query_success is True
@@ -470,7 +471,7 @@ async def test_get_federation_acl_entries_uses_current_transaction_session(
                 "principalType": {"$ne": PrincipalType.PUBLIC.value},
                 "principalId": {"$ne": None},
             },
-            "kwargs": {"session": session},
+            "kwargs": {},
         }
     ]
 

--- a/registry/tests/unit/services/test_federation_sync_acl.py
+++ b/registry/tests/unit/services/test_federation_sync_acl.py
@@ -207,7 +207,7 @@ async def test_apply_sync_plan_inherits_acl_to_unchanged_mcp_and_a2a_resources(
     federation_sync_service._get_federation_acl_entries = AsyncMock(return_value=(federation_acl_entries, True))
     federation_sync_service._batch_inherit_federation_acl = AsyncMock()
 
-    await federation_sync_service._apply_sync_plan(sync_plan, session=None)
+    await federation_sync_service._apply_sync_plan(sync_plan)
 
     federation_sync_service._batch_inherit_federation_acl.assert_awaited_once_with(
         federation_acl_entries=federation_acl_entries,
@@ -215,7 +215,6 @@ async def test_apply_sync_plan_inherits_acl_to_unchanged_mcp_and_a2a_resources(
             (ResourceType.MCPSERVER, mcp_id),
             (ResourceType.REMOTE_AGENT, a2a_id),
         ],
-        session=None,
     )
 
 
@@ -256,12 +255,12 @@ async def test_apply_sync_plan_updates_a2a_runtime_access(
     federation_sync_service._get_federation_acl_entries = AsyncMock(return_value=([], True))
     federation_sync_service._batch_inherit_federation_acl = AsyncMock()
 
-    await federation_sync_service._apply_sync_plan(sync_plan, session=None)
+    await federation_sync_service._apply_sync_plan(sync_plan)
 
     assert existing_a2a.config.runtimeAccess is updated_runtime_access
     assert existing_a2a.config.runtimeAccess.mode == "jwt"
     assert existing_a2a.config.type == update_a2a_item.config.type
-    existing_a2a.save.assert_awaited_once_with(session=None)
+    existing_a2a.save.assert_awaited_once_with()
     federation_sync_service._batch_inherit_federation_acl.assert_not_awaited()
 
 
@@ -388,7 +387,7 @@ async def test_apply_sync_plan_inherits_acl_to_created_updated_and_unchanged_res
     federation_sync_service._get_federation_acl_entries = AsyncMock(return_value=(federation_acl_entries, True))
     federation_sync_service._batch_inherit_federation_acl = AsyncMock()
 
-    await federation_sync_service._apply_sync_plan(sync_plan, session=None)
+    await federation_sync_service._apply_sync_plan(sync_plan)
 
     # Verify that _batch_inherit_federation_acl was called
     federation_sync_service._batch_inherit_federation_acl.assert_awaited_once()
@@ -421,10 +420,11 @@ async def test_apply_sync_plan_inherits_acl_to_created_updated_and_unchanged_res
 
 
 @pytest.mark.asyncio
-async def test_apply_sync_plan_raises_when_federation_acl_query_fails(
+async def test_apply_sync_plan_degrades_when_federation_acl_query_fails(
     federation_sync_service: FederationSyncService,
     monkeypatch,
 ):
+    """ACL query failure no longer raises — it degrades gracefully and records an error."""
     sync_plan = FederationSyncPlan(
         summary=FederationApplySummary(),
         federation_id=PydanticObjectId(),
@@ -436,9 +436,10 @@ async def test_apply_sync_plan_raises_when_federation_acl_query_fails(
     federation_sync_service._get_federation_acl_entries = AsyncMock(return_value=([], False))
     federation_sync_service._batch_inherit_federation_acl = AsyncMock()
 
-    with pytest.raises(RuntimeError, match="could not query federation ACL"):
-        await federation_sync_service._apply_sync_plan(sync_plan, session=None)
+    result = await federation_sync_service._apply_sync_plan(sync_plan)
 
+    assert result.summary.errors >= 1
+    assert any("ACL query failed" in msg for msg in result.summary.errorMessages)
     federation_sync_service._batch_inherit_federation_acl.assert_not_awaited()
 
 
@@ -1105,3 +1106,113 @@ async def test_batch_inherit_acl_raises_after_failure(federation_sync_service: F
             federation_acl_entries=federation_acl_entries,
             resources=[(ResourceType.MCPSERVER, server_id)],
         )
+
+
+# ---------------------------------------------------------------------------
+# T7 – failed resource excluded from ACL inheritance
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_failed_resource_excluded_from_acl_inheritance(
+    federation_sync_service: FederationSyncService,
+):
+    federation_id = PydanticObjectId()
+    ok = SimpleNamespace(
+        id=None,
+        insert=AsyncMock(side_effect=lambda **kw: setattr(ok, "id", PydanticObjectId())),
+    )
+    bad = SimpleNamespace(id=None, insert=AsyncMock(side_effect=Exception("insert fail")))
+
+    sync_plan = FederationSyncPlan(
+        summary=FederationApplySummary(createdMcpServers=2),
+        federation_id=federation_id,
+        provider_type=FederationProviderType.AWS_AGENTCORE,
+        discovered_mcp_count=2,
+        discovered_a2a_count=0,
+        mcp_creates=[(ok, "arn:ok"), (bad, "arn:bad")],
+    )
+
+    acl_entries = [
+        _make_acl_entry(PrincipalType.USER, "kent", RegistryResourceType.FEDERATION, federation_id, RoleBits.OWNER)
+    ]
+    federation_sync_service._get_federation_acl_entries = AsyncMock(return_value=(acl_entries, True))
+    federation_sync_service._batch_inherit_federation_acl = AsyncMock()
+
+    await federation_sync_service._apply_sync_plan(sync_plan)
+
+    federation_sync_service._batch_inherit_federation_acl.assert_awaited_once()
+    call_resources = federation_sync_service._batch_inherit_federation_acl.await_args.kwargs["resources"]
+    resource_ids = {str(rid) for _, rid in call_resources}
+    assert str(ok.id) in resource_ids
+    assert bad.id is None  # never got an ID because insert failed
+
+
+# ---------------------------------------------------------------------------
+# T8 – ACL query failure degrades gracefully (resources still written)
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_acl_query_failure_degrades_gracefully(
+    federation_sync_service: FederationSyncService,
+):
+    federation_id = PydanticObjectId()
+    mcp = SimpleNamespace(
+        id=None,
+        insert=AsyncMock(side_effect=lambda **kw: setattr(mcp, "id", PydanticObjectId())),
+    )
+
+    sync_plan = FederationSyncPlan(
+        summary=FederationApplySummary(createdMcpServers=1),
+        federation_id=federation_id,
+        provider_type=FederationProviderType.AWS_AGENTCORE,
+        discovered_mcp_count=1,
+        discovered_a2a_count=0,
+        mcp_creates=[(mcp, "arn:mcp1")],
+    )
+
+    federation_sync_service._get_federation_acl_entries = AsyncMock(return_value=([], False))
+    federation_sync_service._batch_inherit_federation_acl = AsyncMock()
+
+    result = await federation_sync_service._apply_sync_plan(sync_plan)
+
+    mcp.insert.assert_awaited_once()
+    assert mcp.id is not None
+    assert "arn:mcp1" in result.changed_mcp_runtime_arns
+    assert any("ACL query failed" in msg for msg in result.summary.errorMessages)
+    federation_sync_service._batch_inherit_federation_acl.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# T9 – ACL inheritance failure degrades gracefully
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_acl_inheritance_failure_degrades_gracefully(
+    federation_sync_service: FederationSyncService,
+):
+    federation_id = PydanticObjectId()
+    mcp = SimpleNamespace(
+        id=None,
+        insert=AsyncMock(side_effect=lambda **kw: setattr(mcp, "id", PydanticObjectId())),
+    )
+
+    sync_plan = FederationSyncPlan(
+        summary=FederationApplySummary(createdMcpServers=1),
+        federation_id=federation_id,
+        provider_type=FederationProviderType.AWS_AGENTCORE,
+        discovered_mcp_count=1,
+        discovered_a2a_count=0,
+        mcp_creates=[(mcp, "arn:mcp1")],
+    )
+
+    acl_entries = [
+        _make_acl_entry(PrincipalType.USER, "kent", RegistryResourceType.FEDERATION, federation_id, RoleBits.OWNER)
+    ]
+    federation_sync_service._get_federation_acl_entries = AsyncMock(return_value=(acl_entries, True))
+    federation_sync_service._batch_inherit_federation_acl = AsyncMock(
+        side_effect=RuntimeError("ACL inheritance failed")
+    )
+
+    result = await federation_sync_service._apply_sync_plan(sync_plan)
+
+    mcp.insert.assert_awaited_once()
+    assert "arn:mcp1" in result.changed_mcp_runtime_arns
+    assert result.summary.mongoApplyFailedMcpServers == 0
+    assert any("ACL inheritance failed" in msg for msg in result.summary.errorMessages)

--- a/registry/tests/unit/services/test_federation_sync_acl.py
+++ b/registry/tests/unit/services/test_federation_sync_acl.py
@@ -1141,8 +1141,9 @@ async def test_failed_resource_excluded_from_acl_inheritance(
 
     federation_sync_service._batch_inherit_federation_acl.assert_awaited_once()
     call_resources = federation_sync_service._batch_inherit_federation_acl.await_args.kwargs["resources"]
-    resource_ids = {str(rid) for _, rid in call_resources}
-    assert str(ok.id) in resource_ids
+    resource_ids = {rid for _, rid in call_resources}
+    assert ok.id in resource_ids
+    assert None not in resource_ids  # failed insert must not be queued for ACL inheritance
     assert bad.id is None  # never got an ID because insert failed
 
 

--- a/registry/tests/unit/services/test_federation_sync_finalize.py
+++ b/registry/tests/unit/services/test_federation_sync_finalize.py
@@ -150,7 +150,11 @@ async def test_run_sync_remains_active_and_rejects_second_sync_during_vector_tai
         return VectorSyncOutcome()
 
     federation_sync_service._discover_entities = AsyncMock(return_value={"mcp_servers": [], "a2a_agents": []})
-    federation_sync_service._commit_sync_transaction = AsyncMock(return_value=mutation_result)
+    federation_sync_service._commit_bookkeeping_transaction = AsyncMock(
+        return_value=SimpleNamespace(summary=mutation_result.summary)
+    )
+    federation_sync_service._apply_sync_plan = AsyncMock(return_value=mutation_result)
+    federation_sync_service.federation_job_service.update_apply_summary = AsyncMock()
     federation_sync_service._sync_vector_index_after_commit = AsyncMock(side_effect=_block_vector_sync)
     federation_sync_service._finalize_sync_status = AsyncMock()
     federation_sync_service.federation_job_service.mark_syncing = AsyncMock(side_effect=_mark_syncing)
@@ -345,7 +349,7 @@ async def test_sync_vector_index_after_commit_logs_summary_when_nothing_to_rebui
 
 
 @pytest.mark.asyncio
-async def test_commit_sync_transaction_defers_terminal_status_when_resource_enrichment_fails(
+async def test_bookkeeping_transaction_returns_plan_with_enrichment_errors(
     federation_sync_service: FederationSyncService,
 ):
     federation = _make_federation(FederationProviderType.AWS_AGENTCORE, {"region": "us-east-1"})
@@ -356,30 +360,26 @@ async def test_commit_sync_transaction_defers_terminal_status_when_resource_enri
         discoverySummary=SimpleNamespace(discoveredMcpServers=1, discoveredAgents=1),
     )
     summary = FederationApplySummary(errors=1, errorMessages=["A2A agent pharmacy_fraud_a2a: boom"])
-    mutation_result = FederationSyncMutationResult(summary=summary)
+    plan = SimpleNamespace(
+        summary=summary,
+        discovered_mcp_count=1,
+        discovered_a2a_count=1,
+    )
 
     federation_sync_service.federation_job_service.mark_syncing = AsyncMock()
     federation_sync_service.federation_crud_service.mark_syncing = AsyncMock()
     federation_sync_service.federation_job_service.update_discovery_summary = AsyncMock()
-    federation_sync_service._build_sync_plan = AsyncMock(
-        return_value=SimpleNamespace(
-            summary=summary,
-            discovered_mcp_count=1,
-            discovered_a2a_count=1,
-        )
-    )
-    federation_sync_service._apply_sync_plan = AsyncMock(return_value=mutation_result)
-    federation_sync_service.federation_job_service.update_apply_summary = AsyncMock()
+    federation_sync_service._build_sync_plan = AsyncMock(return_value=plan)
     session = object()
 
-    result = await federation_sync_service._commit_sync_transaction(
+    result = await federation_sync_service._commit_bookkeeping_transaction(
         federation=federation,
         job=job,
         discovered={"mcp_servers": [SimpleNamespace()], "a2a_agents": [SimpleNamespace()]},
         session=session,
     )
 
-    assert result == mutation_result
+    assert result == plan
     assert result.summary.errorMessages == ["A2A agent pharmacy_fraud_a2a: boom"]
     assert federation_sync_service.federation_crud_service.mark_syncing.await_args.kwargs["last_sync"].status == (
         FederationSyncStatus.SYNCING
@@ -606,3 +606,162 @@ def test_build_last_sync_includes_vector_sync_failed_counts():
 
     assert last_sync.summary.vectorSyncFailedMcpServers == 1
     assert last_sync.summary.vectorSyncFailedAgents == 1
+
+
+# ---------------------------------------------------------------------------
+# T10 – imported_total nets mongo apply failures
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_imported_total_nets_apply_failures(
+    federation_sync_service: FederationSyncService,
+    monkeypatch,
+):
+    federation = _make_federation(FederationProviderType.AWS_AGENTCORE, {"region": "us-east-1"})
+
+    monkeypatch.setattr(
+        "registry.services.federation_sync_service.ExtendedMCPServer.find",
+        lambda *a, **kw: _FakeQuery([SimpleNamespace(numTools=1)]),
+    )
+
+    discovery_summary = SimpleNamespace(discoveredMcpServers=3, discoveredAgents=2)
+    apply_summary = FederationApplySummary(
+        createdMcpServers=2,
+        updatedMcpServers=1,
+        unchangedMcpServers=0,
+        mongoApplyFailedMcpServers=1,
+        createdAgents=1,
+        updatedAgents=1,
+        unchangedAgents=0,
+        mongoApplyFailedAgents=1,
+    )
+
+    stats = await federation_sync_service._build_federation_stats(
+        federation.id,
+        discovery_summary,
+        apply_summary,
+        session=None,
+    )
+
+    expected_imported = (2 + 1 + 0 - 0 - 1) + (1 + 1 + 0 - 0 - 1)
+    assert stats.importedTotal == expected_imported
+    assert stats.unimportedTotal == (3 + 2) - expected_imported
+
+
+# ---------------------------------------------------------------------------
+# T11 – finalize partial success (some failures, importedTotal > 0 → SUCCESS)
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_finalize_partial_success(
+    federation_sync_service: FederationSyncService,
+    monkeypatch,
+):
+    federation = _make_federation(FederationProviderType.AWS_AGENTCORE, {"region": "us-east-1"})
+    job = SimpleNamespace(
+        id=PydanticObjectId(),
+        jobType="full_sync",
+        createdAt=datetime.now(UTC),
+        startedAt=datetime.now(UTC),
+        discoverySummary=SimpleNamespace(discoveredMcpServers=10, discoveredAgents=0),
+    )
+    mutation_result = FederationSyncMutationResult(
+        summary=FederationApplySummary(
+            createdMcpServers=10,
+            mongoApplyFailedMcpServers=1,
+            errors=1,
+            errorMessages=["MCP server create failed (remote_id=arn:bad): write conflict"],
+        ),
+    )
+    vector_outcome = VectorSyncOutcome()
+
+    mock_stats = SimpleNamespace(importedTotal=9, unimportedTotal=1)
+    federation_sync_service._build_federation_stats = AsyncMock(return_value=mock_stats)
+    federation_sync_service.federation_crud_service.mark_sync_success = AsyncMock()
+    federation_sync_service.federation_crud_service.mark_sync_failed = AsyncMock()
+    federation_sync_service.federation_job_service.mark_success = AsyncMock()
+    federation_sync_service.federation_job_service.mark_failed = AsyncMock()
+
+    await federation_sync_service._finalize_sync_status(federation, job, mutation_result, vector_outcome)
+
+    federation_sync_service.federation_crud_service.mark_sync_success.assert_awaited_once()
+    federation_sync_service.federation_job_service.mark_success.assert_awaited_once()
+    federation_sync_service.federation_crud_service.mark_sync_failed.assert_not_awaited()
+    success_call = federation_sync_service.federation_job_service.mark_success.await_args
+    assert success_call.kwargs.get("message") is not None
+
+
+# ---------------------------------------------------------------------------
+# T12 – finalize total failure (importedTotal == 0 → FAILED)
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_finalize_total_failure(
+    federation_sync_service: FederationSyncService,
+    monkeypatch,
+):
+    federation = _make_federation(FederationProviderType.AWS_AGENTCORE, {"region": "us-east-1"})
+    job = SimpleNamespace(
+        id=PydanticObjectId(),
+        jobType="full_sync",
+        createdAt=datetime.now(UTC),
+        startedAt=datetime.now(UTC),
+        discoverySummary=SimpleNamespace(discoveredMcpServers=3, discoveredAgents=0),
+    )
+    mutation_result = FederationSyncMutationResult(
+        summary=FederationApplySummary(
+            createdMcpServers=3,
+            mongoApplyFailedMcpServers=3,
+            errors=3,
+            errorMessages=[
+                "MCP server create failed (remote_id=arn:1): err",
+                "MCP server create failed (remote_id=arn:2): err",
+                "MCP server create failed (remote_id=arn:3): err",
+            ],
+        ),
+    )
+    vector_outcome = VectorSyncOutcome()
+
+    mock_stats = SimpleNamespace(importedTotal=0, unimportedTotal=3)
+    federation_sync_service._build_federation_stats = AsyncMock(return_value=mock_stats)
+    federation_sync_service.federation_crud_service.mark_sync_failed = AsyncMock()
+    federation_sync_service.federation_crud_service.mark_sync_success = AsyncMock()
+    federation_sync_service.federation_job_service.mark_failed = AsyncMock()
+    federation_sync_service.federation_job_service.mark_success = AsyncMock()
+
+    await federation_sync_service._finalize_sync_status(federation, job, mutation_result, vector_outcome)
+
+    federation_sync_service.federation_crud_service.mark_sync_failed.assert_awaited_once()
+    federation_sync_service.federation_job_service.mark_failed.assert_awaited_once()
+    federation_sync_service.federation_crud_service.mark_sync_success.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# T14 – delete failure does not affect imported_total
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_delete_failure_does_not_affect_imported_total(
+    federation_sync_service: FederationSyncService,
+    monkeypatch,
+):
+    federation = _make_federation(FederationProviderType.AWS_AGENTCORE, {"region": "us-east-1"})
+
+    monkeypatch.setattr(
+        "registry.services.federation_sync_service.ExtendedMCPServer.find",
+        lambda *a, **kw: _FakeQuery([]),
+    )
+
+    discovery_summary = SimpleNamespace(discoveredMcpServers=2, discoveredAgents=0)
+    apply_summary = FederationApplySummary(
+        createdMcpServers=2,
+        deletedMcpServers=1,
+        errors=1,
+        errorMessages=["MCP server delete failed (runtime_arn=arn:del-bad): delete error"],
+    )
+
+    stats = await federation_sync_service._build_federation_stats(
+        federation.id,
+        discovery_summary,
+        apply_summary,
+        session=None,
+    )
+
+    assert stats.importedTotal == 2
+    assert stats.unimportedTotal == 0

--- a/registry/tests/unit/services/test_federation_sync_finalize.py
+++ b/registry/tests/unit/services/test_federation_sync_finalize.py
@@ -626,12 +626,16 @@ def test_build_last_sync_includes_vector_sync_failed_counts():
         createdAgents=1,
         vectorSyncFailedMcpServers=1,
         vectorSyncFailedAgents=1,
+        mongoApplyFailedMcpServers=1,
+        mongoApplyFailedAgents=1,
     )
 
     last_sync = FederationSyncService._build_last_sync(job, summary)
 
     assert last_sync.summary.vectorSyncFailedMcpServers == 1
     assert last_sync.summary.vectorSyncFailedAgents == 1
+    assert last_sync.summary.mongoApplyFailedMcpServers == 1
+    assert last_sync.summary.mongoApplyFailedAgents == 1
 
 
 # ---------------------------------------------------------------------------

--- a/registry/tests/unit/services/test_federation_sync_finalize.py
+++ b/registry/tests/unit/services/test_federation_sync_finalize.py
@@ -588,6 +588,32 @@ async def test_sync_vector_index_classifies_changed_vs_repair_failures(
     assert len(outcome.error_messages) == 2
 
 
+@pytest.mark.asyncio
+async def test_delete_arn_vector_failure_classified_as_repair_only(
+    federation_sync_service: FederationSyncService,
+):
+    """Delete ARN vector failures must not inflate vectorSyncFailed* and make imported_total negative."""
+    federation = _make_federation(FederationProviderType.AWS_AGENTCORE, {"region": "us-east-1"})
+    job = SimpleNamespace(id=PydanticObjectId())
+    mutation_result = FederationSyncMutationResult(
+        summary=FederationApplySummary(deletedMcpServers=1),
+        changed_mcp_runtime_arns={"arn:mcp:deleted"},
+        deleted_mcp_runtime_arns={"arn:mcp:deleted"},
+    )
+
+    federation_sync_service._current_mcp_runtime_arns = AsyncMock(return_value=[])
+    federation_sync_service._current_a2a_runtime_arns = AsyncMock(return_value=[])
+    federation_sync_service._sync_mcp_vectors_for_runtime = AsyncMock(side_effect=RuntimeError("weaviate down"))
+    federation_sync_service._sync_a2a_vectors_for_runtime = AsyncMock()
+
+    outcome = await federation_sync_service._sync_vector_index_after_commit(
+        federation=federation, job=job, mutation_result=mutation_result
+    )
+
+    assert "arn:mcp:deleted" not in outcome.failed_changed_mcp_runtime_arns
+    assert "arn:mcp:deleted" in outcome.failed_repair_only_runtime_arns
+
+
 def test_build_last_sync_includes_vector_sync_failed_counts():
     job = SimpleNamespace(
         id=PydanticObjectId(),

--- a/registry/tests/unit/services/test_federation_sync_service.py
+++ b/registry/tests/unit/services/test_federation_sync_service.py
@@ -277,7 +277,11 @@ async def test_run_sync_calls_vector_sync_after_commit(
     )
 
     federation_sync_service._discover_entities = AsyncMock(return_value={"mcp_servers": [], "a2a_agents": []})
-    federation_sync_service._commit_sync_transaction = AsyncMock(return_value=mutation_result)
+    federation_sync_service._commit_bookkeeping_transaction = AsyncMock(
+        return_value=SimpleNamespace(summary=mutation_result.summary)
+    )
+    federation_sync_service._apply_sync_plan = AsyncMock(return_value=mutation_result)
+    federation_sync_service.federation_job_service.update_apply_summary = AsyncMock()
     federation_sync_service._sync_vector_index_after_commit = AsyncMock(return_value=VectorSyncOutcome())
     federation_sync_service._finalize_sync_status = AsyncMock()
     federation_sync_service.federation_job_service.mark_syncing = AsyncMock()
@@ -286,12 +290,13 @@ async def test_run_sync_calls_vector_sync_after_commit(
     result = await federation_sync_service.run_sync(federation=federation, job=job, author_id=_DEFAULT_USER_OBJECT_ID)
 
     assert result == job
-    federation_sync_service._commit_sync_transaction.assert_awaited_once_with(
+    federation_sync_service._commit_bookkeeping_transaction.assert_awaited_once_with(
         federation=federation,
         job=job,
         discovered={"mcp_servers": [], "a2a_agents": []},
         session=mongo_session,
     )
+    federation_sync_service._apply_sync_plan.assert_awaited_once()
     federation_sync_service._sync_vector_index_after_commit.assert_awaited_once_with(
         federation=federation,
         job=job,
@@ -322,7 +327,11 @@ async def test_run_sync_passes_vector_outcome_to_finalize(
     )
 
     federation_sync_service._discover_entities = AsyncMock(return_value={"mcp_servers": [], "a2a_agents": []})
-    federation_sync_service._commit_sync_transaction = AsyncMock(return_value=mutation_result)
+    federation_sync_service._commit_bookkeeping_transaction = AsyncMock(
+        return_value=SimpleNamespace(summary=mutation_result.summary)
+    )
+    federation_sync_service._apply_sync_plan = AsyncMock(return_value=mutation_result)
+    federation_sync_service.federation_job_service.update_apply_summary = AsyncMock()
     federation_sync_service._sync_vector_index_after_commit = AsyncMock(return_value=vector_outcome)
     federation_sync_service._finalize_sync_status = AsyncMock()
     federation_sync_service.federation_job_service.mark_syncing = AsyncMock()
@@ -356,7 +365,11 @@ async def test_run_sync_finalizes_committed_apply_when_vector_sync_setup_fails(
     )
 
     federation_sync_service._discover_entities = AsyncMock(return_value={"mcp_servers": [], "a2a_agents": []})
-    federation_sync_service._commit_sync_transaction = AsyncMock(return_value=mutation_result)
+    federation_sync_service._commit_bookkeeping_transaction = AsyncMock(
+        return_value=SimpleNamespace(summary=mutation_result.summary)
+    )
+    federation_sync_service._apply_sync_plan = AsyncMock(return_value=mutation_result)
+    federation_sync_service.federation_job_service.update_apply_summary = AsyncMock()
     federation_sync_service._sync_vector_index_after_commit = AsyncMock(
         side_effect=RuntimeError("Mongo runtime ARN read failed")
     )
@@ -584,7 +597,11 @@ async def test_run_sync_forwards_author_id_to_discover_entities(
 
     discover_mock = AsyncMock(return_value={"mcp_servers": [], "a2a_agents": []})
     federation_sync_service._discover_entities = discover_mock
-    federation_sync_service._commit_sync_transaction = AsyncMock(return_value=mutation_result)
+    federation_sync_service._commit_bookkeeping_transaction = AsyncMock(
+        return_value=SimpleNamespace(summary=mutation_result.summary)
+    )
+    federation_sync_service._apply_sync_plan = AsyncMock(return_value=mutation_result)
+    federation_sync_service.federation_job_service.update_apply_summary = AsyncMock()
     federation_sync_service._sync_vector_index_after_commit = AsyncMock(return_value=VectorSyncOutcome())
     federation_sync_service._finalize_sync_status = AsyncMock()
     federation_sync_service.federation_job_service.mark_syncing = AsyncMock()
@@ -593,3 +610,276 @@ async def test_run_sync_forwards_author_id_to_discover_entities(
     await federation_sync_service.run_sync(federation=federation, job=job, author_id=_DEFAULT_USER_OBJECT_ID)
 
     discover_mock.assert_awaited_once_with(federation, author_id=_DEFAULT_USER_OBJECT_ID)
+
+
+# ---------------------------------------------------------------------------
+# T1 – single MCP create failure, others persist
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_single_mcp_create_failure_others_persist(
+    federation_sync_service: FederationSyncService,
+):
+    federation_id = PydanticObjectId()
+    ok1 = SimpleNamespace(id=None, insert=AsyncMock(side_effect=lambda **kw: setattr(ok1, "id", PydanticObjectId())))
+    bad = SimpleNamespace(id=None, insert=AsyncMock(side_effect=Exception("write conflict")))
+    ok3 = SimpleNamespace(id=None, insert=AsyncMock(side_effect=lambda **kw: setattr(ok3, "id", PydanticObjectId())))
+
+    from registry.services.federation_sync_service import FederationSyncPlan
+
+    sync_plan = FederationSyncPlan(
+        summary=FederationApplySummary(createdMcpServers=3),
+        federation_id=federation_id,
+        provider_type=FederationProviderType.AWS_AGENTCORE,
+        discovered_mcp_count=3,
+        discovered_a2a_count=0,
+        mcp_creates=[(ok1, "arn:ok1"), (bad, "arn:bad"), (ok3, "arn:ok3")],
+    )
+    federation_sync_service._get_federation_acl_entries = AsyncMock(return_value=([], True))
+
+    result = await federation_sync_service._apply_sync_plan(sync_plan)
+
+    ok1.insert.assert_awaited_once()
+    bad.insert.assert_awaited_once()
+    ok3.insert.assert_awaited_once()
+    assert result.summary.mongoApplyFailedMcpServers == 1
+    assert "arn:ok1" in result.changed_mcp_runtime_arns
+    assert "arn:ok3" in result.changed_mcp_runtime_arns
+    assert "arn:bad" not in result.changed_mcp_runtime_arns
+    assert any("arn:bad" in msg for msg in result.summary.errorMessages)
+
+
+# ---------------------------------------------------------------------------
+# T2 – single A2A create failure, others persist
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_single_a2a_create_failure_others_persist(
+    federation_sync_service: FederationSyncService,
+):
+    federation_id = PydanticObjectId()
+    ok1 = SimpleNamespace(id=None, insert=AsyncMock(side_effect=lambda **kw: setattr(ok1, "id", PydanticObjectId())))
+    bad = SimpleNamespace(id=None, insert=AsyncMock(side_effect=Exception("timeout")))
+    ok3 = SimpleNamespace(id=None, insert=AsyncMock(side_effect=lambda **kw: setattr(ok3, "id", PydanticObjectId())))
+
+    from registry.services.federation_sync_service import FederationSyncPlan
+
+    sync_plan = FederationSyncPlan(
+        summary=FederationApplySummary(createdAgents=3),
+        federation_id=federation_id,
+        provider_type=FederationProviderType.AWS_AGENTCORE,
+        discovered_mcp_count=0,
+        discovered_a2a_count=3,
+        a2a_creates=[(ok1, "arn:a2a-ok1"), (bad, "arn:a2a-bad"), (ok3, "arn:a2a-ok3")],
+    )
+    federation_sync_service._get_federation_acl_entries = AsyncMock(return_value=([], True))
+
+    result = await federation_sync_service._apply_sync_plan(sync_plan)
+
+    assert result.summary.mongoApplyFailedAgents == 1
+    assert "arn:a2a-ok1" in result.changed_a2a_runtime_arns
+    assert "arn:a2a-ok3" in result.changed_a2a_runtime_arns
+    assert "arn:a2a-bad" not in result.changed_a2a_runtime_arns
+
+
+# ---------------------------------------------------------------------------
+# T3 – mixed-type failure isolation
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_mixed_type_failure_isolation(
+    federation_sync_service: FederationSyncService,
+):
+    federation_id = PydanticObjectId()
+
+    mcp_ok = SimpleNamespace(
+        id=None, insert=AsyncMock(side_effect=lambda **kw: setattr(mcp_ok, "id", PydanticObjectId()))
+    )
+    mcp_bad = SimpleNamespace(id=None, insert=AsyncMock(side_effect=Exception("mcp fail")))
+    a2a_ok = SimpleNamespace(
+        id=None, insert=AsyncMock(side_effect=lambda **kw: setattr(a2a_ok, "id", PydanticObjectId()))
+    )
+    a2a_bad = SimpleNamespace(id=None, insert=AsyncMock(side_effect=Exception("a2a fail")))
+
+    from registry.services.federation_sync_service import FederationSyncPlan
+
+    sync_plan = FederationSyncPlan(
+        summary=FederationApplySummary(createdMcpServers=2, createdAgents=2),
+        federation_id=federation_id,
+        provider_type=FederationProviderType.AWS_AGENTCORE,
+        discovered_mcp_count=2,
+        discovered_a2a_count=2,
+        mcp_creates=[(mcp_ok, "arn:mcp-ok"), (mcp_bad, "arn:mcp-bad")],
+        a2a_creates=[(a2a_ok, "arn:a2a-ok"), (a2a_bad, "arn:a2a-bad")],
+    )
+    federation_sync_service._get_federation_acl_entries = AsyncMock(return_value=([], True))
+
+    result = await federation_sync_service._apply_sync_plan(sync_plan)
+
+    assert result.summary.mongoApplyFailedMcpServers == 1
+    assert result.summary.mongoApplyFailedAgents == 1
+    assert "arn:mcp-ok" in result.changed_mcp_runtime_arns
+    assert "arn:a2a-ok" in result.changed_a2a_runtime_arns
+    assert len(result.summary.errorMessages) == 2
+
+
+# ---------------------------------------------------------------------------
+# T4 – update failure isolation
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_update_failure_isolation(
+    federation_sync_service: FederationSyncService,
+):
+    federation_id = PydanticObjectId()
+
+    existing_ok = SimpleNamespace(
+        id=PydanticObjectId(),
+        serverName="ok",
+        path="/ok",
+        tags=[],
+        config={},
+        numTools=1,
+        federationMetadata=None,
+        save=AsyncMock(),
+    )
+    update_ok = SimpleNamespace(
+        serverName="ok-v2",
+        path="/ok-v2",
+        tags=[],
+        config={},
+        numTools=2,
+        federationMetadata=None,
+    )
+    existing_bad = SimpleNamespace(
+        id=PydanticObjectId(),
+        serverName="bad",
+        path="/bad",
+        tags=[],
+        config={},
+        numTools=1,
+        federationMetadata=None,
+        save=AsyncMock(side_effect=Exception("save failed")),
+    )
+    update_bad = SimpleNamespace(
+        serverName="bad-v2",
+        path="/bad-v2",
+        tags=[],
+        config={},
+        numTools=3,
+        federationMetadata=None,
+    )
+
+    from registry.services.federation_sync_service import FederationSyncPlan
+
+    sync_plan = FederationSyncPlan(
+        summary=FederationApplySummary(updatedMcpServers=2),
+        federation_id=federation_id,
+        provider_type=FederationProviderType.AWS_AGENTCORE,
+        discovered_mcp_count=2,
+        discovered_a2a_count=0,
+        mcp_updates=[
+            (existing_ok, update_ok, "arn:ok"),
+            (existing_bad, update_bad, "arn:bad"),
+        ],
+    )
+    federation_sync_service._get_federation_acl_entries = AsyncMock(return_value=([], True))
+
+    result = await federation_sync_service._apply_sync_plan(sync_plan)
+
+    existing_ok.save.assert_awaited_once()
+    existing_bad.save.assert_awaited_once()
+    assert result.summary.mongoApplyFailedMcpServers == 1
+    assert "arn:ok" in result.changed_mcp_runtime_arns
+    assert "arn:bad" not in result.changed_mcp_runtime_arns
+
+
+# ---------------------------------------------------------------------------
+# T5 – delete failure isolation (does NOT increment mongoApplyFailed*)
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_delete_failure_isolation(
+    federation_sync_service: FederationSyncService,
+):
+    federation_id = PydanticObjectId()
+    stale_ok = SimpleNamespace(id=PydanticObjectId(), delete=AsyncMock())
+    stale_bad = SimpleNamespace(id=PydanticObjectId(), delete=AsyncMock(side_effect=Exception("delete failed")))
+
+    from registry.services.federation_sync_service import FederationSyncPlan
+
+    sync_plan = FederationSyncPlan(
+        summary=FederationApplySummary(deletedMcpServers=2),
+        federation_id=federation_id,
+        provider_type=FederationProviderType.AWS_AGENTCORE,
+        discovered_mcp_count=0,
+        discovered_a2a_count=0,
+        mcp_deletes=[(stale_ok, "arn:del-ok"), (stale_bad, "arn:del-bad")],
+    )
+    federation_sync_service._get_federation_acl_entries = AsyncMock(return_value=([], True))
+
+    result = await federation_sync_service._apply_sync_plan(sync_plan)
+
+    stale_ok.delete.assert_awaited_once()
+    stale_bad.delete.assert_awaited_once()
+    assert result.summary.mongoApplyFailedMcpServers == 0
+    assert result.summary.mongoApplyFailedAgents == 0
+    assert "arn:del-ok" in result.changed_mcp_runtime_arns
+    assert "arn:del-bad" not in result.changed_mcp_runtime_arns
+    assert any("arn:del-bad" in msg for msg in result.summary.errorMessages)
+
+
+# ---------------------------------------------------------------------------
+# T6 – failed resource not in changed_runtime_arns
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_failed_resource_not_in_changed_runtime_arns(
+    federation_sync_service: FederationSyncService,
+):
+    federation_id = PydanticObjectId()
+    bad_mcp = SimpleNamespace(id=None, insert=AsyncMock(side_effect=Exception("fail")))
+    bad_a2a = SimpleNamespace(id=None, insert=AsyncMock(side_effect=Exception("fail")))
+
+    from registry.services.federation_sync_service import FederationSyncPlan
+
+    sync_plan = FederationSyncPlan(
+        summary=FederationApplySummary(createdMcpServers=1, createdAgents=1),
+        federation_id=federation_id,
+        provider_type=FederationProviderType.AWS_AGENTCORE,
+        discovered_mcp_count=1,
+        discovered_a2a_count=1,
+        mcp_creates=[(bad_mcp, "arn:bad-mcp")],
+        a2a_creates=[(bad_a2a, "arn:bad-a2a")],
+    )
+    federation_sync_service._get_federation_acl_entries = AsyncMock(return_value=([], True))
+
+    result = await federation_sync_service._apply_sync_plan(sync_plan)
+
+    assert len(result.changed_mcp_runtime_arns) == 0
+    assert len(result.changed_a2a_runtime_arns) == 0
+    assert result.summary.mongoApplyFailedMcpServers == 1
+    assert result.summary.mongoApplyFailedAgents == 1
+
+
+# ---------------------------------------------------------------------------
+# T13 – bookkeeping transaction failure aborts entire run
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_bookkeeping_failure_aborts_whole_run(
+    federation_sync_service: FederationSyncService,
+    monkeypatch,
+):
+    federation = _make_federation(FederationProviderType.AWS_AGENTCORE, {"region": "us-east-1"})
+    job = SimpleNamespace(
+        id=PydanticObjectId(),
+        jobType="full_sync",
+        startedAt=datetime.now(UTC),
+        discoverySummary=SimpleNamespace(discoveredMcpServers=0, discoveredAgents=0),
+    )
+
+    federation_sync_service._discover_entities = AsyncMock(return_value={"mcp_servers": [], "a2a_agents": []})
+    federation_sync_service._commit_bookkeeping_transaction = AsyncMock(side_effect=RuntimeError("mark_syncing failed"))
+    federation_sync_service._apply_sync_plan = AsyncMock()
+    federation_sync_service.federation_job_service.mark_failed = AsyncMock()
+    federation_sync_service.federation_crud_service.mark_sync_failed = AsyncMock()
+    _patch_mongo_session(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="mark_syncing failed"):
+        await federation_sync_service.run_sync(federation=federation, job=job, author_id=_DEFAULT_USER_OBJECT_ID)
+
+    federation_sync_service._apply_sync_plan.assert_not_awaited()


### PR DESCRIPTION
## Summary
Isolate per-resource failures in federation sync's Mongo-apply stage (AS-1768).
Previously, all resource writes shared one MongoDB transaction — a single resource failure rolled back the entire batch. Now each resource write is independent, matching the isolation the vector-sync stage already provides via `VectorSyncOutcome`.
- Narrow the transaction to bookkeeping only (`_commit_sync_transaction` → `_commit_bookkeeping_transaction`)
- Per-resource try/except in all 6 `_apply_sync_plan` loops
- New `mongoApplyFailedMcpServers` / `mongoApplyFailedAgents` counters, netted into `imported_total`
- ACL query and inheritance failures degrade gracefully instead of raising `RuntimeError`
## Differences From the Spec
| Spec | Implementation | Reason |
|------|---------------|--------|
| ACL query failure raises `RuntimeError` | Degrades to empty ACL list | Otherwise blocks all resource writes, contradicting isolation goal |
| ACL inheritance failure not addressed | Catches and continues | Resources already persisted; ACL self-heals on next sync |
| Delete failures increment `mongoApplyFailed*` | Does NOT increment | Deletes aren't in `imported_total`; incrementing would incorrectly reduce it |