### PR TITLE
Feature/as 1766 Restrict direct-connect A2A routes to trusted tokens

### DIFF
--- a/registry/src/registry/api/proxy_routes.py
+++ b/registry/src/registry/api/proxy_routes.py
@@ -50,6 +50,14 @@ router = APIRouter(tags=["MCP Proxy"])
 
 _DIRECT_CONNECT_A2A_TOKEN_REQUIREMENT = "A2A invocation requires a token generated from the Jarvis Registry frontend."
 
+# A2A v0.3.x reserves -32001 through -32006 for its own error types (TaskNotFoundError,
+# TaskNotCancelableError, PushNotificationNotSupportedError, UnsupportedOperationError,
+# ContentTypeNotSupportedError, InvalidAgentResponseError) -- none of which mean "access
+# denied". This is a Jarvis-Registry-specific denial code within JSON-RPC 2.0's
+# implementation-defined server-error range (-32000 to -32099), chosen to avoid colliding
+# with any A2A-reserved type.
+_A2A_ACCESS_DENIED_ERROR_CODE = -32007
+
 
 async def _parse_json_rpc_body(request: Request) -> dict[str, Any] | None:
     """
@@ -588,7 +596,7 @@ async def jsonrpc_proxy(
         client_id = user_context.get("client_id", "")
         if not is_direct_connect_a2a_client(client_id, settings.headless_agent_client_id):
             return _jsonrpc_a2a_error_response(
-                -32001,
+                _A2A_ACCESS_DENIED_ERROR_CODE,
                 f"Access denied: direct-connect {_DIRECT_CONNECT_A2A_TOKEN_REQUIREMENT}",
             )
 
@@ -604,7 +612,9 @@ async def jsonrpc_proxy(
                 required_permission="VIEW",
             )
         except HTTPException:
-            return _jsonrpc_a2a_error_response(-32001, f"Access denied to A2A agent '{agent_path}'")
+            return _jsonrpc_a2a_error_response(
+                _A2A_ACCESS_DENIED_ERROR_CODE, f"Access denied to A2A agent '{agent_path}'"
+            )
 
         if not (agent.config and agent.config.enabled):
             return _jsonrpc_a2a_error_response(-32004, f"A2A agent '{agent_path}' is disabled")

--- a/registry/src/registry/api/proxy_routes.py
+++ b/registry/src/registry/api/proxy_routes.py
@@ -40,13 +40,15 @@ from ..mcpgw.tools.utils import build_authenticated_headers, get_target_url, par
 from ..services.a2a_agent_service import A2AAgentService
 from ..services.access_control_service import ACLService
 from ..services.federation.a2a_client_registry import A2AClientRegistry
-from ..services.generated_token_policy import is_consent_exempt
+from ..services.generated_token_policy import is_consent_exempt, is_direct_connect_a2a_client
 from ..services.oauth.oauth_service import MCPOAuthService
 from ..services.server_service import ServerServiceV1
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["MCP Proxy"])
+
+_DIRECT_CONNECT_A2A_TOKEN_REQUIREMENT = "A2A invocation requires a token generated from the Jarvis Registry frontend."
 
 
 async def _parse_json_rpc_body(request: Request) -> dict[str, Any] | None:
@@ -583,6 +585,12 @@ async def jsonrpc_proxy(
 ):
     try:
         user_id = user_context.get("user_id")
+        client_id = user_context.get("client_id", "")
+        if not is_direct_connect_a2a_client(client_id, settings.headless_agent_client_id):
+            return _jsonrpc_a2a_error_response(
+                -32001,
+                f"Access denied: direct-connect {_DIRECT_CONNECT_A2A_TOKEN_REQUIREMENT}",
+            )
 
         agent = await a2a_agent_service.get_agent_by_path(agent_path)
         if agent is None:
@@ -634,7 +642,7 @@ async def jsonrpc_proxy(
 
 
 # Route 2: HTTP+JSON binding — all paths with at least one segment
-@router.route("/a2a/{agent_path}/{http_json_path:path}", methods=["GET", "POST", "DELETE", "PUT"])
+@router.api_route("/a2a/{agent_path}/{http_json_path:path}", methods=["GET", "POST", "DELETE", "PUT"])
 async def http_json_proxy(
     request: Request,
     agent_path: str,
@@ -646,6 +654,12 @@ async def http_json_proxy(
 ):
     try:
         user_id = user_context.get("user_id")
+        client_id = user_context.get("client_id", "")
+        if not is_direct_connect_a2a_client(client_id, settings.headless_agent_client_id):
+            return JSONResponse(
+                status_code=403,
+                content={"error": f"Direct-connect {_DIRECT_CONNECT_A2A_TOKEN_REQUIREMENT}"},
+            )
 
         agent = await a2a_agent_service.get_agent_by_path(agent_path)
         if agent is None:

--- a/registry/src/registry/services/generated_token_policy.py
+++ b/registry/src/registry/services/generated_token_policy.py
@@ -27,3 +27,16 @@ def is_consent_exempt(
 ) -> bool:
     """Return whether a client ID is exempt from per-resource consent."""
     return client_id == headless_agent_client_id
+
+
+def is_direct_connect_a2a_client(
+    client_id: str,
+    headless_agent_client_id: str,
+) -> bool:
+    """Return whether a client ID may use the direct-connect A2A proxy routes.
+
+    Both allowed client IDs are issued only through the authenticated Registry token-vending
+    endpoint, not through Dynamic Client Registration. Other clients are denied because the
+    direct-connect A2A routes do not have a per-agent consent fallback.
+    """
+    return client_id in {headless_agent_client_id, INTERACTIVE_CLIENT_ID}

--- a/registry/tests/integration/test_a2a_proxy_auth.py
+++ b/registry/tests/integration/test_a2a_proxy_auth.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
-from registry.api.proxy_routes import router
+from registry.api.proxy_routes import _A2A_ACCESS_DENIED_ERROR_CODE, router
 from registry.core.config import settings
 from registry.deps import get_a2a_agent_service, get_a2a_client_registry, get_acl_service
 from registry.middleware.auth import UnifiedAuthMiddleware
@@ -57,7 +57,7 @@ def test_valid_dcr_jwt_is_denied_by_jsonrpc_a2a_route(a2a_proxy_context: SimpleN
     )
 
     assert response.status_code == 200
-    assert response.json()["error"]["code"] == -32001
+    assert response.json()["error"]["code"] == _A2A_ACCESS_DENIED_ERROR_CODE
     a2a_proxy_context.agent_service.get_agent_by_path.assert_not_awaited()
 
 

--- a/registry/tests/integration/test_a2a_proxy_auth.py
+++ b/registry/tests/integration/test_a2a_proxy_auth.py
@@ -1,0 +1,72 @@
+"""Integration coverage for A2A direct-connect authentication policy."""
+
+from collections.abc import Generator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from registry.api.proxy_routes import router
+from registry.core.config import settings
+from registry.deps import get_a2a_agent_service, get_a2a_client_registry, get_acl_service
+from registry.middleware.auth import UnifiedAuthMiddleware
+from registry_pkgs.core.jwt_tokens import mint_managed_agent_token
+
+pytestmark = [pytest.mark.integration, pytest.mark.auth, pytest.mark.proxy]
+
+_DCR_CLIENT_ID = "mcp-client-integration-test"
+_USER_ID = "507f1f77bcf86cd799439011"
+
+
+def _mint_dcr_managed_agent_token() -> str:
+    return mint_managed_agent_token(
+        settings.jwt_token_config,
+        subject="integration-user",
+        client_id=_DCR_CLIENT_ID,
+        expires_in_seconds=3600,
+        extra_claims={
+            "user_id": _USER_ID,
+            "scope": "a2a-proxy-ops",
+        },
+    )
+
+
+@pytest.fixture
+def a2a_proxy_context() -> Generator[SimpleNamespace, None, None]:
+    app = FastAPI()
+    app.add_middleware(UnifiedAuthMiddleware)
+    app.include_router(router, prefix="/proxy")
+
+    agent_service = SimpleNamespace(get_agent_by_path=AsyncMock())
+    app.dependency_overrides[get_a2a_agent_service] = lambda: agent_service
+    app.dependency_overrides[get_acl_service] = lambda: AsyncMock()
+    app.dependency_overrides[get_a2a_client_registry] = lambda: AsyncMock()
+
+    with TestClient(app) as client:
+        yield SimpleNamespace(client=client, agent_service=agent_service)
+
+
+def test_valid_dcr_jwt_is_denied_by_jsonrpc_a2a_route(a2a_proxy_context: SimpleNamespace) -> None:
+    response = a2a_proxy_context.client.post(
+        "/proxy/a2a/test-agent",
+        headers={"Authorization": f"Bearer {_mint_dcr_managed_agent_token()}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == -32001
+    a2a_proxy_context.agent_service.get_agent_by_path.assert_not_awaited()
+
+
+def test_valid_dcr_jwt_is_denied_by_http_json_a2a_route(a2a_proxy_context: SimpleNamespace) -> None:
+    response = a2a_proxy_context.client.get(
+        "/proxy/a2a/test-agent/tasks/1",
+        headers={"Authorization": f"Bearer {_mint_dcr_managed_agent_token()}"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "error": "Direct-connect A2A invocation requires a token generated from the Jarvis Registry frontend."
+    }
+    a2a_proxy_context.agent_service.get_agent_by_path.assert_not_awaited()

--- a/registry/tests/integration/test_a2a_proxy_auth.py
+++ b/registry/tests/integration/test_a2a_proxy_auth.py
@@ -6,12 +6,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
 from registry.api.proxy_routes import router
 from registry.core.config import settings
 from registry.deps import get_a2a_agent_service, get_a2a_client_registry, get_acl_service
 from registry.middleware.auth import UnifiedAuthMiddleware
+from registry.services.generated_token_policy import INTERACTIVE_CLIENT_ID
 from registry_pkgs.core.jwt_tokens import mint_managed_agent_token
 
 pytestmark = [pytest.mark.integration, pytest.mark.auth, pytest.mark.proxy]
@@ -20,11 +22,11 @@ _DCR_CLIENT_ID = "mcp-client-integration-test"
 _USER_ID = "507f1f77bcf86cd799439011"
 
 
-def _mint_dcr_managed_agent_token() -> str:
+def _mint_managed_agent_token(client_id: str) -> str:
     return mint_managed_agent_token(
         settings.jwt_token_config,
         subject="integration-user",
-        client_id=_DCR_CLIENT_ID,
+        client_id=client_id,
         expires_in_seconds=3600,
         extra_claims={
             "user_id": _USER_ID,
@@ -51,7 +53,7 @@ def a2a_proxy_context() -> Generator[SimpleNamespace, None, None]:
 def test_valid_dcr_jwt_is_denied_by_jsonrpc_a2a_route(a2a_proxy_context: SimpleNamespace) -> None:
     response = a2a_proxy_context.client.post(
         "/proxy/a2a/test-agent",
-        headers={"Authorization": f"Bearer {_mint_dcr_managed_agent_token()}"},
+        headers={"Authorization": f"Bearer {_mint_managed_agent_token(_DCR_CLIENT_ID)}"},
     )
 
     assert response.status_code == 200
@@ -62,7 +64,7 @@ def test_valid_dcr_jwt_is_denied_by_jsonrpc_a2a_route(a2a_proxy_context: SimpleN
 def test_valid_dcr_jwt_is_denied_by_http_json_a2a_route(a2a_proxy_context: SimpleNamespace) -> None:
     response = a2a_proxy_context.client.get(
         "/proxy/a2a/test-agent/tasks/1",
-        headers={"Authorization": f"Bearer {_mint_dcr_managed_agent_token()}"},
+        headers={"Authorization": f"Bearer {_mint_managed_agent_token(_DCR_CLIENT_ID)}"},
     )
 
     assert response.status_code == 403
@@ -70,3 +72,59 @@ def test_valid_dcr_jwt_is_denied_by_http_json_a2a_route(a2a_proxy_context: Simpl
         "error": "Direct-connect A2A invocation requires a token generated from the Jarvis Registry frontend."
     }
     a2a_proxy_context.agent_service.get_agent_by_path.assert_not_awaited()
+
+
+@pytest.mark.parametrize("client_id", [INTERACTIVE_CLIENT_ID, settings.headless_agent_client_id])
+def test_allowed_client_reaches_agent_lookup_via_jsonrpc_a2a_route(
+    a2a_proxy_context: SimpleNamespace, client_id: str
+) -> None:
+    """An allowlisted client_id must pass the gate through the real routing/DI stack.
+
+    This is the regression guard for the `@router.route` -> `@router.api_route` fix: under
+    the old decorator, FastAPI's dependency injection never ran, so `user_context`, `agent_path`,
+    and the `Depends(...)` services were never bound and the request 500'd before reaching here.
+    """
+    a2a_proxy_context.agent_service.get_agent_by_path.return_value = None
+
+    response = a2a_proxy_context.client.post(
+        "/proxy/a2a/test-agent",
+        headers={"Authorization": f"Bearer {_mint_managed_agent_token(client_id)}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == -32603
+    a2a_proxy_context.agent_service.get_agent_by_path.assert_awaited_once_with("test-agent")
+
+
+@pytest.mark.parametrize("client_id", [INTERACTIVE_CLIENT_ID, settings.headless_agent_client_id])
+def test_allowed_client_reaches_agent_lookup_via_http_json_a2a_route(
+    a2a_proxy_context: SimpleNamespace, client_id: str
+) -> None:
+    """An allowlisted client_id must pass the gate through the real routing/DI stack.
+
+    This is the regression guard for the `@router.route` -> `@router.api_route` fix: under
+    the old decorator, FastAPI's dependency injection never ran, so `user_context`, `agent_path`,
+    `http_json_path`, and the `Depends(...)` services were never bound and the request 500'd
+    before reaching here.
+    """
+    a2a_proxy_context.agent_service.get_agent_by_path.return_value = None
+
+    response = a2a_proxy_context.client.get(
+        "/proxy/a2a/test-agent/tasks/1",
+        headers={"Authorization": f"Bearer {_mint_managed_agent_token(client_id)}"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"error": "A2A agent with path 'test-agent' not found"}
+    a2a_proxy_context.agent_service.get_agent_by_path.assert_awaited_once_with("test-agent")
+
+
+def test_http_json_proxy_route_is_registered_as_api_route() -> None:
+    """Pins the exact defect class that broke this route: a plain Starlette `Route`
+
+    (from `@router.route`) bypasses FastAPI's dependency-injection layer entirely, so a
+    future revert of the `@router.api_route` decorator would silently break every real
+    request to this endpoint without any Python-level error at import time.
+    """
+    route = next(r for r in router.routes if getattr(r, "path", None) == "/a2a/{agent_path}/{http_json_path:path}")
+    assert isinstance(route, APIRoute)

--- a/registry/tests/unit/api/test_proxy_routes.py
+++ b/registry/tests/unit/api/test_proxy_routes.py
@@ -15,7 +15,13 @@ from beanie import PydanticObjectId
 from fastapi import HTTPException
 from starlette.requests import Request
 
-from registry.api.proxy_routes import dynamic_mcp_get_proxy, dynamic_mcp_post_proxy, http_json_proxy, jsonrpc_proxy
+from registry.api.proxy_routes import (
+    _A2A_ACCESS_DENIED_ERROR_CODE,
+    dynamic_mcp_get_proxy,
+    dynamic_mcp_post_proxy,
+    http_json_proxy,
+    jsonrpc_proxy,
+)
 from registry.core.config import settings
 from registry.services.generated_token_policy import INTERACTIVE_CLIENT_ID
 from registry_pkgs.testing.federation_metadata import make_azure_foundry_metadata
@@ -422,7 +428,7 @@ async def test_jsonrpc_proxy_rejects_disallowed_client_before_agent_lookup(clien
 
     body = json.loads(response.body)
     assert response.status_code == 200
-    assert body["error"]["code"] == -32001
+    assert body["error"]["code"] == _A2A_ACCESS_DENIED_ERROR_CODE
     assert "token generated from the Jarvis Registry frontend" in body["error"]["message"]
     a2a_agent_service.get_agent_by_path.assert_not_awaited()
 

--- a/registry/tests/unit/api/test_proxy_routes.py
+++ b/registry/tests/unit/api/test_proxy_routes.py
@@ -23,7 +23,12 @@ from registry_pkgs.testing.federation_metadata import make_azure_foundry_metadat
 VALID_OBJECT_ID = "507f1f77bcf86cd799439011"
 INVALID_USER_IDS = ["mcpgw", "not-an-objectid", "123", ""]
 
-_AUTH_CONTEXT = {"auth_method": "bearer", "user_id": VALID_OBJECT_ID, "username": "test", "client_id": "claude"}
+_AUTH_CONTEXT = {
+    "auth_method": "bearer",
+    "user_id": VALID_OBJECT_ID,
+    "username": "test",
+    "client_id": INTERACTIVE_CLIENT_ID,
+}
 
 
 def _make_server(*, enabled: bool = True):
@@ -397,7 +402,60 @@ async def test_get_proxy_acl_allowed_continues():
     assert "disabled" in body["detail"].lower()
 
 
-async def test_jsonrpc_proxy_gets_client_from_a2a_client_registry(monkeypatch):
+@pytest.mark.parametrize("client_id", ["mcp-client-dcr", None], ids=["dcr-client", "missing-client-id"])
+async def test_jsonrpc_proxy_rejects_disallowed_client_before_agent_lookup(client_id):
+    a2a_agent_service = SimpleNamespace(get_agent_by_path=AsyncMock())
+    user_context = dict(_AUTH_CONTEXT)
+    if client_id is None:
+        user_context.pop("client_id")
+    else:
+        user_context["client_id"] = client_id
+
+    response = await jsonrpc_proxy(
+        request=_a2a_request(),
+        agent_path="test-agent",
+        user_context=user_context,
+        a2a_agent_service=a2a_agent_service,
+        acl_service=AsyncMock(),
+        a2a_client_registry=AsyncMock(),
+    )
+
+    body = json.loads(response.body)
+    assert response.status_code == 200
+    assert body["error"]["code"] == -32001
+    assert "token generated from the Jarvis Registry frontend" in body["error"]["message"]
+    a2a_agent_service.get_agent_by_path.assert_not_awaited()
+
+
+@pytest.mark.parametrize("client_id", ["mcp-client-dcr", None], ids=["dcr-client", "missing-client-id"])
+async def test_http_json_proxy_rejects_disallowed_client_before_agent_lookup(client_id):
+    a2a_agent_service = SimpleNamespace(get_agent_by_path=AsyncMock())
+    user_context = dict(_AUTH_CONTEXT)
+    if client_id is None:
+        user_context.pop("client_id")
+    else:
+        user_context["client_id"] = client_id
+
+    response = await http_json_proxy(
+        request=_a2a_request(method="GET"),
+        agent_path="test-agent",
+        http_json_path="tasks/1",
+        user_context=user_context,
+        a2a_agent_service=a2a_agent_service,
+        acl_service=AsyncMock(),
+        a2a_client_registry=AsyncMock(),
+    )
+
+    body = json.loads(response.body)
+    assert response.status_code == 403
+    assert body == {
+        "error": "Direct-connect A2A invocation requires a token generated from the Jarvis Registry frontend."
+    }
+    a2a_agent_service.get_agent_by_path.assert_not_awaited()
+
+
+@pytest.mark.parametrize("client_id", [INTERACTIVE_CLIENT_ID, settings.headless_agent_client_id])
+async def test_jsonrpc_proxy_gets_client_from_a2a_client_registry(monkeypatch, client_id):
     agent = _a2a_agent()
     proxy_client = Mock()
     registry = SimpleNamespace(get_client=AsyncMock(return_value=proxy_client))
@@ -410,7 +468,7 @@ async def test_jsonrpc_proxy_gets_client_from_a2a_client_registry(monkeypatch):
     response = await jsonrpc_proxy(
         request=request,
         agent_path="test-agent",
-        user_context=_AUTH_CONTEXT,
+        user_context={**_AUTH_CONTEXT, "client_id": client_id},
         a2a_agent_service=a2a_agent_service,
         acl_service=acl_service,
         a2a_client_registry=registry,
@@ -423,7 +481,8 @@ async def test_jsonrpc_proxy_gets_client_from_a2a_client_registry(monkeypatch):
     )
 
 
-async def test_http_json_proxy_gets_client_from_a2a_client_registry(monkeypatch):
+@pytest.mark.parametrize("client_id", [INTERACTIVE_CLIENT_ID, settings.headless_agent_client_id])
+async def test_http_json_proxy_gets_client_from_a2a_client_registry(monkeypatch, client_id):
     agent = _a2a_agent()
     proxy_client = Mock()
     registry = SimpleNamespace(get_client=AsyncMock(return_value=proxy_client))
@@ -437,7 +496,7 @@ async def test_http_json_proxy_gets_client_from_a2a_client_registry(monkeypatch)
         request=request,
         agent_path="test-agent",
         http_json_path="tasks/1",
-        user_context=_AUTH_CONTEXT,
+        user_context={**_AUTH_CONTEXT, "client_id": client_id},
         a2a_agent_service=a2a_agent_service,
         acl_service=acl_service,
         a2a_client_registry=registry,

--- a/registry/tests/unit/services/test_generated_token_policy.py
+++ b/registry/tests/unit/services/test_generated_token_policy.py
@@ -8,6 +8,7 @@ from registry.schemas.enums import TokenPurpose
 from registry.services.generated_token_policy import (
     INTERACTIVE_CLIENT_ID,
     is_consent_exempt,
+    is_direct_connect_a2a_client,
     resolve_generated_token_client_id,
 )
 
@@ -43,3 +44,16 @@ def test_resolve_generated_token_client_id_rejects_unsupported_purpose() -> None
 )
 def test_is_consent_exempt(client_id: str, expected: bool) -> None:
     assert is_consent_exempt(client_id, HEADLESS_CLIENT_ID) is expected
+
+
+@pytest.mark.parametrize(
+    ("client_id", "expected"),
+    [
+        (HEADLESS_CLIENT_ID, True),
+        (INTERACTIVE_CLIENT_ID, True),
+        ("mcp-client-dcr", False),
+        ("", False),
+    ],
+)
+def test_is_direct_connect_a2a_client(client_id: str, expected: bool) -> None:
+    assert is_direct_connect_a2a_client(client_id, HEADLESS_CLIENT_ID) is expected

--- a/tartufo.toml
+++ b/tartufo.toml
@@ -113,6 +113,7 @@ exclude-signatures = [
     {signature = '700d7ed412cc29e96f8284e1e7d823e48e6f80142aad1e871f94ca0113a09121', reason = 'mock data in unit test is not a credential'},
     {signature = 'f9329ddc08f69ab3da79578b91862ae069388567b5e0f94c6b33caaf540af8c2', reason = 'mock data in unit test is not a credential'},
     {signature = '6be613b7517f357707f5adae872a41d98daf0812fea5fd15f9478adaafd2b7cc', reason = 'mock data in unit test is not a credential'},
+    {signature = '5c5484e2aced53bfaba206793049b6928c58e48519ac5f56b89b91771e3f2af7', reason = 'mock data in unit test is not a credential'},
     {signature = '8fed1a3d0f078928095f3ab51a563f8e1b10af0211c83234e293e68d984518f8', reason = 'synthetic MongoDB ObjectId in ACL service unit test is not a credential'},
     {signature = '5c38ca1f84a2bb4b3e45b8dfbfb6947105bfe70097a296ee8935649426f42cb7', reason = 'synthetic MongoDB ObjectId in ACL service unit test is not a credential'},
     {signature = 'e206fce8281466ff2e83634ed64c54b2f0c0229c413cc76ebc68685076112b20', reason = 'synthetic MongoDB ObjectId in search service unit test is not a credential'},


### PR DESCRIPTION
Reject DCR clients before agent lookup to prevent unauthorized invocation and agent discovery