### PR TITLE
Feature/as 1785 a2a dcr discovery

### DIFF
--- a/auth-server/src/auth_server/routes/oauth_flow.py
+++ b/auth-server/src/auth_server/routes/oauth_flow.py
@@ -19,6 +19,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Resp
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from pydantic import BaseModel
 
+from registry_pkgs.core.client_categories import A2A_CLIENT_ID_PREFIX, MCP_CLIENT_ID_PREFIX
 from registry_pkgs.core.consent_store import PENDING_CONSENT_TTL_SECONDS, ConsentStore, PendingConsentStore
 from registry_pkgs.core.downstream_oauth import (
     DEVICE_CODE_GRANT_TYPE,
@@ -467,11 +468,14 @@ def _finish_device_denial(device_code: str, store: OAuthStateStoreProtocol) -> H
     return HTMLResponse(render_device_denied_page())
 
 
-@router.post("/oauth2/register", response_model=ClientRegistrationResponse, response_model_exclude_none=True)
-async def register_client(
+async def _register_client_common(
     registration: ClientRegistrationRequest,
     request: Request,
-    store: OAuthStateStoreProtocol = Depends(get_oauth_state_store),
+    store: OAuthStateStoreProtocol,
+    *,
+    client_id_prefix: str,
+    default_scope: str,
+    default_client_name: str,
 ) -> ClientRegistrationResponse | JSONResponse:
     try:
         logger.info(
@@ -489,7 +493,7 @@ async def register_client(
             )
             return redirect_uri_error
 
-        client_id = f"mcp-client-{secrets.token_urlsafe(16)}"
+        client_id = f"{client_id_prefix}{secrets.token_urlsafe(16)}"
 
         requested_auth_method = registration.token_endpoint_auth_method
         if requested_auth_method in SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS:
@@ -516,12 +520,12 @@ async def register_client(
             "client_secret": client_secret,
             "client_id_issued_at": issued_at,
             "client_secret_expires_at": 0,
-            "client_name": registration.client_name or "MCP Client",
+            "client_name": registration.client_name or default_client_name,
             "client_uri": registration.client_uri,
             "redirect_uris": registration.redirect_uris or [],
             "grant_types": grant_types,
             "response_types": response_types,
-            "scope": registration.scope or "servers-read agents-read",
+            "scope": registration.scope or default_scope,
             "token_endpoint_auth_method": token_endpoint_auth_method,
             "contacts": registration.contacts or [],
             "registered_at": issued_at,
@@ -551,6 +555,38 @@ async def register_client(
         logger.exception("Client registration failed")
 
         raise HTTPException(status_code=500, detail="Client registration failed")
+
+
+@router.post("/oauth2/register", response_model=ClientRegistrationResponse, response_model_exclude_none=True)
+async def register_client(
+    registration: ClientRegistrationRequest,
+    request: Request,
+    store: OAuthStateStoreProtocol = Depends(get_oauth_state_store),
+) -> ClientRegistrationResponse | JSONResponse:
+    return await _register_client_common(
+        registration,
+        request,
+        store,
+        client_id_prefix=MCP_CLIENT_ID_PREFIX,
+        default_scope="mcp-proxy-ops",
+        default_client_name="MCP Client",
+    )
+
+
+@router.post("/oauth2/register/a2a", response_model=ClientRegistrationResponse, response_model_exclude_none=True)
+async def register_a2a_client(
+    registration: ClientRegistrationRequest,
+    request: Request,
+    store: OAuthStateStoreProtocol = Depends(get_oauth_state_store),
+) -> ClientRegistrationResponse | JSONResponse:
+    return await _register_client_common(
+        registration,
+        request,
+        store,
+        client_id_prefix=A2A_CLIENT_ID_PREFIX,
+        default_scope="a2a-proxy-ops",
+        default_client_name="A2A Client",
+    )
 
 
 @router.post("/oauth2/device/code", response_model=DeviceCodeResponse, response_model_exclude_none=True)

--- a/auth-server/src/auth_server/routes/well_known.py
+++ b/auth-server/src/auth_server/routes/well_known.py
@@ -69,6 +69,18 @@ async def oauth_authorization_server_metadata():
     }
 
 
+@router.get("/.well-known/oauth-authorization-server/a2a")
+async def a2a_oauth_authorization_server_metadata():
+    """A2A-specific OAuth 2.0 Authorization Server Metadata.
+
+    Identical to the root metadata except ``registration_endpoint`` points to
+    the A2A DCR endpoint so that A2A clients register with an ``a2a-client-*``
+    prefix and receive the correct scope ceiling.
+    """
+    base = await oauth_authorization_server_metadata()
+    return {**base, "registration_endpoint": f"{settings.auth_server_external_url}/oauth2/register/a2a"}
+
+
 @router.get(f"/.well-known/oauth-authorization-server/{DOWNSTREAM_OAUTH_NAMESPACE}/{{user_id}}/{{server_path:path}}")
 async def downstream_authorization_server_metadata(user_id: str, server_path: str):
     """Per-user, per-server downstream OAuth authorization server metadata (RFC 8414).

--- a/auth-server/tests/integration/test_oauth_flow_routes.py
+++ b/auth-server/tests/integration/test_oauth_flow_routes.py
@@ -230,6 +230,103 @@ class TestDynamicClientRegistration:
 
 
 @pytest.mark.integration
+@pytest.mark.device_flow
+class TestA2ADynamicClientRegistration:
+    """Integration tests for A2A Dynamic Client Registration endpoint."""
+
+    def test_register_a2a_client_default(self, test_client: TestClient, clear_device_storage):
+        response = test_client.post(
+            f"{API_PREFIX}/oauth2/register/a2a",
+            json={"redirect_uris": ["https://example.com/callback"]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["client_id"].startswith("a2a-client-")
+        assert data["grant_types"] == ["authorization_code", "refresh_token", DEVICE_CODE_GRANT_TYPE]
+        assert data["response_types"] == ["code"]
+        assert data["token_endpoint_auth_method"] == "none"
+        assert data["scope"] == "a2a-proxy-ops"
+        assert data["client_name"] == "A2A Client"
+        assert data["client_id"] in registered_clients
+
+    def test_register_a2a_client_full_metadata(self, test_client: TestClient, clear_device_storage):
+        response = test_client.post(
+            f"{API_PREFIX}/oauth2/register/a2a",
+            json={
+                "client_name": "My A2A Agent",
+                "client_uri": "https://example.com",
+                "redirect_uris": ["https://example.com/callback"],
+                "grant_types": ["authorization_code"],
+                "response_types": ["code"],
+                "scope": "a2a-proxy-ops",
+                "contacts": ["admin@example.com"],
+                "token_endpoint_auth_method": "client_secret_post",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["client_id"].startswith("a2a-client-")
+        assert data["client_name"] == "My A2A Agent"
+        assert data["grant_types"] == ["authorization_code", "refresh_token", DEVICE_CODE_GRANT_TYPE]
+        assert data["token_endpoint_auth_method"] == "client_secret_post"
+        assert data["scope"] == "a2a-proxy-ops"
+
+    def test_register_a2a_client_substitutes_unsupported_auth_method(
+        self,
+        test_client: TestClient,
+        clear_device_storage,
+    ):
+        response = test_client.post(
+            f"{API_PREFIX}/oauth2/register/a2a",
+            json={
+                "redirect_uris": ["https://example.com/callback"],
+                "token_endpoint_auth_method": "client_secret_basic",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["token_endpoint_auth_method"] == "none"
+        assert registered_clients[data["client_id"]]["token_endpoint_auth_method"] == "none"
+
+    @pytest.mark.parametrize(
+        "bad_uri",
+        [
+            "http://example.com/cb",
+            "https://10.0.0.1/cb",
+            "https://example.com/cb#frag",
+            "javascript:alert(1)",
+            "data:text/html;base64,PHNjcmlwdD4=",
+        ],
+    )
+    def test_register_a2a_with_unsafe_redirect_uri_rejected(
+        self,
+        test_client: TestClient,
+        clear_device_storage,
+        bad_uri: str,
+    ):
+        response = test_client.post(
+            f"{API_PREFIX}/oauth2/register/a2a",
+            json={"client_name": "Unsafe", "redirect_uris": [bad_uri]},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"] == "invalid_redirect_uri"
+
+    def test_mcp_register_still_produces_mcp_prefix(self, test_client: TestClient, clear_device_storage):
+        """Regression: root /oauth2/register still generates mcp-client-* IDs."""
+        response = test_client.post(
+            f"{API_PREFIX}/oauth2/register",
+            json={"redirect_uris": ["https://example.com/callback"]},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["client_id"].startswith("mcp-client-")
+
+
+@pytest.mark.integration
 @pytest.mark.oauth_flow
 class TestLoginRedirectErrorConsent:
     @pytest.mark.parametrize(

--- a/auth-server/tests/integration/test_well_known_routes.py
+++ b/auth-server/tests/integration/test_well_known_routes.py
@@ -74,6 +74,26 @@ class TestWellKnownRoutes:
         assert isinstance(data["scopes_supported"], list)
         assert len(data["scopes_supported"]) > 0
 
+    def test_a2a_oauth_authorization_server_metadata(self, test_client: TestClient):
+        """A2A metadata overrides only registration_endpoint; everything else matches root."""
+        root_response = test_client.get("/.well-known/oauth-authorization-server")
+        a2a_response = test_client.get("/.well-known/oauth-authorization-server/a2a")
+
+        assert a2a_response.status_code == 200
+        root_data = root_response.json()
+        a2a_data = a2a_response.json()
+
+        assert a2a_data["registration_endpoint"] == "http://localhost:8888/auth/oauth2/register/a2a"
+        assert a2a_data["registration_endpoint"] != root_data["registration_endpoint"]
+
+        assert a2a_data["issuer"] == root_data["issuer"]
+        assert a2a_data["authorization_endpoint"] == root_data["authorization_endpoint"]
+        assert a2a_data["token_endpoint"] == root_data["token_endpoint"]
+        assert a2a_data["device_authorization_endpoint"] == root_data["device_authorization_endpoint"]
+        assert a2a_data["jwks_uri"] == root_data["jwks_uri"]
+        assert a2a_data["grant_types_supported"] == root_data["grant_types_supported"]
+        assert a2a_data["scopes_supported"] == root_data["scopes_supported"]
+
     def test_openid_configuration(self, test_client: TestClient):
         """Test OpenID Connect Discovery endpoint."""
         response = test_client.get("/.well-known/openid-configuration")

--- a/registry/src/registry/services/a2a_agent_service.py
+++ b/registry/src/registry/services/a2a_agent_service.py
@@ -68,7 +68,7 @@ def _build_managed_agent_security() -> tuple[dict[str, Any], list[dict[str, list
                     "scopes": {_A2A_PROXY_SCOPE: _A2A_PROXY_SCOPE_DESCRIPTION},
                 }
             },
-            "oauth2MetadataUrl": f"{settings.jwt_issuer}/.well-known/oauth-authorization-server",
+            "oauth2MetadataUrl": f"{settings.jwt_issuer}/.well-known/oauth-authorization-server/a2a",
         }
     }
     return security_schemes, [{"oauth2": [_A2A_PROXY_SCOPE]}]

--- a/registry/tests/unit/services/test_a2a_agent_service.py
+++ b/registry/tests/unit/services/test_a2a_agent_service.py
@@ -141,7 +141,7 @@ def test_build_managed_agent_card_applies_all_transformations(monkeypatch: pytes
                     "scopes": {"a2a-proxy-ops": "Invoke managed A2A agents via the Jarvis Registry proxy"},
                 }
             },
-            "oauth2MetadataUrl": "https://auth-issuer.example/.well-known/oauth-authorization-server",
+            "oauth2MetadataUrl": "https://auth-issuer.example/.well-known/oauth-authorization-server/a2a",
         }
     }
     assert managed_card["security"] == [{"oauth2": ["a2a-proxy-ops"]}]


### PR DESCRIPTION
> AS-1785 (Client-ID Categorization) is split into 4 independent CRs. This PR implements CR1: A2A DCR + Discovery.

## Goal
Before AS-1784, all DCR clients registered via /oauth2/register and received mcp-client-* IDs. A2A clients requesting a2a-proxy-ops were categorized as MCP_DCR (ceiling {mcp-proxy-ops}), resulting in an empty scope intersection — A2A clients could register but had no usable permissions.

This PR closes the A2A discovery loop: Agent Card → A2A well-known → A2A DCR → a2a-client-* → correct ceiling.