### PR TITLE
Feature/as 1616 Serve public managed agent cards for A2A agents

### DIFF
--- a/registry/src/registry/api/proxy_routes.py
+++ b/registry/src/registry/api/proxy_routes.py
@@ -18,6 +18,7 @@ from redis import Redis
 
 from registry_pkgs.core.consent_store import ConsentStore, PendingConsentStore
 from registry_pkgs.models import ResourceType
+from registry_pkgs.models.a2a_agent import NoSupportedTransportError
 from registry_pkgs.models.enums import AgentCoreRuntimeAccessMode
 from registry_pkgs.models.extended_mcp_server import ExtendedMCPServer
 
@@ -49,6 +50,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["MCP Proxy"])
 
 _DIRECT_CONNECT_A2A_TOKEN_REQUIREMENT = "A2A invocation requires a token generated from the Jarvis Registry frontend."
+_MANAGED_AGENT_CARD_NOT_FOUND_DETAIL = "A2A agent not found"
 
 # A2A v0.3.x reserves -32001 through -32006 for its own error types (TaskNotFoundError,
 # TaskNotCancelableError, PushNotificationNotSupportedError, UnsupportedOperationError,
@@ -466,6 +468,34 @@ def _jsonrpc_a2a_error_response(code: int, message: str) -> JSONResponse:
     )
 
 
+async def _serve_managed_agent_card(
+    agent_path: str,
+    a2a_agent_service: A2AAgentService,
+) -> JSONResponse:
+    """Return the public Registry-managed Agent Card for an enabled agent."""
+    try:
+        agent = await a2a_agent_service.get_agent_by_path(agent_path)
+        if agent is None or agent.config is None or not agent.config.enabled:
+            return JSONResponse(
+                status_code=404,
+                content={"detail": _MANAGED_AGENT_CARD_NOT_FOUND_DETAIL},
+            )
+
+        return JSONResponse(
+            status_code=200,
+            content=a2a_agent_service.build_managed_agent_card(agent),
+        )
+    except NoSupportedTransportError:
+        logger.exception("Managed Agent Card has no supported transport: agent=%s", agent_path)
+    except Exception:
+        logger.exception("Failed to serve managed Agent Card: agent=%s", agent_path)
+
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal server error"},
+    )
+
+
 async def _forward_a2a(
     request: Request,
     target_url: str,
@@ -649,6 +679,24 @@ async def jsonrpc_proxy(
     except Exception:
         logger.exception(f"Unexpected error in jsonrpc_proxy for agent [{agent_path}]")
         return _jsonrpc_a2a_error_response(-32603, "Internal server error")
+
+
+@router.get("/a2a/{agent_path}/agent-card.json")
+async def managed_agent_card(
+    agent_path: str,
+    a2a_agent_service: A2AAgentService = Depends(get_a2a_agent_service),
+) -> JSONResponse:
+    """Serve the primary public managed Agent Card endpoint."""
+    return await _serve_managed_agent_card(agent_path, a2a_agent_service)
+
+
+@router.get("/a2a/{agent_path}/.well-known/agent-card.json")
+async def managed_agent_card_well_known_alias(
+    agent_path: str,
+    a2a_agent_service: A2AAgentService = Depends(get_a2a_agent_service),
+) -> JSONResponse:
+    """Serve the SDK-compatible managed Agent Card alias."""
+    return await _serve_managed_agent_card(agent_path, a2a_agent_service)
 
 
 # Route 2: HTTP+JSON binding — all paths with at least one segment

--- a/registry/src/registry/api/proxy_routes.py
+++ b/registry/src/registry/api/proxy_routes.py
@@ -41,7 +41,7 @@ from ..mcpgw.tools.utils import build_authenticated_headers, get_target_url, par
 from ..services.a2a_agent_service import A2AAgentService
 from ..services.access_control_service import ACLService
 from ..services.federation.a2a_client_registry import A2AClientRegistry
-from ..services.generated_token_policy import is_consent_exempt, is_direct_connect_a2a_client
+from ..services.generated_token_policy import is_consent_exempt
 from ..services.oauth.oauth_service import MCPOAuthService
 from ..services.server_service import ServerServiceV1
 
@@ -49,7 +49,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["MCP Proxy"])
 
-_DIRECT_CONNECT_A2A_TOKEN_REQUIREMENT = "A2A invocation requires a token generated from the Jarvis Registry frontend."
 _MANAGED_AGENT_CARD_NOT_FOUND_DETAIL = "A2A agent not found"
 
 # A2A v0.3.x reserves -32001 through -32006 for its own error types (TaskNotFoundError,
@@ -623,13 +622,6 @@ async def jsonrpc_proxy(
 ):
     try:
         user_id = user_context.get("user_id")
-        client_id = user_context.get("client_id", "")
-        if not is_direct_connect_a2a_client(client_id, settings.headless_agent_client_id):
-            return _jsonrpc_a2a_error_response(
-                _A2A_ACCESS_DENIED_ERROR_CODE,
-                f"Access denied: direct-connect {_DIRECT_CONNECT_A2A_TOKEN_REQUIREMENT}",
-            )
-
         agent = await a2a_agent_service.get_agent_by_path(agent_path)
         if agent is None:
             return _jsonrpc_a2a_error_response(-32603, f"A2A agent with path '{agent_path}' not found")
@@ -712,13 +704,6 @@ async def http_json_proxy(
 ):
     try:
         user_id = user_context.get("user_id")
-        client_id = user_context.get("client_id", "")
-        if not is_direct_connect_a2a_client(client_id, settings.headless_agent_client_id):
-            return JSONResponse(
-                status_code=403,
-                content={"error": f"Direct-connect {_DIRECT_CONNECT_A2A_TOKEN_REQUIREMENT}"},
-            )
-
         agent = await a2a_agent_service.get_agent_by_path(agent_path)
         if agent is None:
             return JSONResponse(status_code=404, content={"error": f"A2A agent with path '{agent_path}' not found"})

--- a/registry/src/registry/middleware/auth.py
+++ b/registry/src/registry/middleware/auth.py
@@ -79,6 +79,8 @@ class UnifiedAuthMiddleware:
                 f"/api/{settings.api_version}/mcp/downstream/oauth/device/{{user_id}}/{{server_path:path}}",
                 f"/api/{settings.api_version}/mcp/downstream/oauth/token/{{user_id}}/{{server_path:path}}",
                 f"/api/{settings.api_version}/mcp/consent/device/resolve",
+                "/proxy/a2a/{agent_path}/agent-card.json",
+                "/proxy/a2a/{agent_path}/.well-known/agent-card.json",
                 "/.well-known/{path:path}",  # OAuth discovery endpoints must be public
             ]
         )

--- a/registry/src/registry/services/a2a_agent_service.py
+++ b/registry/src/registry/services/a2a_agent_service.py
@@ -489,7 +489,7 @@ class A2AAgentService:
         """Build an ephemeral Agent Card that advertises the Registry proxy and OAuth."""
         managed_card = agent.card.model_dump(mode="json", by_alias=True, exclude_none=True)
         preferred_transport, additional_interfaces = strip_grpc_and_select_preferred_transport(agent.card)
-        base_url = f"{settings.jwt_issuer}{settings.service_base_path}/proxy/a2a/{agent.path}"
+        base_url = f"{settings.registry_url}/proxy/a2a/{agent.path}"
         security_schemes, security = _build_managed_agent_security()
 
         managed_card["preferredTransport"] = preferred_transport

--- a/registry/src/registry/services/a2a_agent_service.py
+++ b/registry/src/registry/services/a2a_agent_service.py
@@ -26,24 +26,52 @@ from registry.core.exceptions import (
 )
 from registry.services.federation.azure_foundry_auth import AzureFoundryAuthService
 from registry_pkgs.core.config import JwtSigningConfig
-from registry_pkgs.models.a2a_agent import A2AAgent, AgentConfig, normalize_a2a_agent_path
+from registry_pkgs.models.a2a_agent import (
+    A2AAgent,
+    AgentConfig,
+    normalize_a2a_agent_path,
+    strip_grpc_and_select_preferred_transport,
+)
 from registry_pkgs.models.enums import FederationProviderType
 from registry_pkgs.models.federation import AzureAiFoundryProviderConfig, Federation
 from registry_pkgs.models.federation_metadata import AzureFoundryFederationMetadata
 from registry_pkgs.vector.repositories.a2a_agent_repository import A2AAgentRepository
 from registry_pkgs.workflows.a2a_client import build_headers, is_azure_foundry_runtime
 
+from ..core.config import settings
 from ..schemas.a2a_agent_api_schemas import AgentCreateRequest, AgentUpdateRequest
 
 logger = logging.getLogger(__name__)
 
 
 _WELL_KNOWN_SUFFIX_RE = re.compile(r"/\.well-known(/.*)?$")
+_A2A_PROXY_SCOPE = "a2a-proxy-ops"
+_A2A_PROXY_SCOPE_DESCRIPTION = "Invoke managed A2A agents via the Jarvis Registry proxy"
 
 
 def _normalize_config_url(url: str) -> str:
     """Strip trailing slash and any terminal /.well-known/... suffix from a URL."""
     return _WELL_KNOWN_SUFFIX_RE.sub("", url.rstrip("/"))
+
+
+def _build_managed_agent_security() -> tuple[dict[str, Any], list[dict[str, list[str]]]]:
+    """Build the Registry OAuth requirements advertised by managed agent cards."""
+    token_url = f"{settings.auth_server_external_url}/oauth2/token"
+    security_schemes = {
+        "oauth2": {
+            "type": "oauth2",
+            "flows": {
+                "authorizationCode": {
+                    "authorizationUrl": (f"{settings.auth_server_external_url}/oauth2/login/{settings.auth_provider}"),
+                    "tokenUrl": token_url,
+                    "refreshUrl": token_url,
+                    "scopes": {_A2A_PROXY_SCOPE: _A2A_PROXY_SCOPE_DESCRIPTION},
+                }
+            },
+            "oauth2MetadataUrl": f"{settings.jwt_issuer}/.well-known/oauth-authorization-server",
+        }
+    }
+    return security_schemes, [{"oauth2": [_A2A_PROXY_SCOPE]}]
 
 
 class A2AAgentService:
@@ -456,6 +484,35 @@ class A2AAgentService:
             Agent document, or None if not found
         """
         return await A2AAgent.find_one({"path": path})
+
+    def build_managed_agent_card(self, agent: A2AAgent) -> dict[str, Any]:
+        """Build an ephemeral Agent Card that advertises the Registry proxy and OAuth."""
+        managed_card = agent.card.model_dump(mode="json", by_alias=True, exclude_none=True)
+        preferred_transport, additional_interfaces = strip_grpc_and_select_preferred_transport(agent.card)
+        base_url = f"{settings.jwt_issuer}{settings.service_base_path}/proxy/a2a/{agent.path}"
+        security_schemes, security = _build_managed_agent_security()
+
+        managed_card["preferredTransport"] = preferred_transport
+        managed_card["url"] = base_url
+        managed_card["additionalInterfaces"] = [
+            {
+                **interface.model_dump(mode="json", by_alias=True, exclude_none=True),
+                "url": base_url,
+            }
+            for interface in additional_interfaces
+        ]
+        managed_card["supportsAuthenticatedExtendedCard"] = False
+        managed_card["securitySchemes"] = security_schemes
+        managed_card["security"] = security
+        managed_card.pop("signatures", None)
+
+        for skill in managed_card.get("skills", []):
+            skill.pop("security", None)
+
+        config = agent.config
+        managed_card["name"] = config.title if config and config.title else agent.card.name
+        managed_card["description"] = config.description if config and config.description else agent.card.description
+        return managed_card
 
     async def create_agent(
         self,

--- a/registry/src/registry/services/generated_token_policy.py
+++ b/registry/src/registry/services/generated_token_policy.py
@@ -27,16 +27,3 @@ def is_consent_exempt(
 ) -> bool:
     """Return whether a client ID is exempt from per-resource consent."""
     return client_id == headless_agent_client_id
-
-
-def is_direct_connect_a2a_client(
-    client_id: str,
-    headless_agent_client_id: str,
-) -> bool:
-    """Return whether a client ID may use the direct-connect A2A proxy routes.
-
-    Both allowed client IDs are issued only through the authenticated Registry token-vending
-    endpoint, not through Dynamic Client Registration. Other clients are denied because the
-    direct-connect A2A routes do not have a per-agent consent fallback.
-    """
-    return client_id in {headless_agent_client_id, INTERACTIVE_CLIENT_ID}

--- a/registry/tests/integration/test_a2a_proxy_auth.py
+++ b/registry/tests/integration/test_a2a_proxy_auth.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Generator
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from fastapi import FastAPI
@@ -41,7 +41,10 @@ def a2a_proxy_context() -> Generator[SimpleNamespace, None, None]:
     app.add_middleware(UnifiedAuthMiddleware)
     app.include_router(router, prefix="/proxy")
 
-    agent_service = SimpleNamespace(get_agent_by_path=AsyncMock())
+    agent_service = SimpleNamespace(
+        get_agent_by_path=AsyncMock(),
+        build_managed_agent_card=Mock(),
+    )
     app.dependency_overrides[get_a2a_agent_service] = lambda: agent_service
     app.dependency_overrides[get_acl_service] = lambda: AsyncMock()
     app.dependency_overrides[get_a2a_client_registry] = lambda: AsyncMock()
@@ -72,6 +75,27 @@ def test_valid_dcr_jwt_is_denied_by_http_json_a2a_route(a2a_proxy_context: Simpl
         "error": "Direct-connect A2A invocation requires a token generated from the Jarvis Registry frontend."
     }
     a2a_proxy_context.agent_service.get_agent_by_path.assert_not_awaited()
+
+
+def test_managed_agent_card_routes_are_public_and_not_swallowed(
+    a2a_proxy_context: SimpleNamespace,
+) -> None:
+    agent = SimpleNamespace(config=SimpleNamespace(enabled=True))
+    managed_card = {
+        "name": "Managed Agent",
+        "preferredTransport": "JSONRPC",
+        "url": "https://registry.example/proxy/a2a/test-agent",
+    }
+    a2a_proxy_context.agent_service.get_agent_by_path.return_value = agent
+    a2a_proxy_context.agent_service.build_managed_agent_card.return_value = managed_card
+
+    primary = a2a_proxy_context.client.get("/proxy/a2a/test-agent/agent-card.json")
+    alias = a2a_proxy_context.client.get("/proxy/a2a/test-agent/.well-known/agent-card.json")
+
+    assert primary.status_code == 200
+    assert primary.content == alias.content
+    assert primary.json() == managed_card
+    assert a2a_proxy_context.agent_service.get_agent_by_path.await_count == 2
 
 
 @pytest.mark.parametrize("client_id", [INTERACTIVE_CLIENT_ID, settings.headless_agent_client_id])

--- a/registry/tests/integration/test_a2a_proxy_auth.py
+++ b/registry/tests/integration/test_a2a_proxy_auth.py
@@ -5,7 +5,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from fastapi import FastAPI
+from beanie import PydanticObjectId
+from fastapi import FastAPI, HTTPException
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
@@ -13,16 +14,19 @@ from registry.api.proxy_routes import _A2A_ACCESS_DENIED_ERROR_CODE, router
 from registry.core.config import settings
 from registry.deps import get_a2a_agent_service, get_a2a_client_registry, get_acl_service
 from registry.middleware.auth import UnifiedAuthMiddleware
+from registry.middleware.rbac import ScopePermissionMiddleware
 from registry.services.generated_token_policy import INTERACTIVE_CLIENT_ID
 from registry_pkgs.core.jwt_tokens import mint_managed_agent_token
+from registry_pkgs.models.enums import AgentCoreRuntimeAccessMode
 
 pytestmark = [pytest.mark.integration, pytest.mark.auth, pytest.mark.proxy]
 
 _DCR_CLIENT_ID = "mcp-client-integration-test"
 _USER_ID = "507f1f77bcf86cd799439011"
+_ORIGINAL_HAS_PERMISSION = ScopePermissionMiddleware._has_permission
 
 
-def _mint_managed_agent_token(client_id: str) -> str:
+def _mint_managed_agent_token(client_id: str, scope: str = "a2a-proxy-ops") -> str:
     return mint_managed_agent_token(
         settings.jwt_token_config,
         subject="integration-user",
@@ -30,14 +34,30 @@ def _mint_managed_agent_token(client_id: str) -> str:
         expires_in_seconds=3600,
         extra_claims={
             "user_id": _USER_ID,
-            "scope": "a2a-proxy-ops",
+            "scope": scope,
         },
     )
 
 
+def _enabled_agent(*, iam: bool = False) -> SimpleNamespace:
+    runtime_access = SimpleNamespace(mode=AgentCoreRuntimeAccessMode.IAM) if iam else None
+    return SimpleNamespace(
+        id=PydanticObjectId(),
+        path="test-agent",
+        config=SimpleNamespace(enabled=True, runtimeAccess=runtime_access, url=None),
+        card=SimpleNamespace(url="https://agent.example.com/a2a"),
+        federationMetadata=None,
+    )
+
+
 @pytest.fixture
-def a2a_proxy_context() -> Generator[SimpleNamespace, None, None]:
+def a2a_proxy_context(monkeypatch: pytest.MonkeyPatch) -> Generator[SimpleNamespace, None, None]:
+    # The global test fixture bypasses RBAC by default. This suite verifies the real
+    # scope boundary, so restore the production implementation before building the app.
+    monkeypatch.setattr(ScopePermissionMiddleware, "_has_permission", _ORIGINAL_HAS_PERMISSION)
+
     app = FastAPI()
+    app.add_middleware(ScopePermissionMiddleware)
     app.add_middleware(UnifiedAuthMiddleware)
     app.include_router(router, prefix="/proxy")
 
@@ -45,35 +65,67 @@ def a2a_proxy_context() -> Generator[SimpleNamespace, None, None]:
         get_agent_by_path=AsyncMock(),
         build_managed_agent_card=Mock(),
     )
+    acl_service = AsyncMock()
+    client_registry = AsyncMock()
     app.dependency_overrides[get_a2a_agent_service] = lambda: agent_service
-    app.dependency_overrides[get_acl_service] = lambda: AsyncMock()
-    app.dependency_overrides[get_a2a_client_registry] = lambda: AsyncMock()
+    app.dependency_overrides[get_acl_service] = lambda: acl_service
+    app.dependency_overrides[get_a2a_client_registry] = lambda: client_registry
 
     with TestClient(app) as client:
-        yield SimpleNamespace(client=client, agent_service=agent_service)
+        yield SimpleNamespace(
+            client=client,
+            agent_service=agent_service,
+            acl_service=acl_service,
+            client_registry=client_registry,
+        )
 
 
-def test_valid_dcr_jwt_is_denied_by_jsonrpc_a2a_route(a2a_proxy_context: SimpleNamespace) -> None:
+def test_dcr_jwt_with_a2a_scope_reaches_jsonrpc_agent_lookup(a2a_proxy_context: SimpleNamespace) -> None:
+    a2a_proxy_context.agent_service.get_agent_by_path.return_value = None
+
     response = a2a_proxy_context.client.post(
         "/proxy/a2a/test-agent",
         headers={"Authorization": f"Bearer {_mint_managed_agent_token(_DCR_CLIENT_ID)}"},
     )
 
     assert response.status_code == 200
-    assert response.json()["error"]["code"] == _A2A_ACCESS_DENIED_ERROR_CODE
-    a2a_proxy_context.agent_service.get_agent_by_path.assert_not_awaited()
+    assert response.json()["error"]["code"] == -32603
+    a2a_proxy_context.agent_service.get_agent_by_path.assert_awaited_once_with("test-agent")
 
 
-def test_valid_dcr_jwt_is_denied_by_http_json_a2a_route(a2a_proxy_context: SimpleNamespace) -> None:
+def test_dcr_jwt_with_a2a_scope_reaches_http_json_agent_lookup(a2a_proxy_context: SimpleNamespace) -> None:
+    a2a_proxy_context.agent_service.get_agent_by_path.return_value = None
+
     response = a2a_proxy_context.client.get(
         "/proxy/a2a/test-agent/tasks/1",
         headers={"Authorization": f"Bearer {_mint_managed_agent_token(_DCR_CLIENT_ID)}"},
     )
 
+    assert response.status_code == 404
+    assert response.json() == {"error": "A2A agent with path 'test-agent' not found"}
+    a2a_proxy_context.agent_service.get_agent_by_path.assert_awaited_once_with("test-agent")
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("POST", "/proxy/a2a/test-agent"),
+        ("GET", "/proxy/a2a/test-agent/tasks/1"),
+    ],
+)
+def test_dcr_jwt_without_a2a_scope_is_rejected_before_agent_lookup(
+    a2a_proxy_context: SimpleNamespace,
+    method: str,
+    path: str,
+) -> None:
+    response = a2a_proxy_context.client.request(
+        method,
+        path,
+        headers={"Authorization": f"Bearer {_mint_managed_agent_token(_DCR_CLIENT_ID, scope='agents-read')}"},
+    )
+
     assert response.status_code == 403
-    assert response.json() == {
-        "error": "Direct-connect A2A invocation requires a token generated from the Jarvis Registry frontend."
-    }
+    assert response.json() == {"detail": "Insufficient permissions"}
     a2a_proxy_context.agent_service.get_agent_by_path.assert_not_awaited()
 
 
@@ -102,7 +154,7 @@ def test_managed_agent_card_routes_are_public_and_not_swallowed(
 def test_allowed_client_reaches_agent_lookup_via_jsonrpc_a2a_route(
     a2a_proxy_context: SimpleNamespace, client_id: str
 ) -> None:
-    """An allowlisted client_id must pass the gate through the real routing/DI stack.
+    """A first-party token with the required scope passes the real routing/DI stack.
 
     This is the regression guard for the `@router.route` -> `@router.api_route` fix: under
     the old decorator, FastAPI's dependency injection never ran, so `user_context`, `agent_path`,
@@ -124,7 +176,7 @@ def test_allowed_client_reaches_agent_lookup_via_jsonrpc_a2a_route(
 def test_allowed_client_reaches_agent_lookup_via_http_json_a2a_route(
     a2a_proxy_context: SimpleNamespace, client_id: str
 ) -> None:
-    """An allowlisted client_id must pass the gate through the real routing/DI stack.
+    """A first-party token with the required scope passes the real routing/DI stack.
 
     This is the regression guard for the `@router.route` -> `@router.api_route` fix: under
     the old decorator, FastAPI's dependency injection never ran, so `user_context`, `agent_path`,
@@ -141,6 +193,64 @@ def test_allowed_client_reaches_agent_lookup_via_http_json_a2a_route(
     assert response.status_code == 404
     assert response.json() == {"error": "A2A agent with path 'test-agent' not found"}
     a2a_proxy_context.agent_service.get_agent_by_path.assert_awaited_once_with("test-agent")
+
+
+def test_dcr_jsonrpc_token_still_enforces_agent_acl(a2a_proxy_context: SimpleNamespace) -> None:
+    a2a_proxy_context.agent_service.get_agent_by_path.return_value = _enabled_agent()
+    a2a_proxy_context.acl_service.check_user_permission.side_effect = HTTPException(status_code=403)
+
+    response = a2a_proxy_context.client.post(
+        "/proxy/a2a/test-agent",
+        headers={"Authorization": f"Bearer {_mint_managed_agent_token(_DCR_CLIENT_ID)}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == _A2A_ACCESS_DENIED_ERROR_CODE
+    assert response.json()["error"]["message"] == "Access denied to A2A agent 'test-agent'"
+    a2a_proxy_context.client_registry.get_client.assert_not_awaited()
+
+
+def test_dcr_http_json_token_still_enforces_agent_acl(a2a_proxy_context: SimpleNamespace) -> None:
+    a2a_proxy_context.agent_service.get_agent_by_path.return_value = _enabled_agent()
+    a2a_proxy_context.acl_service.check_user_permission.side_effect = HTTPException(status_code=403)
+
+    response = a2a_proxy_context.client.get(
+        "/proxy/a2a/test-agent/tasks/1",
+        headers={"Authorization": f"Bearer {_mint_managed_agent_token(_DCR_CLIENT_ID)}"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"error": "Access denied to A2A agent 'test-agent'"}
+    a2a_proxy_context.client_registry.get_client.assert_not_awaited()
+
+
+def test_dcr_jsonrpc_token_receives_explicit_iam_error(a2a_proxy_context: SimpleNamespace) -> None:
+    a2a_proxy_context.agent_service.get_agent_by_path.return_value = _enabled_agent(iam=True)
+
+    response = a2a_proxy_context.client.post(
+        "/proxy/a2a/test-agent",
+        headers={"Authorization": f"Bearer {_mint_managed_agent_token(_DCR_CLIENT_ID)}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["error"] == {
+        "code": -32004,
+        "message": "A2A agent 'test-agent' uses IAM inbound auth which is not supported by this gateway",
+    }
+    a2a_proxy_context.client_registry.get_client.assert_not_awaited()
+
+
+def test_dcr_http_json_token_receives_explicit_iam_error(a2a_proxy_context: SimpleNamespace) -> None:
+    a2a_proxy_context.agent_service.get_agent_by_path.return_value = _enabled_agent(iam=True)
+
+    response = a2a_proxy_context.client.get(
+        "/proxy/a2a/test-agent/tasks/1",
+        headers={"Authorization": f"Bearer {_mint_managed_agent_token(_DCR_CLIENT_ID)}"},
+    )
+
+    assert response.status_code == 501
+    assert response.json() == {"error": "A2A agent 'test-agent' uses IAM inbound auth which is not supported"}
+    a2a_proxy_context.client_registry.get_client.assert_not_awaited()
 
 
 def test_http_json_proxy_route_is_registered_as_api_route() -> None:

--- a/registry/tests/unit/api/test_proxy_routes.py
+++ b/registry/tests/unit/api/test_proxy_routes.py
@@ -17,7 +17,6 @@ from fastapi import HTTPException
 from starlette.requests import Request
 
 from registry.api.proxy_routes import (
-    _A2A_ACCESS_DENIED_ERROR_CODE,
     _serve_managed_agent_card,
     dynamic_mcp_get_proxy,
     dynamic_mcp_post_proxy,
@@ -493,59 +492,10 @@ async def test_get_proxy_acl_allowed_continues():
     assert "disabled" in body["detail"].lower()
 
 
-@pytest.mark.parametrize("client_id", ["mcp-client-dcr", None], ids=["dcr-client", "missing-client-id"])
-async def test_jsonrpc_proxy_rejects_disallowed_client_before_agent_lookup(client_id):
-    a2a_agent_service = SimpleNamespace(get_agent_by_path=AsyncMock())
-    user_context = dict(_AUTH_CONTEXT)
-    if client_id is None:
-        user_context.pop("client_id")
-    else:
-        user_context["client_id"] = client_id
-
-    response = await jsonrpc_proxy(
-        request=_a2a_request(),
-        agent_path="test-agent",
-        user_context=user_context,
-        a2a_agent_service=a2a_agent_service,
-        acl_service=AsyncMock(),
-        a2a_client_registry=AsyncMock(),
-    )
-
-    body = json.loads(response.body)
-    assert response.status_code == 200
-    assert body["error"]["code"] == _A2A_ACCESS_DENIED_ERROR_CODE
-    assert "token generated from the Jarvis Registry frontend" in body["error"]["message"]
-    a2a_agent_service.get_agent_by_path.assert_not_awaited()
-
-
-@pytest.mark.parametrize("client_id", ["mcp-client-dcr", None], ids=["dcr-client", "missing-client-id"])
-async def test_http_json_proxy_rejects_disallowed_client_before_agent_lookup(client_id):
-    a2a_agent_service = SimpleNamespace(get_agent_by_path=AsyncMock())
-    user_context = dict(_AUTH_CONTEXT)
-    if client_id is None:
-        user_context.pop("client_id")
-    else:
-        user_context["client_id"] = client_id
-
-    response = await http_json_proxy(
-        request=_a2a_request(method="GET"),
-        agent_path="test-agent",
-        http_json_path="tasks/1",
-        user_context=user_context,
-        a2a_agent_service=a2a_agent_service,
-        acl_service=AsyncMock(),
-        a2a_client_registry=AsyncMock(),
-    )
-
-    body = json.loads(response.body)
-    assert response.status_code == 403
-    assert body == {
-        "error": "Direct-connect A2A invocation requires a token generated from the Jarvis Registry frontend."
-    }
-    a2a_agent_service.get_agent_by_path.assert_not_awaited()
-
-
-@pytest.mark.parametrize("client_id", [INTERACTIVE_CLIENT_ID, settings.headless_agent_client_id])
+@pytest.mark.parametrize(
+    "client_id",
+    [INTERACTIVE_CLIENT_ID, settings.headless_agent_client_id, "mcp-client-dcr"],
+)
 async def test_jsonrpc_proxy_gets_client_from_a2a_client_registry(monkeypatch, client_id):
     agent = _a2a_agent()
     proxy_client = Mock()
@@ -572,7 +522,10 @@ async def test_jsonrpc_proxy_gets_client_from_a2a_client_registry(monkeypatch, c
     )
 
 
-@pytest.mark.parametrize("client_id", [INTERACTIVE_CLIENT_ID, settings.headless_agent_client_id])
+@pytest.mark.parametrize(
+    "client_id",
+    [INTERACTIVE_CLIENT_ID, settings.headless_agent_client_id, "mcp-client-dcr"],
+)
 async def test_http_json_proxy_gets_client_from_a2a_client_registry(monkeypatch, client_id):
     agent = _a2a_agent()
     proxy_client = Mock()

--- a/registry/tests/unit/api/test_proxy_routes.py
+++ b/registry/tests/unit/api/test_proxy_routes.py
@@ -6,8 +6,9 @@ format. These tests verify that both handlers reject non-ObjectId user_id values
 """
 
 import json
+import logging
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call
 from uuid import UUID
 
 import pytest
@@ -17,13 +18,19 @@ from starlette.requests import Request
 
 from registry.api.proxy_routes import (
     _A2A_ACCESS_DENIED_ERROR_CODE,
+    _serve_managed_agent_card,
     dynamic_mcp_get_proxy,
     dynamic_mcp_post_proxy,
     http_json_proxy,
     jsonrpc_proxy,
+    managed_agent_card,
+    managed_agent_card_well_known_alias,
+    router,
 )
 from registry.core.config import settings
 from registry.services.generated_token_policy import INTERACTIVE_CLIENT_ID
+from registry_pkgs.models.a2a_agent import NoSupportedTransportError
+from registry_pkgs.models.enums import AgentCoreRuntimeAccessMode
 from registry_pkgs.testing.federation_metadata import make_azure_foundry_metadata
 
 VALID_OBJECT_ID = "507f1f77bcf86cd799439011"
@@ -126,6 +133,84 @@ def _a2a_agent():
         card=SimpleNamespace(url="https://agent.example.com/a2a"),
         federationMetadata=make_azure_foundry_metadata(),
     )
+
+
+def _managed_card_service(agent: object | None, card: dict | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        get_agent_by_path=AsyncMock(return_value=agent),
+        build_managed_agent_card=Mock(return_value=card or {"name": "Managed Agent"}),
+    )
+
+
+async def test_managed_agent_card_routes_return_byte_identical_content() -> None:
+    agent = _a2a_agent()
+    service = _managed_card_service(agent, {"name": "Managed Agent", "preferredTransport": "JSONRPC"})
+
+    primary = await managed_agent_card("test-agent", service)
+    alias = await managed_agent_card_well_known_alias("test-agent", service)
+
+    assert primary.status_code == 200
+    assert primary.body == alias.body
+    assert service.get_agent_by_path.await_count == 2
+    assert service.build_managed_agent_card.call_args_list == [call(agent), call(agent)]
+
+
+@pytest.mark.parametrize(
+    "agent",
+    [
+        None,
+        SimpleNamespace(config=None),
+        SimpleNamespace(config=SimpleNamespace(enabled=False)),
+    ],
+    ids=["not-found", "missing-config", "disabled"],
+)
+async def test_managed_agent_card_returns_indistinguishable_not_found(agent: object | None) -> None:
+    service = _managed_card_service(agent)
+
+    response = await _serve_managed_agent_card("test-agent", service)
+
+    assert response.status_code == 404
+    assert response.body == b'{"detail":"A2A agent not found"}'
+    service.build_managed_agent_card.assert_not_called()
+
+
+async def test_managed_agent_card_is_available_for_enabled_iam_agent() -> None:
+    agent = SimpleNamespace(
+        config=SimpleNamespace(
+            enabled=True,
+            runtimeAccess=SimpleNamespace(mode=AgentCoreRuntimeAccessMode.IAM),
+        )
+    )
+    service = _managed_card_service(agent)
+
+    response = await _serve_managed_agent_card("iam-agent", service)
+
+    assert response.status_code == 200
+    service.build_managed_agent_card.assert_called_once_with(agent)
+
+
+async def test_managed_agent_card_maps_unsupported_legacy_transport_to_500(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    agent = _a2a_agent()
+    service = _managed_card_service(agent)
+    service.build_managed_agent_card.side_effect = NoSupportedTransportError("legacy gRPC-only card")
+
+    with caplog.at_level(logging.ERROR, logger="registry.api.proxy_routes"):
+        response = await _serve_managed_agent_card("legacy-agent", service)
+
+    assert response.status_code == 500
+    assert response.body == b'{"detail":"Internal server error"}'
+    assert "legacy-agent" in caplog.text
+    assert "legacy gRPC-only card" not in response.body.decode()
+
+
+def test_managed_agent_card_routes_are_registered_before_http_json_catch_all() -> None:
+    paths = [route.path for route in router.routes]
+    catch_all_index = paths.index("/a2a/{agent_path}/{http_json_path:path}")
+
+    assert paths.index("/a2a/{agent_path}/agent-card.json") < catch_all_index
+    assert paths.index("/a2a/{agent_path}/.well-known/agent-card.json") < catch_all_index
 
 
 @pytest.mark.parametrize("user_id", INVALID_USER_IDS)

--- a/registry/tests/unit/middleware/test_auth_dispatch.py
+++ b/registry/tests/unit/middleware/test_auth_dispatch.py
@@ -29,6 +29,22 @@ def _build_app() -> FastAPI:
     async def direct_connect_ep(user_id: str, server_path: str):
         return JSONResponse({"ok": "direct", "user_id": user_id, "server_path": server_path})
 
+    @app.get("/proxy/a2a/{agent_path}/agent-card.json")
+    async def managed_agent_card_ep(agent_path: str):
+        return JSONResponse({"ok": "managed-card", "agent_path": agent_path})
+
+    @app.get("/proxy/a2a/{agent_path}/.well-known/agent-card.json")
+    async def managed_agent_card_alias_ep(agent_path: str):
+        return JSONResponse({"ok": "managed-card-alias", "agent_path": agent_path})
+
+    @app.api_route("/proxy/a2a/{agent_path}", methods=["GET", "POST"])
+    async def direct_a2a_ep(agent_path: str):
+        return JSONResponse({"ok": "a2a", "agent_path": agent_path})
+
+    @app.get("/proxy/a2a/{agent_path}/{suffix:path}")
+    async def direct_a2a_suffix_ep(agent_path: str, suffix: str):
+        return JSONResponse({"ok": "a2a-suffix", "agent_path": agent_path, "suffix": suffix})
+
     @app.get("/api/v1/servers")
     async def crud_ep():
         return JSONResponse({"ok": "crud"})
@@ -201,6 +217,35 @@ def test_downstream_device_endpoint_is_public(client):
 def test_downstream_device_resolver_is_public(client):
     resp = client.get("/api/v1/mcp/consent/device/resolve")
     assert resp.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/proxy/a2a/weather/agent-card.json",
+        "/proxy/a2a/weather/.well-known/agent-card.json",
+    ],
+)
+def test_managed_agent_card_paths_are_public(client: TestClient, path: str) -> None:
+    resp = client.get(path)
+    assert resp.status_code == 200
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("POST", "/proxy/a2a/weather"),
+        ("GET", "/proxy/a2a/weather/tasks/1"),
+        ("GET", "/proxy/a2a/weather/not-agent-card.json"),
+    ],
+)
+def test_other_a2a_paths_still_require_bearer(
+    client: TestClient,
+    method: str,
+    path: str,
+) -> None:
+    resp = client.request(method, path)
+    assert resp.status_code == 401
 
 
 def test_downstream_authorize_endpoint_is_not_public(client):

--- a/registry/tests/unit/services/test_a2a_agent_service.py
+++ b/registry/tests/unit/services/test_a2a_agent_service.py
@@ -99,8 +99,12 @@ def _managed_card_agent(
 
 
 def test_build_managed_agent_card_applies_all_transformations(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("registry.services.a2a_agent_service.settings.jwt_issuer", "https://registry.example")
-    monkeypatch.setattr("registry.services.a2a_agent_service.settings.service_base_path", "/gateway")
+    # `registry_url` and `jwt_issuer` are deliberately set to different hosts here: `url` /
+    # `additionalInterfaces[*].url` live on the registry backend (registry_url), while
+    # `oauth2MetadataUrl` lives on the auth-server (jwt_issuer). A regression that conflates
+    # the two (e.g. building the proxy URL from jwt_issuer) must fail this test.
+    monkeypatch.setattr("registry.services.a2a_agent_service.settings.registry_url", "https://registry.example/gateway")
+    monkeypatch.setattr("registry.services.a2a_agent_service.settings.jwt_issuer", "https://auth-issuer.example")
     monkeypatch.setattr(
         "registry.services.a2a_agent_service.settings.auth_server_external_url",
         "https://auth.example",
@@ -137,7 +141,7 @@ def test_build_managed_agent_card_applies_all_transformations(monkeypatch: pytes
                     "scopes": {"a2a-proxy-ops": "Invoke managed A2A agents via the Jarvis Registry proxy"},
                 }
             },
-            "oauth2MetadataUrl": "https://registry.example/.well-known/oauth-authorization-server",
+            "oauth2MetadataUrl": "https://auth-issuer.example/.well-known/oauth-authorization-server",
         }
     }
     assert managed_card["security"] == [{"oauth2": ["a2a-proxy-ops"]}]

--- a/registry/tests/unit/services/test_a2a_agent_service.py
+++ b/registry/tests/unit/services/test_a2a_agent_service.py
@@ -4,10 +4,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from a2a.client import A2AClientHTTPError
+from a2a.types import AgentCard, TransportProtocol
 from beanie import PydanticObjectId
 
 from registry.schemas.a2a_agent_api_schemas import AgentCreateRequest, AgentUpdateRequest
 from registry.services.a2a_agent_service import A2AAgentService, _normalize_config_url
+from registry_pkgs.models.a2a_agent import A2AAgent, AgentConfig, NoSupportedTransportError
 from registry_pkgs.models.enums import FederationProviderType
 from registry_pkgs.testing.federation_metadata import (
     make_agentcore_a2a_metadata,
@@ -33,6 +35,155 @@ class _AsyncCM:
 def _service() -> A2AAgentService:
     # No repo -> the _schedule_* helpers return early (no asyncio.create_task).
     return A2AAgentService(a2a_agent_repo=None)
+
+
+def _managed_card_agent(
+    *,
+    config: AgentConfig | None = None,
+    grpc_only: bool = False,
+) -> A2AAgent:
+    additional_interfaces = [{"transport": "GRPC", "url": "https://origin.example/grpc"}]
+    if not grpc_only:
+        additional_interfaces = [
+            {"transport": "HTTP+JSON", "url": "https://origin.example/http"},
+            *additional_interfaces,
+            {"transport": "JSONRPC", "url": "https://origin.example/jsonrpc"},
+        ]
+
+    card = AgentCard.model_validate(
+        {
+            "name": "Origin Agent",
+            "description": "Origin description",
+            "url": "https://origin.example/grpc",
+            "version": "1.2.3",
+            "protocolVersion": "0.3.0",
+            "capabilities": {"streaming": True},
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["application/json"],
+            "preferredTransport": "GRPC",
+            "additionalInterfaces": additional_interfaces,
+            "supportsAuthenticatedExtendedCard": True,
+            "securitySchemes": {
+                "originKey": {
+                    "type": "apiKey",
+                    "name": "X-Origin-Key",
+                    "in": "header",
+                }
+            },
+            "security": [{"originKey": []}],
+            "signatures": [{"protected": "header", "signature": "signature"}],
+            "skills": [
+                {
+                    "id": "weather",
+                    "name": "Weather",
+                    "description": "Returns weather",
+                    "tags": ["weather"],
+                    "security": [{"originKey": []}],
+                }
+            ],
+            "provider": {
+                "organization": "Origin Corp",
+                "url": "https://origin.example",
+            },
+            "documentationUrl": "https://origin.example/docs",
+            "iconUrl": "https://origin.example/icon.png",
+        }
+    )
+    return A2AAgent.model_construct(
+        id=PydanticObjectId(),
+        path="weather-agent",
+        card=card,
+        config=config,
+        author=PydanticObjectId(),
+    )
+
+
+def test_build_managed_agent_card_applies_all_transformations(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("registry.services.a2a_agent_service.settings.jwt_issuer", "https://registry.example")
+    monkeypatch.setattr("registry.services.a2a_agent_service.settings.service_base_path", "/gateway")
+    monkeypatch.setattr(
+        "registry.services.a2a_agent_service.settings.auth_server_external_url",
+        "https://auth.example",
+    )
+    monkeypatch.setattr("registry.services.a2a_agent_service.settings.auth_provider", "entra")
+    agent = _managed_card_agent(
+        config=AgentConfig(
+            title="Curated Agent",
+            description="Curated description",
+            type="jsonrpc",
+            enabled=True,
+        )
+    )
+    original_card = agent.card.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+    managed_card = _service().build_managed_agent_card(agent)
+
+    proxy_url = "https://registry.example/gateway/proxy/a2a/weather-agent"
+    assert managed_card["preferredTransport"] == TransportProtocol.jsonrpc
+    assert managed_card["url"] == proxy_url
+    assert managed_card["additionalInterfaces"] == [
+        {"transport": "HTTP+JSON", "url": proxy_url},
+        {"transport": "JSONRPC", "url": proxy_url},
+    ]
+    assert managed_card["supportsAuthenticatedExtendedCard"] is False
+    assert managed_card["securitySchemes"] == {
+        "oauth2": {
+            "type": "oauth2",
+            "flows": {
+                "authorizationCode": {
+                    "authorizationUrl": "https://auth.example/oauth2/login/entra",
+                    "tokenUrl": "https://auth.example/oauth2/token",
+                    "refreshUrl": "https://auth.example/oauth2/token",
+                    "scopes": {"a2a-proxy-ops": "Invoke managed A2A agents via the Jarvis Registry proxy"},
+                }
+            },
+            "oauth2MetadataUrl": "https://registry.example/.well-known/oauth-authorization-server",
+        }
+    }
+    assert managed_card["security"] == [{"oauth2": ["a2a-proxy-ops"]}]
+    assert "signatures" not in managed_card
+    assert "security" not in managed_card["skills"][0]
+    assert managed_card["skills"][0]["tags"] == ["weather"]
+    assert managed_card["name"] == "Curated Agent"
+    assert managed_card["description"] == "Curated description"
+    for field in (
+        "capabilities",
+        "defaultInputModes",
+        "defaultOutputModes",
+        "provider",
+        "documentationUrl",
+        "iconUrl",
+        "version",
+        "protocolVersion",
+    ):
+        assert managed_card[field] == original_card[field]
+    assert agent.card.model_dump(mode="json", by_alias=True, exclude_none=True) == original_card
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        None,
+        AgentConfig(title="", description="", type="jsonrpc", enabled=True),
+    ],
+)
+def test_build_managed_agent_card_falls_back_to_origin_metadata(config: AgentConfig | None) -> None:
+    agent = _managed_card_agent(config=config)
+
+    managed_card = _service().build_managed_agent_card(agent)
+
+    assert managed_card["name"] == "Origin Agent"
+    assert managed_card["description"] == "Origin description"
+
+
+def test_build_managed_agent_card_rejects_legacy_grpc_only_card() -> None:
+    agent = _managed_card_agent(
+        config=AgentConfig(title="Legacy", description="", type="grpc", enabled=True),
+        grpc_only=True,
+    )
+
+    with pytest.raises(NoSupportedTransportError):
+        _service().build_managed_agent_card(agent)
 
 
 @pytest.mark.asyncio

--- a/registry/tests/unit/services/test_generated_token_policy.py
+++ b/registry/tests/unit/services/test_generated_token_policy.py
@@ -8,7 +8,6 @@ from registry.schemas.enums import TokenPurpose
 from registry.services.generated_token_policy import (
     INTERACTIVE_CLIENT_ID,
     is_consent_exempt,
-    is_direct_connect_a2a_client,
     resolve_generated_token_client_id,
 )
 
@@ -44,16 +43,3 @@ def test_resolve_generated_token_client_id_rejects_unsupported_purpose() -> None
 )
 def test_is_consent_exempt(client_id: str, expected: bool) -> None:
     assert is_consent_exempt(client_id, HEADLESS_CLIENT_ID) is expected
-
-
-@pytest.mark.parametrize(
-    ("client_id", "expected"),
-    [
-        (HEADLESS_CLIENT_ID, True),
-        (INTERACTIVE_CLIENT_ID, True),
-        ("mcp-client-dcr", False),
-        ("", False),
-    ],
-)
-def test_is_direct_connect_a2a_client(client_id: str, expected: bool) -> None:
-    assert is_direct_connect_a2a_client(client_id, HEADLESS_CLIENT_ID) is expected


### PR DESCRIPTION
Adds public managed Agent Card endpoints with Registry proxy URLs, OAuth security metadata, and non-gRPC transport filtering. Returns identical 404 responses for nonexistent and disabled agents while keeping enabled IAM agents discoverable.