### PR TITLE
fix: raise A2A task budget to 1 hour so long-running agents stop timi…

### DIFF
--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
@@ -36,10 +36,9 @@ from registry_pkgs.models.federation_metadata import (
 
 logger = logging.getLogger(__name__)
 
-_A2A_JWT_TTL_SECONDS = 300
-_A2A_HTTP_TIMEOUT = 300
-# a2a poll timeout needs to be strictly less than _A2A_JWT_TTL_SECONDS and _A2A_HTTP_TIMEOUT
-_A2A_POLL_TIMEOUT = _A2A_HTTP_TIMEOUT * 0.6
+_A2A_TASK_BUDGET_SECONDS = 3600
+_A2A_JWT_TTL_SECONDS = _A2A_TASK_BUDGET_SECONDS + 300
+_A2A_HTTP_TIMEOUT = httpx.Timeout(30.0, read=_A2A_TASK_BUDGET_SECONDS)
 
 HeadersProvider = Callable[[A2AAgent], Awaitable[dict[str, str]]]
 ClientProvider = Callable[[A2AAgent], Awaitable[httpx.AsyncClient]]
@@ -265,11 +264,10 @@ async def _poll_until_terminal(
     `blocking=True` is only a hint; servers may ignore it and return a
     `submitted`/`working` Task immediately. Caller-side polling is the
     documented workaround (see a2a-send-message-1.md, Bug 2). Returns the
-    final Task. Raises TimeoutError if the _A2A_POLL_TIMEOUT budget is exceeded.
+    final Task. Raises TimeoutError if _A2A_TASK_BUDGET_SECONDS is exceeded.
     """
-    # Exponential backoff capped at 8s; total budget _A2A_POLL_TIMEOUT.
-    back_offs = (0.5, 1.0, 2.0, 4.0, 8.0)
-    deadline = time.monotonic() + _A2A_POLL_TIMEOUT
+    back_offs = (0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0)
+    deadline = time.monotonic() + _A2A_TASK_BUDGET_SECONDS
     delay_iter = iter(back_offs)
     while True:
         try:
@@ -279,7 +277,7 @@ async def _poll_until_terminal(
 
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            raise TimeoutError(f"polling timed out after {_A2A_POLL_TIMEOUT}s for task {task_id!r}")
+            raise TimeoutError(f"polling timed out after {_A2A_TASK_BUDGET_SECONDS}s for task {task_id!r}")
         await asyncio.sleep(min(delay, remaining))
 
         task = await client.get_task(TaskQueryParams(id=task_id), context=context)

--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from time import monotonic
 from typing import Any
 
 import httpx
@@ -36,9 +36,14 @@ from registry_pkgs.models.federation_metadata import (
 
 logger = logging.getLogger(__name__)
 
+# Every timeout below derives from _A2A_TASK_BUDGET_SECONDS rather than being set independently:
+# each bounds a different layer: credential lifetime, transport read, hard cancellation. The shortest becomes
+# the real ceiling, failing in that layer's terms rather than as a clean task timeout. Retune via budget.
 _A2A_TASK_BUDGET_SECONDS = 3600
 _A2A_JWT_TTL_SECONDS = _A2A_TASK_BUDGET_SECONDS + 300
 _A2A_HTTP_TIMEOUT = httpx.Timeout(30.0, read=_A2A_TASK_BUDGET_SECONDS)
+# Preemptive backstop: a still-streaming send never reaches the poll loop's own check.
+_A2A_HARD_TIMEOUT_SECONDS = _A2A_TASK_BUDGET_SECONDS + 60
 
 HeadersProvider = Callable[[A2AAgent], Awaitable[dict[str, str]]]
 ClientProvider = Callable[[A2AAgent], Awaitable[httpx.AsyncClient]]
@@ -258,16 +263,17 @@ async def _poll_until_terminal(
     task_id: str,
     *,
     context: ClientCallContext,
+    deadline: float,
 ) -> Task:
     """Poll `client.get_task` until the task leaves the in-progress states.
 
     `blocking=True` is only a hint; servers may ignore it and return a
     `submitted`/`working` Task immediately. Caller-side polling is the
     documented workaround (see a2a-send-message-1.md, Bug 2). Returns the
-    final Task. Raises TimeoutError if _A2A_TASK_BUDGET_SECONDS is exceeded.
+    final Task, or raises TimeoutError at `deadline` — an absolute `monotonic()`
+    value seeded before the send, so sending and polling share one budget.
     """
     back_offs = (0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0)
-    deadline = time.monotonic() + _A2A_TASK_BUDGET_SECONDS
     delay_iter = iter(back_offs)
     while True:
         try:
@@ -275,9 +281,9 @@ async def _poll_until_terminal(
         except StopIteration:
             delay = back_offs[-1]
 
-        remaining = deadline - time.monotonic()
+        remaining = deadline - monotonic()
         if remaining <= 0:
-            raise TimeoutError(f"polling timed out after {_A2A_TASK_BUDGET_SECONDS}s for task {task_id!r}")
+            raise TimeoutError(f"polling timed out after the {_A2A_TASK_BUDGET_SECONDS}s budget for task {task_id!r}")
         await asyncio.sleep(min(delay, remaining))
 
         task = await client.get_task(TaskQueryParams(id=task_id), context=context)
@@ -340,6 +346,8 @@ async def _call_with_open_client(
     context: ClientCallContext,
 ) -> A2ACallResult:
     """Run the three-phase consume/poll/build pipeline against an already-open client."""
+    deadline = monotonic() + _A2A_TASK_BUDGET_SECONDS
+
     # 1. drain the event stream.
     msg = text if isinstance(text, Message) else _create_message(text)
     outcome = await _consume_stream(client, msg, context=context)
@@ -357,9 +365,9 @@ async def _call_with_open_client(
     if task.status.state in _IN_PROGRESS_STATES:
         logger.debug("polling task %r from state=%s", task.id, task.status.state.value)
         try:
-            task = await _poll_until_terminal(client, task.id, context=context)
+            task = await _poll_until_terminal(client, task.id, context=context, deadline=deadline)
         except TimeoutError as exc:
-            logger.warning("polling timed out: %s", exc)
+            logger.warning("A2A call to %r: %s", agent_name, exc)
             return A2ACallResult(task=task, success=False, error=str(exc))
 
     # 3. classify the final Task
@@ -482,10 +490,21 @@ async def call_a2a(
 
         # ClientFactory.create() is annotated -> Client, but always returns BaseClient in a2a-sdk==0.3.24.
         client: BaseClient = factory.create(agent_card)  # type: ignore[assignment]
-        if httpx_client is None:
-            async with client:
+        try:
+            async with asyncio.timeout(_A2A_HARD_TIMEOUT_SECONDS) as hard_timeout:
+                if httpx_client is None:
+                    async with client:
+                        return await _call_with_open_client(client, agent_name, text, context)
                 return await _call_with_open_client(client, agent_name, text, context)
-        return await _call_with_open_client(client, agent_name, text, context)
+        except TimeoutError:
+            if not hard_timeout.expired():
+                raise  # unrelated TimeoutError; report it as itself, not as our ceiling
+            # asyncio.timeout's TimeoutError carries no message; supply one so it isn't empty.
+            logger.warning("A2A call to %r hit the %ss hard timeout", agent_name, _A2A_HARD_TIMEOUT_SECONDS)
+            return A2ACallResult(
+                success=False,
+                error=f"A2A invocation cancelled at the {_A2A_HARD_TIMEOUT_SECONDS}s hard timeout",
+            )
 
     except Exception as exc:
         logger.exception("A2A call to %r failed", agent_name)

--- a/registry-pkgs/tests/unit/workflow/test_a2a_client.py
+++ b/registry-pkgs/tests/unit/workflow/test_a2a_client.py
@@ -1,3 +1,5 @@
+import asyncio
+import time
 from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -28,10 +30,13 @@ from registry_pkgs.testing.federation_metadata import (
     make_azure_foundry_metadata,
 )
 from registry_pkgs.workflows.a2a_client import (
+    _A2A_HARD_TIMEOUT_SECONDS,
+    _A2A_JWT_TTL_SECONDS,
     _A2A_TASK_BUDGET_SECONDS,
     A2ACallResult,
     _ensure_a2a_result_fields,
     _extra_call_headers,
+    _poll_until_terminal,
     build_headers,
     call_a2a,
 )
@@ -377,12 +382,76 @@ async def test_call_a2a_polling_timeout_returns_failure():
     with (
         patch("registry_pkgs.workflows.a2a_client.ClientFactory", return_value=mock_factory),
         patch("registry_pkgs.workflows.a2a_client.asyncio.sleep", new_callable=AsyncMock),
-        patch("registry_pkgs.workflows.a2a_client.time.monotonic", side_effect=lambda: next(monotonic_values)),
+        # Patch the module binding, not time.monotonic: asyncio's loop clock is monotonic.
+        patch("registry_pkgs.workflows.a2a_client.monotonic", side_effect=lambda: next(monotonic_values)),
     ):
         result = await call_a2a(agent, "test")
 
     assert result.success is False
     assert "polling timed out" in result.error
+
+
+@pytest.mark.asyncio
+async def test_call_a2a_hard_timeout_bounds_a_still_streaming_send():
+    """A send that keeps streaming is cancelled at the hard timeout with a usable error.
+
+    The httpx read timeout only bounds the gap between reads and the poll loop never runs,
+    so this is the one ceiling that applies. Also guards the empty-message trap:
+    asyncio.timeout raises a bare TimeoutError the broad handler would surface as ``""``.
+    """
+    agent = _make_agent()
+
+    async def never_finishing_stream(*_args, **_kwargs):
+        await asyncio.sleep(10)
+        yield (_task(TaskState.completed), None)
+
+    mock_client = MagicMock()
+    mock_client.send_message = MagicMock(side_effect=never_finishing_stream)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_factory = MagicMock()
+    mock_factory.create = MagicMock(return_value=mock_client)
+
+    with (
+        patch("registry_pkgs.workflows.a2a_client.ClientFactory", return_value=mock_factory),
+        patch("registry_pkgs.workflows.a2a_client._A2A_HARD_TIMEOUT_SECONDS", 0.05),
+    ):
+        result = await call_a2a(agent, "test")
+
+    assert result.success is False
+    assert "hard timeout" in result.error
+    assert "0.05" in result.error
+
+
+@pytest.mark.asyncio
+async def test_poll_until_terminal_honors_an_already_expired_caller_deadline():
+    """The deadline is absolute and caller-owned, so sending and polling share one budget.
+
+    Polling must abort against a deadline that has already passed rather than starting a
+    fresh budget of its own — otherwise the effective ceiling is double the advertised
+    one (send gets a full budget, then polling gets another).
+    """
+    mock_client = MagicMock()
+    mock_client.get_task = AsyncMock()
+
+    with pytest.raises(TimeoutError, match="polling timed out"):
+        await _poll_until_terminal(
+            mock_client,
+            "task-1",
+            context=MagicMock(),
+            deadline=time.monotonic() - 1.0,
+        )
+
+    mock_client.get_task.assert_not_awaited()
+
+
+def test_timeout_constants_stay_ordered():
+    """budget < hard timeout < JWT TTL.
+
+    Collapsing the first gap makes the poll loop's per-task error unreachable — the outer
+    cancellation always wins the race. Closing the second revives the mid-flight 401.
+    """
+    assert _A2A_TASK_BUDGET_SECONDS < _A2A_HARD_TIMEOUT_SECONDS < _A2A_JWT_TTL_SECONDS
 
 
 # ── call_a2a: error/empty paths ──────────────────────────────────────────────

--- a/registry-pkgs/tests/unit/workflow/test_a2a_client.py
+++ b/registry-pkgs/tests/unit/workflow/test_a2a_client.py
@@ -28,6 +28,7 @@ from registry_pkgs.testing.federation_metadata import (
     make_azure_foundry_metadata,
 )
 from registry_pkgs.workflows.a2a_client import (
+    _A2A_TASK_BUDGET_SECONDS,
     A2ACallResult,
     _ensure_a2a_result_fields,
     _extra_call_headers,
@@ -370,7 +371,8 @@ async def test_call_a2a_polling_timeout_returns_failure():
     )
 
     # Patch time.monotonic to jump past deadline on the second call.
-    monotonic_values = iter([0.0, 1000.0, 1000.0, 1000.0])
+    past_budget = _A2A_TASK_BUDGET_SECONDS + 1
+    monotonic_values = iter([0.0, past_budget, past_budget, past_budget])
 
     with (
         patch("registry_pkgs.workflows.a2a_client.ClientFactory", return_value=mock_factory),

--- a/registry/src/registry/container.py
+++ b/registry/src/registry/container.py
@@ -286,7 +286,10 @@ class RegistryContainer:
     def a2a_client_registry(self) -> A2AClientRegistry:
         return A2AClientRegistry(
             agentcore_registry=self.a2a_proxy_client_registry,
-            azure_client_cache=AzureFoundryClientCache(),
+            azure_client_cache=AzureFoundryClientCache(
+                max_connections=self.settings.azure_foundry_max_connections,
+                max_keepalive_connections=self.settings.azure_foundry_max_keepalive_connections,
+            ),
         )
 
     @cached_property
@@ -384,6 +387,8 @@ class RegistryContainer:
             jwt_signing_config=self.settings.jwt_signing_config,
             jwt_subject=self.settings.registry_app_name,
             jwt_expires_in_seconds=3600,
+            max_connections=self.settings.a2a_proxy_max_connections,
+            max_keepalive_connections=self.settings.a2a_proxy_max_keepalive_connections,
         )
 
     async def startup(self) -> None:

--- a/registry/src/registry/container.py
+++ b/registry/src/registry/container.py
@@ -353,7 +353,10 @@ class RegistryContainer:
         return httpx.AsyncClient(
             timeout=httpx.Timeout(connect=30.0, read=None, write=60.0, pool=30.0),
             follow_redirects=False,
-            limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+            limits=httpx.Limits(
+                max_connections=self.settings.a2a_max_connections,
+                max_keepalive_connections=self.settings.a2a_max_keepalive_connections,
+            ),
         )
 
     @cached_property

--- a/registry/src/registry/core/a2a_proxy.py
+++ b/registry/src/registry/core/a2a_proxy.py
@@ -57,10 +57,16 @@ class A2AProxyClientRegistry:
         jwt_signing_config: JwtSigningConfig,
         jwt_subject: str,
         jwt_expires_in_seconds: int = 3600,
+        max_connections: int = 100,
+        max_keepalive_connections: int = 20,
     ):
         self._jwt_signing_config = jwt_signing_config
         self._jwt_subject = jwt_subject
         self._expires_in_seconds = jwt_expires_in_seconds
+        self._limits = Limits(
+            max_connections=max_connections,
+            max_keepalive_connections=max_keepalive_connections,
+        )
 
         self._dict: dict[str, tuple[_ClientCacheConfig, AsyncClient]] = {}
 
@@ -107,7 +113,7 @@ class A2AProxyClientRegistry:
         client = AsyncClient(
             timeout=Timeout(30.0, read=60.0),
             follow_redirects=True,
-            limits=Limits(max_connections=100, max_keepalive_connections=20),
+            limits=self._limits,
             auth=auth,
         )
 

--- a/registry/src/registry/core/config.py
+++ b/registry/src/registry/core/config.py
@@ -173,8 +173,13 @@ class Settings(JarvisBaseSettings):
     # ==================== A2A HTTP Client ====================
     # A2A calls hold a pooled connection for their whole duration, so concurrent
     # connections scale with hold time (Little's Law) — sized for the A2A task budget.
+    # Sized by how many of each exist: one shared, one per target agent, one per federation.
     a2a_max_connections: int = 500
     a2a_max_keepalive_connections: int = 20
+    a2a_proxy_max_connections: int = 100
+    a2a_proxy_max_keepalive_connections: int = 20
+    azure_foundry_max_connections: int = 300
+    azure_foundry_max_keepalive_connections: int = 20
 
     # ==================== Model Validation ====================
 

--- a/registry/src/registry/core/config.py
+++ b/registry/src/registry/core/config.py
@@ -170,6 +170,12 @@ class Settings(JarvisBaseSettings):
     asor_access_token: str | None = None
     asor_client_credentials: str | None = None
 
+    # ==================== A2A HTTP Client ====================
+    # A2A calls hold a pooled connection for their whole duration, so concurrent
+    # connections scale with hold time (Little's Law) — sized for the A2A task budget.
+    a2a_max_connections: int = 500
+    a2a_max_keepalive_connections: int = 20
+
     # ==================== Model Validation ====================
 
     @model_validator(mode="after")

--- a/registry/src/registry/services/federation/azure_foundry_proxy_auth.py
+++ b/registry/src/registry/services/federation/azure_foundry_proxy_auth.py
@@ -40,9 +40,13 @@ class AzureEntraAuth(httpx.Auth):
 class AzureFoundryClientCache:
     """Cache one Azure-authenticated A2A client per federation."""
 
-    def __init__(self):
+    def __init__(self, *, max_connections: int = 300, max_keepalive_connections: int = 20):
         self._dict: dict[PydanticObjectId, httpx.AsyncClient] = {}
         self._locks: dict[PydanticObjectId, asyncio.Lock] = {}
+        self._limits = httpx.Limits(
+            max_connections=max_connections,
+            max_keepalive_connections=max_keepalive_connections,
+        )
 
     async def get_client(self, agent: A2AAgent) -> httpx.AsyncClient:
         federation_id = agent.federationRefId
@@ -73,7 +77,7 @@ class AzureFoundryClientCache:
             client = httpx.AsyncClient(
                 auth=AzureEntraAuth(auth_service),
                 timeout=httpx.Timeout(connect=30.0, read=None, write=60.0, pool=30.0),
-                limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+                limits=self._limits,
             )
             self._dict[federation_id] = client
             return client

--- a/registry/tests/unit/core/test_config.py
+++ b/registry/tests/unit/core/test_config.py
@@ -254,3 +254,12 @@ class TestSettings:
         settings = Settings(_env_file=None)
 
         assert settings.workflow_llm_model_id == _GOVERNANCE_SONNET_AIP_ARN
+
+
+@pytest.mark.unit
+@pytest.mark.core
+def test_a2a_pool_defaults_are_sized_for_hour_long_calls() -> None:
+    """A2A calls hold a pooled connection for up to the task budget, so the default pool
+    must be far above httpx's own 100."""
+    assert Settings.model_fields["a2a_max_connections"].default == 500
+    assert Settings.model_fields["a2a_max_keepalive_connections"].default == 20

--- a/registry/tests/unit/core/test_config.py
+++ b/registry/tests/unit/core/test_config.py
@@ -258,8 +258,13 @@ class TestSettings:
 
 @pytest.mark.unit
 @pytest.mark.core
-def test_a2a_pool_defaults_are_sized_for_hour_long_calls() -> None:
-    """A2A calls hold a pooled connection for up to the task budget, so the default pool
-    must be far above httpx's own 100."""
+def test_a2a_pool_defaults_are_sized_per_pool() -> None:
+    """A2A calls hold a pooled connection for up to the task budget, so each pool is sized
+    for how many of it exist: one shared workflow pool, one proxy pool per target agent,
+    one Azure pool per federation."""
     assert Settings.model_fields["a2a_max_connections"].default == 500
     assert Settings.model_fields["a2a_max_keepalive_connections"].default == 20
+    assert Settings.model_fields["a2a_proxy_max_connections"].default == 100
+    assert Settings.model_fields["a2a_proxy_max_keepalive_connections"].default == 20
+    assert Settings.model_fields["azure_foundry_max_connections"].default == 300
+    assert Settings.model_fields["azure_foundry_max_keepalive_connections"].default == 20

--- a/registry/tests/unit/test_container.py
+++ b/registry/tests/unit/test_container.py
@@ -92,6 +92,29 @@ def test_a2a_httpx_client_pool_limits_come_from_settings(mock_async_client):
 
 
 @pytest.mark.unit
+def test_proxy_and_azure_pools_use_their_own_settings():
+    """The proxy pool is per target agent and the Azure pool is per federation, so they are
+    sized independently. Distinct sentinels catch a cross-wired setting."""
+    settings = _make_settings()
+    settings.a2a_proxy_max_connections = 111
+    settings.a2a_proxy_max_keepalive_connections = 11
+    settings.azure_foundry_max_connections = 333
+    settings.azure_foundry_max_keepalive_connections = 33
+    container = RegistryContainer(
+        settings=settings,
+        db_client=MagicMock(),
+        redis_client=MagicMock(),
+    )
+
+    registry = container.a2a_client_registry
+
+    assert registry._agentcore_registry._limits.max_connections == 111
+    assert registry._agentcore_registry._limits.max_keepalive_connections == 11
+    assert registry._azure_client_cache._limits.max_connections == 333
+    assert registry._azure_client_cache._limits.max_keepalive_connections == 33
+
+
+@pytest.mark.unit
 def test_skill_service_is_app_scoped_and_uses_shared_acl_service():
     container = _make_container(_make_settings())
 

--- a/registry/tests/unit/test_container.py
+++ b/registry/tests/unit/test_container.py
@@ -71,6 +71,27 @@ class TestWorkflowRunnerModelSelection:
 
 
 @pytest.mark.unit
+@patch("registry.container.httpx.AsyncClient")
+def test_a2a_httpx_client_pool_limits_come_from_settings(mock_async_client):
+    """Long A2A reads hold pooled connections for the whole call, so the pool size must
+    stay settings-tunable rather than hardcoded."""
+    settings = _make_settings()
+    settings.a2a_max_connections = 777  # sentinels, not the defaults, so pass-through is unambiguous
+    settings.a2a_max_keepalive_connections = 13
+    container = RegistryContainer(
+        settings=settings,
+        db_client=MagicMock(),
+        redis_client=MagicMock(),
+    )
+
+    _ = container.a2a_httpx_client
+
+    limits = mock_async_client.call_args.kwargs["limits"]
+    assert limits.max_connections == 777
+    assert limits.max_keepalive_connections == 13
+
+
+@pytest.mark.unit
 def test_skill_service_is_app_scoped_and_uses_shared_acl_service():
     container = _make_container(_make_settings())
 


### PR DESCRIPTION
## Summary

  Longer running A2A agents were consistently timing out around the 5 minute mark during normal triggers and particularly during workflows. 
  
  ## Changes

  All three values now derive from one lever to control future updates

  ```python
  _A2A_TASK_BUDGET_SECONDS = 3600
  _A2A_JWT_TTL_SECONDS = _A2A_TASK_BUDGET_SECONDS + 300
  _A2A_HTTP_TIMEOUT = httpx.Timeout(30.0, read=_A2A_TASK_BUDGET_SECONDS)
  ```

  - **Only `read` stretches to the budget.** `connect`/`write`/`pool` stay at 30s, so an unreachable host still fails fast instead of hanging for an hour. This matters most for `pool`: with agents holding connections for 10+ minutes, a workflow fan-out can exhaust the pool, and a flat scalar would make the next request wait an hour for a slot.
  - **Poll backoff extended** to cap at 30s (was 8s), keeping an hour-long task at ~2 polls/min instead of ~8. 
  - **JWT TTL derives from the budget** rather than being independently set, so the credential always outlives the task.