### PR TITLE
Feature/as 1795 1

### DIFF
--- a/docs/design/skill-sync-source-api.md
+++ b/docs/design/skill-sync-source-api.md
@@ -1,0 +1,714 @@
+# Skill Sync Source Management API
+
+## Table of Contents
+
+1. [API Route Prefix](#api-route-prefix)
+2. [API Endpoints](#api-endpoints)
+   - 2.1. [Create Skill Sync Source](#1-create-skill-sync-source)
+   - 2.2. [List Skill Sync Sources](#2-list-skill-sync-sources)
+   - 2.3. [Get Skill Sync Source Detail](#3-get-skill-sync-source-detail)
+   - 2.4. [Update Skill Sync Source](#4-update-skill-sync-source)
+   - 2.5. [Delete Skill Sync Source](#5-delete-skill-sync-source)
+   - 2.6. [Trigger Sync](#6-trigger-sync)
+   - 2.7. [Initiate OAuth](#7-initiate-oauth)
+   - 2.8. [OAuth Callback](#8-oauth-callback)
+   - 2.9. [Get Sync Job](#9-get-sync-job)
+3. [Access Control](#access-control)
+4. [Data Models](#data-models)
+   - 4.1. [SkillSyncSource](#skillsyncsource)
+   - 4.2. [SkillSyncJob](#skillsyncjob)
+   - 4.3. [Enums](#enums)
+5. [State Machine](#state-machine)
+6. [GitHub App OAuth Flow (PKCE)](#github-app-oauth-flow-pkce)
+7. [Token Management](#token-management)
+8. [Error Response Format](#error-response-format)
+
+---
+
+## API Route Prefix
+
+```
+/api/v1/skill-sync-sources
+```
+
+---
+
+## API Endpoints
+
+### 1. Create Skill Sync Source
+
+**Endpoint**: `POST /api/v1/skill-sync-sources`
+
+**Request Body**:
+```json
+{
+  "displayName": "My Skills Repo",
+  "description": "Production skill definitions",
+  "tags": ["production", "internal"],
+  "owner": "my-org",
+  "repo": "skills-repo",
+  "ref": "main",
+  "paths": ["skills/", "prompts/mcp"],
+  "skillDiscoveryDepth": 2,
+  "githubAppClientId": "github-app-client-id",
+  "githubAppClientSecret": "github-app-client-secret"
+}
+```
+
+**Request Fields**:
+- `displayName` (required, string): Human-readable name, 1–128 characters
+- `description` (optional, string): Source description
+- `tags` (optional, array of strings): Categorization tags
+- `owner` (required, string): GitHub owner (user or org), 1–39 characters, alphanumeric + hyphens, regex: `^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$`
+- `repo` (required, string): GitHub repository name, 1–100 characters, regex: `^[A-Za-z0-9._-]+$`
+- `ref` (optional, string): Git ref to sync from (default: `"main"`), 1–255 characters, validated against path traversal
+- `paths` (required, array of strings, min 1): Repository-relative POSIX paths to scan for skills. Must be safe relative paths (no leading `/`, no `..`, no `\`)
+- `skillDiscoveryDepth` (optional, integer): Max directory depth for skill discovery (default: 2, range: 0–10)
+- `githubAppClientId` (required, string): GitHub App OAuth client ID
+- `githubAppClientSecret` (required, string): GitHub App client secret (encrypted at rest via AES-CBC)
+
+**Validation Rules**:
+- `paths` must not contain duplicates after normalization
+- `ref` must be a safe Git ref (no `..`, `//`, `@{`, or `\`)
+- `owner` must match GitHub username format
+- `repo` must match GitHub repository name format
+
+**Response**: `201 Created`
+```json
+{
+  "id": "source-id-1",
+  "providerType": "github",
+  "displayName": "My Skills Repo",
+  "description": "Production skill definitions",
+  "tags": ["production", "internal"],
+  "owner": "my-org",
+  "repo": "skills-repo",
+  "ref": "main",
+  "paths": ["skills/", "prompts/mcp"],
+  "skillDiscoveryDepth": 2,
+  "status": "active",
+  "syncStatus": "idle",
+  "syncMessage": null,
+  "stats": { "skillCount": 0, "fileCount": 0 },
+  "lastSync": null,
+  "permissions": { "VIEW": true, "EDIT": true, "DELETE": true, "SHARE": true },
+  "createdAt": "2026-08-19T10:30:00Z",
+  "updatedAt": "2026-08-19T10:30:00Z",
+  "githubAppClientId": "github-app-client-id",
+  "hasClientSecret": true,
+  "recentJobs": [],
+  "createdBy": "user-id-1",
+  "updatedBy": "user-id-1"
+}
+```
+
+**Important Notes**:
+- The creator is automatically granted **OWNER** permission (VIEW + EDIT + DELETE + SHARE) via an atomic MongoDB transaction
+- `githubAppClientSecret` is never returned in any response; `hasClientSecret` indicates whether one is stored
+
+**Error**:
+- `400` Validation error (invalid paths, bad owner/repo format, missing required fields)
+- `500` Internal server error
+
+---
+
+### 2. List Skill Sync Sources
+
+**Endpoint**: `GET /api/v1/skill-sync-sources`
+
+**Query Parameters**:
+```typescript
+{
+  syncStatus?: string;     // Filter by sync status (e.g., "idle", "syncing", "failed")
+  tag?: string;            // Filter by tag
+  query?: string;          // Full-text search (displayName, description)
+  page?: number;           // Page number (default: 1, min: 1)
+  perPage?: number;        // Items per page (default: 20, min: 1, max: 100)
+}
+```
+
+**Response**: `200 OK`
+```json
+{
+  "sources": [
+    {
+      "id": "source-id-1",
+      "providerType": "github",
+      "displayName": "My Skills Repo",
+      "description": "Production skill definitions",
+      "tags": ["production"],
+      "owner": "my-org",
+      "repo": "skills-repo",
+      "ref": "main",
+      "paths": ["skills/"],
+      "skillDiscoveryDepth": 2,
+      "status": "active",
+      "syncStatus": "success",
+      "syncMessage": null,
+      "stats": { "skillCount": 12, "fileCount": 8 },
+      "lastSync": {
+        "jobId": "job-id-1",
+        "status": "success",
+        "startedAt": "2026-08-19T10:00:00Z",
+        "finishedAt": "2026-08-19T10:02:30Z",
+        "commitSha": "commit-sha-1"
+      },
+      "permissions": { "VIEW": true, "EDIT": true, "DELETE": false, "SHARE": false },
+      "createdAt": "2026-08-19T10:30:00Z",
+      "updatedAt": "2026-08-19T15:45:00Z"
+    }
+  ],
+  "pagination": {
+    "total": 5,
+    "page": 1,
+    "perPage": 20,
+    "totalPages": 1
+  }
+}
+```
+
+**Important Notes**:
+- Only returns sources the authenticated user has VIEW access to (ACL-filtered)
+- Each source includes per-resource `permissions` for the requesting user
+- Results are sorted by `updatedAt` descending
+
+**Error**:
+- `500` Internal server error
+
+---
+
+### 3. Get Skill Sync Source Detail
+
+**Endpoint**: `GET /api/v1/skill-sync-sources/{source_id}`
+
+**Response**: `200 OK`
+```json
+{
+  "id": "source-id-1",
+  "providerType": "github",
+  "displayName": "My Skills Repo",
+  "description": "Production skill definitions",
+  "tags": ["production"],
+  "owner": "my-org",
+  "repo": "skills-repo",
+  "ref": "main",
+  "paths": ["skills/"],
+  "skillDiscoveryDepth": 2,
+  "status": "active",
+  "syncStatus": "success",
+  "syncMessage": null,
+  "stats": { "skillCount": 12, "fileCount": 8 },
+  "lastSync": {
+    "jobId": "job-id-1",
+    "status": "success",
+    "startedAt": "2026-08-19T10:00:00Z",
+    "finishedAt": "2026-08-19T10:02:30Z",
+    "commitSha": "commit-sha-1"
+  },
+  "permissions": { "VIEW": true, "EDIT": true, "DELETE": true, "SHARE": true },
+  "createdAt": "2026-08-19T10:30:00Z",
+  "updatedAt": "2026-08-19T15:45:00Z",
+  "githubAppClientId": "github-app-client-id",
+  "hasClientSecret": true,
+  "recentJobs": [
+    {
+      "id": "job-id-1",
+      "sourceId": "source-id-1",
+      "jobType": "full_sync",
+      "triggerType": "manual",
+      "status": "success",
+      "phase": "completed",
+      "requestSnapshot": {},
+      "discoverySummary": { "discoveredSkillCount": 12, "discoveredFileCount": 8, "skippedPaths": [] },
+      "applySummary": { "skillsCreated": 12, "skillsUpdated": 0, "skillsDeleted": 0, "skillsFailed": 0, "filesCreated": 8, "filesUpdated": 0, "filesDeleted": 0 },
+      "skillErrors": [],
+      "errorCode": null,
+      "error": null,
+      "startedAt": "2026-08-19T10:00:00Z",
+      "finishedAt": "2026-08-19T10:02:30Z",
+      "createdAt": "2026-08-19T10:00:00Z",
+      "updatedAt": "2026-08-19T10:02:30Z"
+    }
+  ],
+  "createdBy": "user-id-1",
+  "updatedBy": "user-id-1"
+}
+```
+
+**Important Notes**:
+- Detail response extends the list response with `githubAppClientId`, `hasClientSecret`, `recentJobs`, `createdBy`, `updatedBy`
+- `recentJobs` returns the last 10 jobs sorted by `createdAt` descending
+
+**Error**:
+- `403` User does not have VIEW permission
+- `404` Source not found
+- `500` Internal server error
+
+---
+
+### 4. Update Skill Sync Source
+
+**Endpoint**: `PUT /api/v1/skill-sync-sources/{source_id}`
+
+**Request Body** (all fields optional, partial update via `exclude_unset`):
+```json
+{
+  "displayName": "Updated Name",
+  "description": "Updated description",
+  "tags": ["production", "v2"],
+  "owner": "new-org",
+  "repo": "new-repo",
+  "ref": "develop",
+  "paths": ["src/skills/"],
+  "skillDiscoveryDepth": 3,
+  "githubAppClientId": "new-github-app-client-id",
+  "githubAppClientSecret": "new-secret",
+  "syncAfterUpdate": false
+}
+```
+
+**Request Fields**:
+- All create fields are accepted (same validation rules apply)
+- `syncAfterUpdate` (optional, boolean, default: `false`): When `true`, triggers a sync after the update. Currently returns `501 Not Implemented` (deferred to PR2)
+
+**Behavior**:
+- Only `ACTIVE` sources can be updated (state machine guard)
+- Changing `githubAppClientId` or `githubAppClientSecret` automatically **deletes all stored OAuth tokens** for this source, forcing re-authorization on next sync
+
+**Response**: `200 OK` — returns the updated `SkillSyncSourceDetailResponse`
+
+**Error**:
+- `403` User does not have EDIT permission
+- `404` Source not found
+- `409` Source cannot be updated (status is not `ACTIVE`)
+- `501` `syncAfterUpdate=true` is not yet implemented
+- `500` Internal server error
+
+---
+
+### 5. Delete Skill Sync Source
+
+**Endpoint**: `DELETE /api/v1/skill-sync-sources/{source_id}`
+
+> **Status**: `501 Not Implemented` — gated until PR2 ships the sync execution engine.
+
+When implemented, this endpoint will:
+1. Transition source status to `DELETING`
+2. Create a `DELETE_SYNC` job to remove all synced skills
+3. Return `202 Accepted` with the job ID
+
+**Response** (planned): `202 Accepted`
+```json
+{
+  "sourceId": "source-id-1",
+  "jobId": "job-id-2",
+  "status": "pending"
+}
+```
+
+**Error**:
+- `403` User does not have DELETE permission
+- `404` Source not found
+- `409` Source cannot be deleted (status is not `ACTIVE`)
+- `501` Not implemented (current)
+- `500` Internal server error
+
+---
+
+### 6. Trigger Sync
+
+**Endpoint**: `POST /api/v1/skill-sync-sources/{source_id}/sync`
+
+> **Status**: `501 Not Implemented` — gated until PR2 ships the sync execution engine.
+
+When implemented, this endpoint will:
+1. Check for an existing OAuth token (access → refresh fallback)
+2. If no valid token, return `needsAuthorization: true` with `authorizeUrl`
+3. If token is valid, create a `FULL_SYNC` job and return job details
+
+**Response** (planned): `200 OK`
+```json
+{
+  "job": {
+    "id": "job-id-3",
+    "sourceId": "source-id-1",
+    "jobType": "full_sync",
+    "triggerType": "manual",
+    "status": "pending",
+    "phase": "queued",
+    "...": "..."
+  },
+  "needsAuthorization": false,
+  "authorizeUrl": null
+}
+```
+
+Or when re-authorization is needed:
+```json
+{
+  "job": null,
+  "needsAuthorization": true,
+  "authorizeUrl": "https://github.com/login/oauth/authorize?client_id=...&state=...&code_challenge=...&code_challenge_method=S256"
+}
+```
+
+**Error**:
+- `403` User does not have EDIT permission
+- `404` Source not found
+- `409` Source already has an active sync job
+- `501` Not implemented (current)
+- `500` Internal server error
+
+---
+
+### 7. Initiate OAuth
+
+**Endpoint**: `GET /api/v1/skill-sync-sources/{source_id}/oauth/initiate`
+
+> **Status**: `501 Not Implemented` — gated until PR2.
+
+When implemented, this endpoint will:
+1. Generate PKCE `code_verifier` + `code_challenge` (S256 via authlib)
+2. Store OAuth flow state in FlowStateManager (Redis or memory fallback)
+3. Redirect (`307`) to `https://github.com/login/oauth/authorize` with PKCE parameters
+
+**Response** (planned): `307 Temporary Redirect`
+- `Location: https://github.com/login/oauth/authorize?client_id=...&redirect_uri=...&state=...&code_challenge=...&code_challenge_method=S256`
+
+**Error**:
+- `403` User does not have EDIT permission
+- `404` Source not found
+- `501` Not implemented (current)
+- `500` Internal server error
+
+---
+
+### 8. OAuth Callback
+
+**Endpoint**: `GET /api/v1/skill-sync-sources/{source_id}/oauth/callback`
+
+This is the GitHub OAuth redirect target. It is **unauthenticated** (GitHub redirects do not carry session cookies).
+
+**Query Parameters** (set by GitHub):
+```typescript
+{
+  code?: string;    // Authorization code
+  state?: string;   // CSRF state token
+  error?: string;   // Error from GitHub (e.g., "access_denied")
+}
+```
+
+**Current Behavior** (PR1):
+- If `error` is present or `code`/`state` is missing → redirects to frontend with `error=auth_failed`
+- If source exists → redirects to frontend with `error=sync_unavailable`
+- If source not found → redirects to frontend with `error=auth_failed`
+
+**Planned Behavior** (PR2):
+1. Validate state token and consume flow from FlowStateManager
+2. Exchange `code` for tokens at `https://github.com/login/oauth/access_token` (with `code_verifier`)
+3. Store encrypted tokens (access + refresh) in MongoDB `Token` collection
+4. Redirect to frontend: `{registry_client_url}/skill-sync-sources/{source_id}?syncTriggered=true`
+
+**Response**: `307 Temporary Redirect`
+- Success: `Location: {registry_client_url}/skill-sync-sources/{source_id}?syncTriggered=true`
+- Error: `Location: {registry_client_url}/skill-sync-sources/{source_id}?error=auth_failed`
+
+---
+
+### 9. Get Sync Job
+
+**Endpoint**: `GET /api/v1/skill-sync-sources/{source_id}/jobs/{job_id}`
+
+**Response**: `200 OK`
+```json
+{
+  "id": "job-id-1",
+  "sourceId": "source-id-1",
+  "jobType": "full_sync",
+  "triggerType": "manual",
+  "status": "syncing",
+  "phase": "discovering",
+  "requestSnapshot": {},
+  "discoverySummary": {
+    "discoveredSkillCount": 8,
+    "discoveredFileCount": 5,
+    "skippedPaths": ["vendor/"]
+  },
+  "applySummary": {
+    "skillsCreated": 0,
+    "skillsUpdated": 0,
+    "skillsDeleted": 0,
+    "skillsFailed": 0,
+    "filesCreated": 0,
+    "filesUpdated": 0,
+    "filesDeleted": 0
+  },
+  "skillErrors": [],
+  "errorCode": null,
+  "error": null,
+  "startedAt": "2026-08-19T10:00:00Z",
+  "finishedAt": null,
+  "createdAt": "2026-08-19T10:00:00Z",
+  "updatedAt": "2026-08-19T10:01:15Z"
+}
+```
+
+**Error**:
+- `403` User does not have VIEW permission on the source
+- `404` Source or job not found
+- `500` Internal server error
+
+---
+
+## Access Control
+
+Skill sync sources use the same ACL system as MCP Servers, A2A Agents, and Workflows:
+
+| Property | Value |
+|----------|-------|
+| Resource type | `skill_sync_source` (in `RegistryResourceType` enum) |
+| Permission bits | VIEW (1), EDIT (3), DELETE / OWNER (15) |
+| Seed roles | `skill_sync_source_viewer` (permBits=1), `skill_sync_source_editor` (permBits=3), `skill_sync_source_owner` (permBits=15) |
+| On create | Creator is automatically granted OWNER permission (atomic MongoDB transaction) |
+
+**Per-endpoint permission requirements**:
+
+| Endpoint | Required Permission |
+|----------|-------------------|
+| `POST /` (create) | Authenticated user (any) |
+| `GET /` (list) | VIEW (ACL-filtered) |
+| `GET /{id}` (detail) | VIEW |
+| `PUT /{id}` (update) | EDIT |
+| `DELETE /{id}` | DELETE |
+| `POST /{id}/sync` | EDIT |
+| `GET /{id}/oauth/initiate` | EDIT |
+| `GET /{id}/oauth/callback` | None (unauthenticated, GitHub redirect) |
+| `GET /{id}/jobs/{job_id}` | VIEW |
+
+---
+
+## Data Models
+
+### SkillSyncSource
+
+MongoDB collection: `skill_sync_sources`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `providerType` | SkillSyncProviderType | Source provider, always `github` for now |
+| `displayName` | string | Human-readable name |
+| `description` | string \| null | Optional description |
+| `tags` | string[] | Categorization tags |
+| `owner` | string | GitHub owner (user or org) |
+| `repo` | string | GitHub repository name |
+| `ref` | string | Git ref (branch/tag), default `"main"` |
+| `paths` | string[] | Repo-relative POSIX paths to scan |
+| `skillDiscoveryDepth` | int | Max directory depth for discovery (0–10) |
+| `githubAppClientId` | string | GitHub App OAuth client ID |
+| `githubAppClientSecretEncrypted` | string | AES-CBC encrypted client secret |
+| `status` | SkillSyncSourceStatus | Source lifecycle status |
+| `syncStatus` | SkillSyncStatus | Current sync state |
+| `syncMessage` | string \| null | Last sync error/status message |
+| `stats` | SkillSyncSourceStats | `{ skillCount, fileCount }` |
+| `lastSync` | SkillSyncSourceLastSync \| null | Last completed sync snapshot |
+| `createdBy` | string \| null | Creator user ID |
+| `updatedBy` | string \| null | Last updater user ID |
+| `createdAt` | datetime | Auto-set on insert |
+| `updatedAt` | datetime | Auto-updated on save |
+| `deletedAt` | datetime \| null | Soft delete timestamp |
+
+**Indexes**:
+- `(providerType, status, updatedAt desc)` — filtered listing
+- `(syncStatus, updatedAt desc)` — sync queue queries
+- Text index on `(displayName, description)` — full-text search
+
+### SkillSyncJob
+
+MongoDB collection: `skill_sync_jobs`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sourceId` | PydanticObjectId | Reference to SkillSyncSource |
+| `jobType` | SkillSyncJobType | `full_sync` / `config_resync` / `delete_sync` |
+| `triggerType` | SkillSyncTriggerType | `manual` / `oauth_callback` / `api` |
+| `triggeredBy` | string | User ID who triggered the job |
+| `status` | SkillSyncJobStatus | Job status |
+| `phase` | SkillSyncJobPhase | Detailed execution phase |
+| `requestSnapshot` | dict | Frozen source config at job creation time |
+| `discoverySummary` | SkillSyncDiscoverySummary | `{ discoveredSkillCount, discoveredFileCount, skippedPaths }` |
+| `applySummary` | SkillSyncApplySummary | `{ skillsCreated/Updated/Deleted/Failed, filesCreated/Updated/Deleted }` |
+| `skillErrors` | SkillSyncSkillError[] | Per-skill error details |
+| `errorCode` | string \| null | Machine-readable error code |
+| `error` | string \| null | Human-readable error message |
+| `startedAt` | datetime \| null | When execution started |
+| `finishedAt` | datetime \| null | When execution completed |
+
+**Indexes**:
+- `(sourceId, createdAt desc)` — recent jobs query
+- `(sourceId, status)` — active job guard
+
+### Enums
+
+**SkillSyncSourceStatus**: `active` | `deleting` | `deleted`
+
+**SkillSyncStatus**: `idle` | `pending` | `syncing` | `success` | `partial_success` | `failed`
+
+**SkillSyncJobType**: `full_sync` | `config_resync` | `delete_sync`
+
+**SkillSyncTriggerType**: `manual` | `oauth_callback` | `api`
+
+**SkillSyncJobStatus**: `pending` | `syncing` | `success` | `partial_success` | `failed`
+
+**SkillSyncJobPhase**: `queued` | `downloading` | `extracting` | `discovering` | `applying` | `completed` | `failed`
+
+**SkillSyncJobErrorCode**: `github_auth_failed` | `github_rate_limited` | `github_not_found` | `download_failed` | `download_too_large` | `extraction_failed` | `decompression_bomb` | `no_skills_found` | `sync_not_implemented` | `internal_error`
+
+**SkillSyncSkillErrorCode**: `skill_parse_failed` | `skill_name_missing` | `duplicate_skill_name` | `file_too_large` | `too_many_files` | `write_failed`
+
+---
+
+## State Machine
+
+### Source Status Transitions
+
+```
+ACTIVE ──→ DELETING ──→ DELETED
+  ↑            │
+  └── (restore on delete failure)
+```
+
+- Only `ACTIVE` sources can be updated or start a sync
+- Only `ACTIVE` sources can transition to `DELETING`
+- `restore_after_delete_failure` reverts `DELETING` → `ACTIVE` with `syncStatus=FAILED`
+
+### Sync Status Transitions
+
+```
+IDLE ──→ PENDING ──→ SYNCING ──→ SUCCESS
+  ↑                      │        PARTIAL_SUCCESS
+  └──────────────────────←── FAILED
+```
+
+- `can_start_sync`: allowed from `IDLE`, `SUCCESS`, `PARTIAL_SUCCESS`, `FAILED`
+- Cannot start a new sync while in `PENDING` or `SYNCING`
+
+### Job Status Transitions
+
+```
+PENDING → SYNCING → SUCCESS / PARTIAL_SUCCESS / FAILED
+```
+
+### Job Phase Transitions
+
+```
+QUEUED → DOWNLOADING → EXTRACTING → DISCOVERING → APPLYING → COMPLETED
+                                                                FAILED
+```
+
+---
+
+## GitHub App OAuth Flow (PKCE)
+
+### Prerequisites
+
+1. **Create a GitHub App** (not an OAuth App):
+   - GitHub → Settings → Developer settings → GitHub Apps → New GitHub App
+   - Set Callback URL to `https://<your-domain>/api/v1/skill-sync-sources/{source_id}/oauth/callback`
+   - Enable "Request user authorization (OAuth) during installation"
+
+2. **Set permissions**: Repository permissions → Contents → **Read-only**
+
+3. **Generate client secret** on the App settings page
+
+4. **Install the App** on the target org/user account, granting access to specific repositories
+
+### Flow Sequence
+
+```
+1. User clicks "Connect GitHub"
+   → GET /api/v1/skill-sync-sources/{source_id}/oauth/initiate
+
+2. Server generates PKCE parameters:
+   - code_verifier = secrets.token_urlsafe(32)
+   - code_challenge = create_s256_code_challenge(code_verifier)  # via authlib
+   - Stores flow state in FlowStateManager (Redis / memory fallback)
+
+3. Server redirects (307) to GitHub:
+   → https://github.com/login/oauth/authorize
+     ?client_id={githubAppClientId}
+     &redirect_uri={callback_url}
+     &state={encrypted_flow_state}
+     &code_challenge={code_challenge}
+     &code_challenge_method=S256
+
+4. User authorizes on GitHub
+
+5. GitHub redirects to callback:
+   → GET /api/v1/skill-sync-sources/{source_id}/oauth/callback
+     ?code={authorization_code}
+     &state={state}
+
+6. Server exchanges code for tokens:
+   → POST https://github.com/login/oauth/access_token
+     client_id, client_secret, code, redirect_uri, code_verifier
+
+7. Server stores encrypted tokens (AES-CBC) in MongoDB Token collection
+
+8. Server redirects to frontend:
+   → {registry_client_url}/skill-sync-sources/{source_id}?syncTriggered=true
+```
+
+### Token Prefix Reference
+
+| Prefix | Type | Description |
+|--------|------|-------------|
+| `ghu_` | GitHub App user-to-server token | Issued by GitHub Apps via user OAuth |
+| `gho_` | OAuth App token | Issued by classic OAuth Apps (not used here) |
+
+---
+
+## Token Management
+
+### Storage
+
+OAuth tokens are stored in the `tokens` MongoDB collection with AES-CBC encryption:
+
+| Token Type | Identifier Pattern | Default Lifetime |
+|------------|-------------------|-----------------|
+| `skill_sync_github_access` | `skillsync:{source_id}` | 10 years (GitHub Apps without expiration setting) |
+| `skill_sync_github_refresh` | `skillsync:{source_id}` | 1 year |
+
+### Resolution Flow
+
+```
+resolve_access_token(user_id, source_id, client_id, client_secret):
+  1. Look up access token → if valid (not expired), return it
+  2. Look up refresh token → if valid, refresh via GitHub API → store new tokens → return
+  3. No valid token → return None (caller returns needsAuthorization=true)
+```
+
+### Token Cleanup
+
+- When `githubAppClientId` or `githubAppClientSecret` is changed via `PUT`, all stored tokens for the source are deleted
+- When a source is deleted, all associated tokens are removed
+
+---
+
+## Error Response Format
+
+All error responses follow the standard format:
+
+```json
+{
+  "detail": "Human-readable error message"
+}
+```
+
+| Status Code | Meaning |
+|-------------|---------|
+| `400` | Validation error (invalid input) |
+| `403` | Insufficient permissions |
+| `404` | Resource not found |
+| `409` | Conflict (invalid state for operation, e.g., updating a non-ACTIVE source) |
+| `501` | Feature not yet implemented (sync execution, delete, OAuth) |
+| `500` | Internal server error |

--- a/registry-pkgs/src/registry_pkgs/database/mongodb.py
+++ b/registry-pkgs/src/registry_pkgs/database/mongodb.py
@@ -23,6 +23,8 @@ from ..models import (
     NodeRun,
     RegistryAccessRole,
     RegistryAclEntry,
+    SkillSyncJob,
+    SkillSyncSource,
     Token,
     User,
     WorkflowDefinition,
@@ -107,6 +109,8 @@ class MongoDB:
                 "A2AAgent": A2AAgent,
                 "Federation": Federation,
                 "FederationSyncJob": FederationSyncJob,
+                "SkillSyncSource": SkillSyncSource,
+                "SkillSyncJob": SkillSyncJob,
                 "ExtendedSkill": ExtendedSkill,
                 "ExtendedSkillFile": ExtendedSkillFile,
             }
@@ -120,6 +124,8 @@ class MongoDB:
             A2AAgent.model_rebuild(_types_namespace=rebuild_namespace)
             Federation.model_rebuild(_types_namespace=rebuild_namespace)
             FederationSyncJob.model_rebuild(_types_namespace=rebuild_namespace)
+            SkillSyncSource.model_rebuild(_types_namespace=rebuild_namespace)
+            SkillSyncJob.model_rebuild(_types_namespace=rebuild_namespace)
             ExtendedSkill.model_rebuild(_types_namespace=rebuild_namespace)
             ExtendedSkillFile.model_rebuild(_types_namespace=rebuild_namespace)
 
@@ -137,6 +143,8 @@ class MongoDB:
                     A2AAgent,
                     Federation,
                     FederationSyncJob,
+                    SkillSyncSource,
+                    SkillSyncJob,
                     WorkflowDefinition,
                     WorkflowRun,
                     NodeRun,

--- a/registry-pkgs/src/registry_pkgs/models/__init__.py
+++ b/registry-pkgs/src/registry_pkgs/models/__init__.py
@@ -32,6 +32,8 @@ from .federation_metadata import (
     FederationMetadata,
 )
 from .federation_sync_job import FederationSyncJob
+from .skill_sync_job import SkillSyncJob
+from .skill_sync_source import SkillSyncSource
 from .token_type import TokenType
 from .workflow import NodeRun, WorkflowDefinition, WorkflowRun, WorkflowVersion
 
@@ -49,6 +51,8 @@ __all__ = [
     "AzureFoundryFederationMetadata",
     "FederationMetadata",
     "FederationSyncJob",
+    "SkillSyncJob",
+    "SkillSyncSource",
     "RegistryAccessRole",
     "NodeRun",
     "WorkflowDefinition",

--- a/registry-pkgs/src/registry_pkgs/models/enums.py
+++ b/registry-pkgs/src/registry_pkgs/models/enums.py
@@ -51,6 +51,179 @@ class FederationProviderType(StrEnum):
     AZURE_AI_FOUNDRY = "azure_ai_foundry"
 
 
+class SkillSyncProviderType(StrEnum):
+    """Supported providers for external skill sources."""
+
+    GITHUB = "github"
+
+
+class SkillSyncSourceStatus(StrEnum):
+    ACTIVE = "active"
+    DELETING = "deleting"
+    DELETED = "deleted"
+
+
+class SkillSyncStatus(StrEnum):
+    IDLE = "idle"
+    PENDING = "pending"
+    SYNCING = "syncing"
+    SUCCESS = "success"
+    PARTIAL_SUCCESS = "partial_success"
+    FAILED = "failed"
+
+    def is_running(self) -> bool:
+        return self in {SkillSyncStatus.PENDING, SkillSyncStatus.SYNCING}
+
+
+class SkillSyncJobType(StrEnum):
+    FULL_SYNC = "full_sync"
+    CONFIG_RESYNC = "config_resync"
+    DELETE_SYNC = "delete_sync"
+
+
+class SkillSyncTriggerType(StrEnum):
+    MANUAL = "manual"
+    OAUTH_CALLBACK = "oauth_callback"
+    API = "api"
+
+
+class SkillSyncJobStatus(StrEnum):
+    PENDING = "pending"
+    SYNCING = "syncing"
+    SUCCESS = "success"
+    PARTIAL_SUCCESS = "partial_success"
+    FAILED = "failed"
+
+
+class SkillSyncJobPhase(StrEnum):
+    QUEUED = "queued"
+    DOWNLOADING = "downloading"
+    EXTRACTING = "extracting"
+    DISCOVERING = "discovering"
+    APPLYING = "applying"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class SkillSyncJobErrorCode(StrEnum):
+    GITHUB_AUTH_FAILED = "github_auth_failed"
+    GITHUB_RATE_LIMITED = "github_rate_limited"
+    GITHUB_NOT_FOUND = "github_not_found"
+    DOWNLOAD_FAILED = "download_failed"
+    DOWNLOAD_TOO_LARGE = "download_too_large"
+    EXTRACTION_FAILED = "extraction_failed"
+    DECOMPRESSION_BOMB = "decompression_bomb"
+    NO_SKILLS_FOUND = "no_skills_found"
+    SYNC_NOT_IMPLEMENTED = "sync_not_implemented"
+    INTERNAL_ERROR = "internal_error"
+
+
+class SkillSyncSkillErrorCode(StrEnum):
+    SKILL_PARSE_FAILED = "skill_parse_failed"
+    SKILL_NAME_MISSING = "skill_name_missing"
+    DUPLICATE_SKILL_NAME = "duplicate_skill_name"
+    FILE_TOO_LARGE = "file_too_large"
+    TOO_MANY_FILES = "too_many_files"
+    WRITE_FAILED = "write_failed"
+
+
+class SkillSyncStateMachine:
+    """State transition guards for skill sync sources and jobs."""
+
+    @staticmethod
+    def can_start_sync(sync_status: SkillSyncStatus) -> bool:
+        return sync_status in {
+            SkillSyncStatus.IDLE,
+            SkillSyncStatus.SUCCESS,
+            SkillSyncStatus.PARTIAL_SUCCESS,
+            SkillSyncStatus.FAILED,
+        }
+
+    @staticmethod
+    def can_update(status: SkillSyncSourceStatus) -> bool:
+        return status == SkillSyncSourceStatus.ACTIVE
+
+    @staticmethod
+    def can_delete(status: SkillSyncSourceStatus) -> bool:
+        return status == SkillSyncSourceStatus.ACTIVE
+
+    @staticmethod
+    def transition_to_sync_pending(
+        status: SkillSyncSourceStatus,
+        sync_status: SkillSyncStatus,
+    ) -> SkillSyncStatus:
+        if status != SkillSyncSourceStatus.ACTIVE:
+            raise ValueError(f"Skill sync source in status '{status}' cannot start a sync")
+        if not SkillSyncStateMachine.can_start_sync(sync_status):
+            raise ValueError("Skill sync source already has an active sync job")
+        return SkillSyncStatus.PENDING
+
+    @staticmethod
+    def transition_to_syncing(
+        status: SkillSyncSourceStatus,
+        sync_status: SkillSyncStatus,
+    ) -> SkillSyncStatus:
+        if status != SkillSyncSourceStatus.ACTIVE:
+            raise ValueError(f"Skill sync source in status '{status}' cannot transition to syncing")
+        if sync_status not in {SkillSyncStatus.PENDING, SkillSyncStatus.SYNCING}:
+            raise ValueError(f"Skill sync source in sync status '{sync_status}' cannot transition to syncing")
+        return SkillSyncStatus.SYNCING
+
+    @staticmethod
+    def transition_to_sync_success(sync_status: SkillSyncStatus) -> SkillSyncStatus:
+        if sync_status not in {SkillSyncStatus.PENDING, SkillSyncStatus.SYNCING, SkillSyncStatus.SUCCESS}:
+            raise ValueError(f"Skill sync source in sync status '{sync_status}' cannot transition to success")
+        return SkillSyncStatus.SUCCESS
+
+    @staticmethod
+    def transition_to_sync_partial_success(sync_status: SkillSyncStatus) -> SkillSyncStatus:
+        if sync_status not in {SkillSyncStatus.PENDING, SkillSyncStatus.SYNCING, SkillSyncStatus.PARTIAL_SUCCESS}:
+            raise ValueError(f"Skill sync source in sync status '{sync_status}' cannot transition to partial_success")
+        return SkillSyncStatus.PARTIAL_SUCCESS
+
+    @staticmethod
+    def transition_to_sync_failed(sync_status: SkillSyncStatus) -> SkillSyncStatus:
+        if sync_status not in {SkillSyncStatus.PENDING, SkillSyncStatus.SYNCING, SkillSyncStatus.FAILED}:
+            raise ValueError(f"Skill sync source in sync status '{sync_status}' cannot transition to failed")
+        return SkillSyncStatus.FAILED
+
+    @staticmethod
+    def transition_to_deleting(status: SkillSyncSourceStatus) -> SkillSyncSourceStatus:
+        if not SkillSyncStateMachine.can_delete(status):
+            raise ValueError(f"Skill sync source in status '{status}' cannot be deleted")
+        return SkillSyncSourceStatus.DELETING
+
+
+class SkillSyncJobStateMachine:
+    @staticmethod
+    def transition_to_syncing(status: SkillSyncJobStatus) -> SkillSyncJobStatus:
+        if status not in {SkillSyncJobStatus.PENDING, SkillSyncJobStatus.SYNCING}:
+            raise ValueError(f"Skill sync job in status '{status}' cannot transition to syncing")
+        return SkillSyncJobStatus.SYNCING
+
+    @staticmethod
+    def transition_to_success(status: SkillSyncJobStatus) -> SkillSyncJobStatus:
+        if status not in {SkillSyncJobStatus.PENDING, SkillSyncJobStatus.SYNCING, SkillSyncJobStatus.SUCCESS}:
+            raise ValueError(f"Skill sync job in status '{status}' cannot transition to success")
+        return SkillSyncJobStatus.SUCCESS
+
+    @staticmethod
+    def transition_to_partial_success(status: SkillSyncJobStatus) -> SkillSyncJobStatus:
+        if status not in {
+            SkillSyncJobStatus.PENDING,
+            SkillSyncJobStatus.SYNCING,
+            SkillSyncJobStatus.PARTIAL_SUCCESS,
+        }:
+            raise ValueError(f"Skill sync job in status '{status}' cannot transition to partial_success")
+        return SkillSyncJobStatus.PARTIAL_SUCCESS
+
+    @staticmethod
+    def transition_to_failed(status: SkillSyncJobStatus) -> SkillSyncJobStatus:
+        if status not in {SkillSyncJobStatus.PENDING, SkillSyncJobStatus.SYNCING, SkillSyncJobStatus.FAILED}:
+            raise ValueError(f"Skill sync job in status '{status}' cannot transition to failed")
+        return SkillSyncJobStatus.FAILED
+
+
 class AgentCoreRuntimeAccessMode(StrEnum):
     """Federation-configured auth mode for AgentCore runtime data-plane access."""
 

--- a/registry-pkgs/src/registry_pkgs/models/extended_access_role.py
+++ b/registry-pkgs/src/registry_pkgs/models/extended_access_role.py
@@ -11,6 +11,7 @@ class RegistryResourceType(StrEnum):
     FEDERATION = "federation"
     WORKFLOW = "workflow"
     SKILL = "skill"
+    SKILL_SYNC_SOURCE = "skillSyncSource"
 
 
 class RegistryAccessRole(AccessRole):

--- a/registry-pkgs/src/registry_pkgs/models/skill_sync_job.py
+++ b/registry-pkgs/src/registry_pkgs/models/skill_sync_job.py
@@ -1,0 +1,69 @@
+from datetime import UTC, datetime
+from typing import Any
+
+from beanie import Document, Insert, PydanticObjectId, Replace, Save, before_event
+from pydantic import BaseModel, ConfigDict, Field
+from pymongo import IndexModel
+
+from .enums import (
+    SkillSyncJobPhase,
+    SkillSyncJobStatus,
+    SkillSyncJobType,
+    SkillSyncSkillErrorCode,
+    SkillSyncTriggerType,
+)
+
+
+class SkillSyncSkillError(BaseModel):
+    skillPath: str
+    upstreamId: str
+    errorCode: SkillSyncSkillErrorCode
+    errorMessage: str
+    phase: str
+
+
+class SkillSyncDiscoverySummary(BaseModel):
+    discoveredSkillCount: int = 0
+    discoveredFileCount: int = 0
+    skippedPaths: list[str] = Field(default_factory=list)
+
+
+class SkillSyncApplySummary(BaseModel):
+    skillsCreated: int = 0
+    skillsUpdated: int = 0
+    skillsDeleted: int = 0
+    skillsFailed: int = 0
+    filesCreated: int = 0
+    filesUpdated: int = 0
+    filesDeleted: int = 0
+
+
+class SkillSyncJob(Document):
+    sourceId: PydanticObjectId
+    jobType: SkillSyncJobType
+    triggerType: SkillSyncTriggerType = SkillSyncTriggerType.MANUAL
+    triggeredBy: str
+    status: SkillSyncJobStatus = SkillSyncJobStatus.PENDING
+    phase: SkillSyncJobPhase = SkillSyncJobPhase.QUEUED
+    requestSnapshot: dict[str, Any] = Field(default_factory=dict)
+    discoverySummary: SkillSyncDiscoverySummary = Field(default_factory=SkillSyncDiscoverySummary)
+    applySummary: SkillSyncApplySummary = Field(default_factory=SkillSyncApplySummary)
+    skillErrors: list[SkillSyncSkillError] = Field(default_factory=list)
+    errorCode: str | None = None
+    error: str | None = None
+    startedAt: datetime | None = None
+    finishedAt: datetime | None = None
+    createdAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updatedAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "skill_sync_jobs"
+        keep_nulls = False
+        use_state_management = True
+        indexes = [IndexModel([("sourceId", 1), ("createdAt", -1)]), IndexModel([("sourceId", 1), ("status", 1)])]
+
+    @before_event(Insert, Replace, Save)
+    async def update_timestamps(self) -> None:
+        self.updatedAt = datetime.now(UTC)
+
+    model_config = ConfigDict(populate_by_name=True, use_enum_values=True)

--- a/registry-pkgs/src/registry_pkgs/models/skill_sync_source.py
+++ b/registry-pkgs/src/registry_pkgs/models/skill_sync_source.py
@@ -1,0 +1,64 @@
+from datetime import UTC, datetime
+
+from beanie import Document, Insert, Replace, Save, before_event
+from pydantic import BaseModel, ConfigDict, Field
+from pymongo import IndexModel
+
+from .enums import SkillSyncJobStatus, SkillSyncProviderType, SkillSyncSourceStatus, SkillSyncStatus
+
+
+class SkillSyncSourceStats(BaseModel):
+    skillCount: int = 0
+    fileCount: int = 0
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SkillSyncSourceLastSync(BaseModel):
+    jobId: object
+    status: SkillSyncJobStatus
+    startedAt: datetime | None = None
+    finishedAt: datetime | None = None
+    commitSha: str | None = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SkillSyncSource(Document):
+    providerType: SkillSyncProviderType = SkillSyncProviderType.GITHUB
+    displayName: str
+    description: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    owner: str
+    repo: str
+    ref: str = "main"
+    paths: list[str] = Field(default_factory=list)
+    skillDiscoveryDepth: int = 2
+    githubAppClientId: str
+    githubAppClientSecretEncrypted: str
+    status: SkillSyncSourceStatus = SkillSyncSourceStatus.ACTIVE
+    syncStatus: SkillSyncStatus = SkillSyncStatus.IDLE
+    syncMessage: str | None = None
+    stats: SkillSyncSourceStats = Field(default_factory=SkillSyncSourceStats)
+    lastSync: SkillSyncSourceLastSync | None = None
+    createdBy: str | None = None
+    updatedBy: str | None = None
+    createdAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updatedAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    deletedAt: datetime | None = None
+
+    class Settings:
+        name = "skill_sync_sources"
+        keep_nulls = False
+        use_state_management = True
+        indexes = [
+            IndexModel([("providerType", 1), ("status", 1), ("updatedAt", -1)]),
+            IndexModel([("syncStatus", 1), ("updatedAt", -1)]),
+            IndexModel([("displayName", "text"), ("description", "text")]),
+        ]
+
+    @before_event(Insert, Replace, Save)
+    async def update_timestamps(self) -> None:
+        self.updatedAt = datetime.now(UTC)
+
+    model_config = ConfigDict(populate_by_name=True, use_enum_values=True)

--- a/registry-pkgs/src/registry_pkgs/models/skill_sync_source.py
+++ b/registry-pkgs/src/registry_pkgs/models/skill_sync_source.py
@@ -15,7 +15,7 @@ class SkillSyncSourceStats(BaseModel):
 
 
 class SkillSyncSourceLastSync(BaseModel):
-    jobId: object
+    jobId: str
     status: SkillSyncJobStatus
     startedAt: datetime | None = None
     finishedAt: datetime | None = None

--- a/registry-pkgs/src/registry_pkgs/models/token_type.py
+++ b/registry-pkgs/src/registry_pkgs/models/token_type.py
@@ -15,3 +15,5 @@ class TokenType(StrEnum):
     MCP_OAUTH = MCP_OAUTH_ACCESS
     MCP_OAUTH_REFRESH = "mcp_oauth_refresh"  # Refresh token
     MCP_OAUTH_CLIENT = "mcp_oauth_client"  # Client credentials (client_id, client_secret)
+    SKILL_SYNC_GITHUB_ACCESS = "skill_sync_github_access"
+    SKILL_SYNC_GITHUB_REFRESH = "skill_sync_github_refresh"

--- a/registry-pkgs/src/registry_pkgs/scopes.yml
+++ b/registry-pkgs/src/registry_pkgs/scopes.yml
@@ -474,6 +474,15 @@ skills-read:
   - action: get_skill_file_content
     method: GET
     endpoint: /skills/{skill_id}/files/{path}
+  - action: list_skill_sync_sources
+    method: GET
+    endpoint: /skill-sync-sources
+  - action: get_skill_sync_source
+    method: GET
+    endpoint: /skill-sync-sources/{source_id}
+  - action: get_skill_sync_job
+    method: GET
+    endpoint: /skill-sync-sources/{source_id}/jobs/{job_id}
 
 skills-write:
   description: "Create, update, delete, and enable/disable skills."
@@ -490,3 +499,18 @@ skills-write:
   - action: toggle_skill
     method: POST
     endpoint: /skills/{skill_id}/toggle
+  - action: create_skill_sync_source
+    method: POST
+    endpoint: /skill-sync-sources
+  - action: update_skill_sync_source
+    method: PUT
+    endpoint: /skill-sync-sources/{source_id}
+  - action: delete_skill_sync_source
+    method: DELETE
+    endpoint: /skill-sync-sources/{source_id}
+  - action: trigger_skill_sync
+    method: POST
+    endpoint: /skill-sync-sources/{source_id}/sync
+  - action: initiate_skill_sync_oauth
+    method: GET
+    endpoint: /skill-sync-sources/{source_id}/oauth/initiate

--- a/registry-pkgs/tests/unit/models/test_skill_sync_models.py
+++ b/registry-pkgs/tests/unit/models/test_skill_sync_models.py
@@ -1,0 +1,54 @@
+from registry_pkgs.models.enums import (
+    SkillSyncJobStatus,
+    SkillSyncSourceStatus,
+    SkillSyncStateMachine,
+    SkillSyncStatus,
+)
+from registry_pkgs.models.skill_sync_job import SkillSyncApplySummary, SkillSyncDiscoverySummary, SkillSyncJob
+from registry_pkgs.models.skill_sync_source import SkillSyncSource
+
+
+def test_source_defaults_and_secret_field() -> None:
+    source = SkillSyncSource.model_construct(
+        displayName="Docs",
+        owner="octocat",
+        repo="skills",
+        paths=["skills"],
+        githubAppClientId="client-id",
+        githubAppClientSecretEncrypted="encrypted-secret",
+    )
+
+    assert source.ref == "main"
+    assert source.skillDiscoveryDepth == 2
+    assert source.syncStatus == SkillSyncStatus.IDLE
+    assert "githubAppClientSecret" not in source.model_dump()
+
+
+def test_job_defaults_are_independent() -> None:
+    first = SkillSyncJob.model_construct(sourceId="source", jobType="full_sync")
+    second = SkillSyncJob.model_construct(sourceId="source", jobType="full_sync")
+
+    first.discoverySummary.skippedPaths.append("missing")
+    assert second.discoverySummary == SkillSyncDiscoverySummary()
+    assert second.applySummary == SkillSyncApplySummary()
+    assert second.status == SkillSyncJobStatus.PENDING
+
+
+def test_state_machine_rejects_concurrent_sync() -> None:
+    assert (
+        SkillSyncStateMachine.transition_to_sync_pending(
+            SkillSyncSourceStatus.ACTIVE,
+            SkillSyncStatus.SUCCESS,
+        )
+        == SkillSyncStatus.PENDING
+    )
+
+    try:
+        SkillSyncStateMachine.transition_to_sync_pending(
+            SkillSyncSourceStatus.ACTIVE,
+            SkillSyncStatus.SYNCING,
+        )
+    except ValueError as exc:
+        assert "active sync job" in str(exc)
+    else:
+        raise AssertionError("Concurrent sync must be rejected")

--- a/registry-pkgs/tests/unit/test_mongodb.py
+++ b/registry-pkgs/tests/unit/test_mongodb.py
@@ -123,6 +123,8 @@ class TestMongoDBConnection:
             assert "A2AAgent" in model_names
             assert "Federation" in model_names
             assert "FederationSyncJob" in model_names
+            assert "SkillSyncSource" in model_names
+            assert "SkillSyncJob" in model_names
 
     @pytest.mark.asyncio
     async def test_connect_db_only_once(self):

--- a/registry/src/registry/api/v1/federation/federation_routes.py
+++ b/registry/src/registry/api/v1/federation/federation_routes.py
@@ -41,7 +41,9 @@ from ....schemas.federation_api_schemas import (
 from ....schemas.server_api_schemas import PaginationMetadata
 from ....services.access_control_service import ACLService
 from ....services.federation.a2a_client_registry import A2AClientRegistry
-from ....services.federation_sync_service import run_federation_sync_background
+from ....services.federation_crud_service import FederationCrudService
+from ....services.federation_job_service import FederationJobService
+from ....services.federation_sync_service import FederationSyncService, run_federation_sync_background
 
 logger = logging.getLogger(__name__)
 
@@ -231,7 +233,7 @@ def _to_delete_response(federation, job) -> FederationDeleteResponse:
     )
 
 
-async def _get_required_federation(federation_id: str, federation_crud_service):
+async def _get_required_federation(federation_id: str, federation_crud_service: FederationCrudService):
     federation = await federation_crud_service.get_federation(federation_id)
     if federation:
         return federation
@@ -243,7 +245,7 @@ async def _get_required_federation(federation_id: str, federation_crud_service):
 
 async def _to_detail_response(
     federation,
-    federation_crud_service,
+    federation_crud_service: FederationCrudService,
     permissions: ResourcePermissions | None = None,
 ) -> FederationDetailResponse:
     recent_jobs = await federation_crud_service.get_recent_jobs(federation.id, limit=10)
@@ -284,7 +286,7 @@ def _raise_conflict(message: str) -> None:
 async def create_federation(
     data: FederationCreateRequest,
     user_context: CurrentUser,
-    federation_crud_service=Depends(get_federation_crud_service),
+    federation_crud_service: FederationCrudService = Depends(get_federation_crud_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     """
@@ -341,7 +343,7 @@ async def list_federations(
     page: int = Query(default=1, ge=1),
     per_page: int = Query(default=20, ge=1, le=100),
     pageSize: int | None = Query(default=None, ge=1, le=100, include_in_schema=False),
-    federation_crud_service=Depends(get_federation_crud_service),
+    federation_crud_service: FederationCrudService = Depends(get_federation_crud_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     """
@@ -402,7 +404,7 @@ async def list_federations(
 async def get_federation(
     federation_id: str,
     user_context: CurrentUser,
-    federation_crud_service=Depends(get_federation_crud_service),
+    federation_crud_service: FederationCrudService = Depends(get_federation_crud_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     """
@@ -437,8 +439,8 @@ async def get_federation_sync_job(
     federation_id: str,
     job_id: str,
     user_context: CurrentUser,
-    federation_crud_service=Depends(get_federation_crud_service),
-    federation_job_service=Depends(get_federation_job_service),
+    federation_crud_service: FederationCrudService = Depends(get_federation_crud_service),
+    federation_job_service: FederationJobService = Depends(get_federation_job_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     """Return one federation sync job for status polling."""
@@ -485,8 +487,8 @@ async def update_federation(
     federation_id: str,
     data: FederationUpdateRequest,
     user_context: CurrentUser,
-    federation_crud_service=Depends(get_federation_crud_service),
-    federation_sync_service=Depends(get_federation_sync_service),
+    federation_crud_service: FederationCrudService = Depends(get_federation_crud_service),
+    federation_sync_service: FederationSyncService = Depends(get_federation_sync_service),
     acl_service: ACLService = Depends(get_acl_service),
     a2a_client_registry: A2AClientRegistry = Depends(get_a2a_client_registry),
 ):
@@ -536,7 +538,11 @@ def _require_syncable_federation(federation, *, dry_run: bool) -> None:
         _raise_conflict(f"Federation in sync status '{federation.syncStatus}' cannot start a new sync")
 
 
-def _validate_sync_provider_config(federation_crud_service, provider_type, provider_config: dict) -> dict:
+def _validate_sync_provider_config(
+    federation_crud_service: FederationCrudService,
+    provider_type,
+    provider_config: dict,
+) -> dict:
     try:
         return federation_crud_service.validate_provider_config(provider_type, provider_config)
     except ValueError as exc:
@@ -555,8 +561,8 @@ async def sync_federation(
     user_context: CurrentUser,
     response: Response,
     background_tasks: BackgroundTasks,
-    federation_crud_service=Depends(get_federation_crud_service),
-    federation_sync_service=Depends(get_federation_sync_service),
+    federation_crud_service: FederationCrudService = Depends(get_federation_crud_service),
+    federation_sync_service: FederationSyncService = Depends(get_federation_sync_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     """
@@ -652,8 +658,8 @@ async def sync_federation(
 async def delete_federation(
     federation_id: str,
     user_context: CurrentUser,
-    federation_crud_service=Depends(get_federation_crud_service),
-    federation_sync_service=Depends(get_federation_sync_service),
+    federation_crud_service: FederationCrudService = Depends(get_federation_crud_service),
+    federation_sync_service: FederationSyncService = Depends(get_federation_sync_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     """

--- a/registry/src/registry/api/v1/skill_sync/skill_sync_source_routes.py
+++ b/registry/src/registry/api/v1/skill_sync/skill_sync_source_routes.py
@@ -2,19 +2,13 @@ import logging
 import math
 from urllib.parse import urlencode
 
-import httpx
 from beanie import PydanticObjectId
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi import status as http_status
 from fastapi.responses import RedirectResponse
 
-from registry_pkgs.database.mongodb import MongoDB
-from registry_pkgs.models import PrincipalType
 from registry_pkgs.models.enums import (
-    RoleBits,
-    SkillSyncJobType,
     SkillSyncStateMachine,
-    SkillSyncTriggerType,
 )
 from registry_pkgs.models.extended_access_role import RegistryResourceType
 from registry_pkgs.models.skill_sync_job import SkillSyncJob
@@ -25,7 +19,7 @@ from ....core.config import settings
 from ....deps import (
     get_acl_service,
     get_skill_sync_job_service,
-    get_skill_sync_oauth_service,
+    get_skill_sync_service,
     get_skill_sync_source_crud_service,
     get_skill_sync_token_service,
 )
@@ -44,9 +38,11 @@ from ....schemas.skill_sync_api_schemas import (
     SkillSyncTriggerResponse,
 )
 from ....services.access_control_service import ACLService
-from ....services.skill_sync_service import run_skill_sync_background
+from ....services.skill_sync_service import (
+    SKILL_SYNC_EXECUTION_UNAVAILABLE_DETAIL,
+    SkillSyncService,
+)
 from ....services.skill_sync_token_service import SkillSyncTokenService
-from ....utils.crypto_utils import decrypt_value
 
 logger = logging.getLogger(__name__)
 
@@ -118,25 +114,9 @@ async def _to_detail_response(
     permissions: ResourcePermissions | None = None,
 ) -> SkillSyncSourceDetailResponse:
     recent_jobs = await source_service.get_recent_jobs(source.id)
+    base = _to_list_response(source, permissions)
     return SkillSyncSourceDetailResponse(
-        id=str(source.id),
-        providerType=source.providerType,
-        displayName=source.displayName,
-        description=source.description,
-        tags=source.tags,
-        owner=source.owner,
-        repo=source.repo,
-        ref=source.ref,
-        paths=source.paths,
-        skillDiscoveryDepth=source.skillDiscoveryDepth,
-        status=source.status,
-        syncStatus=source.syncStatus,
-        syncMessage=source.syncMessage,
-        stats=SkillSyncSourceStatsResponse.model_validate(source.stats),
-        lastSync=_to_last_sync_response(source.lastSync),
-        permissions=permissions,
-        createdAt=source.createdAt,
-        updatedAt=source.updatedAt,
+        **base.model_dump(),
         githubAppClientId=source.githubAppClientId,
         hasClientSecret=bool(source.githubAppClientSecretEncrypted),
         recentJobs=[_to_job_response(job) for job in recent_jobs],
@@ -152,81 +132,32 @@ async def _required_source(source_id: str, source_service) -> SkillSyncSource:
     return source
 
 
-async def _create_job(
-    *,
-    source: SkillSyncSource,
-    user_id: str,
-    job_type: SkillSyncJobType,
-    trigger_type: SkillSyncTriggerType,
-    source_service,
-    job_service,
-) -> SkillSyncJob:
-    """Create a sync job and transition the source status atomically in one transaction."""
-    snapshot = {"owner": source.owner, "repo": source.repo, "ref": source.ref, "paths": source.paths}
-    async with MongoDB.get_client().start_session() as mongo_session:
-        async with await mongo_session.start_transaction():
-            job = await job_service.create_job(
-                source_id=source.id,
-                job_type=job_type,
-                trigger_type=trigger_type,
-                triggered_by=user_id,
-                request_snapshot=snapshot,
-                session=mongo_session,
-            )
-            if job_type == SkillSyncJobType.DELETE_SYNC:
-                await source_service.mark_deleting(source, session=mongo_session)
-            else:
-                await source_service.mark_sync_pending(source, session=mongo_session)
-    return job
-
-
-def _schedule_placeholder(
-    background_tasks: BackgroundTasks, source: SkillSyncSource, job: SkillSyncJob, services
-) -> None:
-    source_service, job_service = services
-    background_tasks.add_task(
-        run_skill_sync_background,
-        source_id=str(source.id),
-        job_id=str(job.id),
-        source_service=source_service,
-        job_service=job_service,
-    )
-
-
 @router.post("", response_model=SkillSyncSourceDetailResponse, status_code=http_status.HTTP_201_CREATED)
 async def create_source(
     data: SkillSyncSourceCreateRequest,
     user_context: CurrentUser,
     source_service=Depends(get_skill_sync_source_crud_service),
+    skill_sync_service: SkillSyncService = Depends(get_skill_sync_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     user_str_id = str(user_context["user_id"])
     user_object_id = PydanticObjectId(user_context["user_id"])
     try:
-        async with MongoDB.get_client().start_session() as mongo_session:
-            async with await mongo_session.start_transaction():
-                source = await source_service.create_source(
-                    display_name=data.displayName,
-                    description=data.description,
-                    tags=data.tags,
-                    owner=data.owner,
-                    repo=data.repo,
-                    ref=data.ref,
-                    paths=data.paths,
-                    skill_discovery_depth=data.skillDiscoveryDepth,
-                    github_app_client_id=data.githubAppClientId,
-                    github_app_client_secret=data.githubAppClientSecret,
-                    created_by=user_str_id,
-                    session=mongo_session,
-                )
-                await acl_service.grant_permission(
-                    principal_type=PrincipalType.USER,
-                    principal_id=user_object_id,
-                    resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
-                    resource_id=source.id,
-                    perm_bits=RoleBits.OWNER,
-                    session=mongo_session,
-                )
+        source = await skill_sync_service.create_source_with_owner_acl(
+            display_name=data.displayName,
+            description=data.description,
+            tags=data.tags,
+            owner=data.owner,
+            repo=data.repo,
+            ref=data.ref,
+            paths=data.paths,
+            skill_discovery_depth=data.skillDiscoveryDepth,
+            github_app_client_id=data.githubAppClientId,
+            github_app_client_secret=data.githubAppClientSecret,
+            created_by=user_str_id,
+            principal_id=user_object_id,
+            acl_service=acl_service,
+        )
         return await _to_detail_response(
             source,
             source_service,
@@ -264,14 +195,12 @@ async def list_sources(
             page_size=per_page,
             accessible_source_ids=accessible_ids,
         )
-        responses = []
-        for source in items:
-            permissions = await acl_service.get_user_permissions_for_resource(
-                user_id=user_object_id,
-                resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
-                resource_id=source.id,
-            )
-            responses.append(_to_list_response(source, permissions))
+        permissions_by_id = await acl_service.get_user_permissions_for_resources(
+            user_id=user_object_id,
+            resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+            resource_ids=[source.id for source in items],
+        )
+        responses = [_to_list_response(source, permissions_by_id[source.id]) for source in items]
         return SkillSyncSourcePagedResponse(
             sources=responses,
             pagination=PaginationMetadata(
@@ -317,9 +246,7 @@ async def update_source(
     source_id: str,
     data: SkillSyncSourceUpdateRequest,
     user_context: CurrentUser,
-    background_tasks: BackgroundTasks,
     source_service=Depends(get_skill_sync_source_crud_service),
-    job_service=Depends(get_skill_sync_job_service),
     token_service: SkillSyncTokenService = Depends(get_skill_sync_token_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
@@ -335,29 +262,16 @@ async def update_source(
         )
         if not SkillSyncStateMachine.can_update(source.status):
             raise HTTPException(http_status.HTTP_409_CONFLICT, detail="Skill sync source cannot be updated")
+        if data.syncAfterUpdate:
+            raise HTTPException(
+                status_code=http_status.HTTP_501_NOT_IMPLEMENTED,
+                detail=SKILL_SYNC_EXECUTION_UNAVAILABLE_DETAIL,
+            )
         changes = data.model_dump(exclude_unset=True, exclude={"syncAfterUpdate"})
         credentials_changed = "githubAppClientId" in changes or "githubAppClientSecret" in changes
         source = await source_service.update_source(source, changes, updated_by=user_str_id)
         if credentials_changed:
             await token_service.delete_source_tokens(source.id)
-        if data.syncAfterUpdate:
-            access_token = await token_service.resolve_access_token(
-                user_id=user_str_id,
-                source_id=source.id,
-                client_id=source.githubAppClientId,
-                client_secret=decrypt_value(source.githubAppClientSecretEncrypted),
-            )
-            if access_token is None:
-                raise HTTPException(http_status.HTTP_409_CONFLICT, detail="GitHub authorization is required")
-            job = await _create_job(
-                source=source,
-                user_id=user_str_id,
-                job_type=SkillSyncJobType.CONFIG_RESYNC,
-                trigger_type=SkillSyncTriggerType.MANUAL,
-                source_service=source_service,
-                job_service=job_service,
-            )
-            _schedule_placeholder(background_tasks, source, job, (source_service, job_service))
         return await _to_detail_response(source, source_service, permissions)
     except HTTPException:
         raise
@@ -372,14 +286,11 @@ async def update_source(
 async def delete_source(
     source_id: str,
     user_context: CurrentUser,
-    background_tasks: BackgroundTasks,
     source_service=Depends(get_skill_sync_source_crud_service),
-    job_service=Depends(get_skill_sync_job_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     try:
         user_object_id = PydanticObjectId(user_context["user_id"])
-        user_str_id = str(user_context["user_id"])
         source = await _required_source(source_id, source_service)
         await acl_service.check_user_permission(
             user_id=user_object_id,
@@ -387,16 +298,10 @@ async def delete_source(
             resource_id=source.id,
             required_permission="DELETE",
         )
-        job = await _create_job(
-            source=source,
-            user_id=user_str_id,
-            job_type=SkillSyncJobType.DELETE_SYNC,
-            trigger_type=SkillSyncTriggerType.MANUAL,
-            source_service=source_service,
-            job_service=job_service,
+        raise HTTPException(
+            status_code=http_status.HTTP_501_NOT_IMPLEMENTED,
+            detail=SKILL_SYNC_EXECUTION_UNAVAILABLE_DETAIL,
         )
-        _schedule_placeholder(background_tasks, source, job, (source_service, job_service))
-        return SkillSyncDeleteResponse(sourceId=str(source.id), jobId=str(job.id), status="deleting")
     except HTTPException:
         raise
     except ValueError as exc:
@@ -410,18 +315,11 @@ async def delete_source(
 async def sync_source(
     source_id: str,
     user_context: CurrentUser,
-    request: Request,
-    response: Response,
-    background_tasks: BackgroundTasks,
     source_service=Depends(get_skill_sync_source_crud_service),
-    job_service=Depends(get_skill_sync_job_service),
-    token_service: SkillSyncTokenService = Depends(get_skill_sync_token_service),
-    oauth_service=Depends(get_skill_sync_oauth_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     try:
         user_object_id = PydanticObjectId(user_context["user_id"])
-        user_str_id = str(user_context["user_id"])
         source = await _required_source(source_id, source_service)
         await acl_service.check_user_permission(
             user_id=user_object_id,
@@ -429,32 +327,10 @@ async def sync_source(
             resource_id=source.id,
             required_permission="EDIT",
         )
-        token = await token_service.resolve_access_token(
-            user_id=user_str_id,
-            source_id=source.id,
-            client_id=source.githubAppClientId,
-            client_secret=decrypt_value(source.githubAppClientSecretEncrypted),
+        raise HTTPException(
+            status_code=http_status.HTTP_501_NOT_IMPLEMENTED,
+            detail=SKILL_SYNC_EXECUTION_UNAVAILABLE_DETAIL,
         )
-        if token is None:
-            redirect_uri = str(request.url_for("skill_sync_oauth_callback", source_id=str(source.id)))
-            authorize_url = oauth_service.create_authorization_url(
-                source=source,
-                user_id=user_str_id,
-                redirect_uri=redirect_uri,
-            )
-            response.status_code = http_status.HTTP_200_OK
-            return SkillSyncTriggerResponse(needsAuthorization=True, authorizeUrl=authorize_url)
-        job = await _create_job(
-            source=source,
-            user_id=user_str_id,
-            job_type=SkillSyncJobType.FULL_SYNC,
-            trigger_type=SkillSyncTriggerType.MANUAL,
-            source_service=source_service,
-            job_service=job_service,
-        )
-        _schedule_placeholder(background_tasks, source, job, (source_service, job_service))
-        response.status_code = http_status.HTTP_202_ACCEPTED
-        return SkillSyncTriggerResponse(job=_to_job_response(job))
     except HTTPException:
         raise
     except ValueError as exc:
@@ -468,14 +344,11 @@ async def sync_source(
 async def initiate_skill_sync_oauth(
     source_id: str,
     user_context: CurrentUser,
-    request: Request,
     source_service=Depends(get_skill_sync_source_crud_service),
-    oauth_service=Depends(get_skill_sync_oauth_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     try:
         user_object_id = PydanticObjectId(user_context["user_id"])
-        user_str_id = str(user_context["user_id"])
         source = await _required_source(source_id, source_service)
         await acl_service.check_user_permission(
             user_id=user_object_id,
@@ -483,13 +356,9 @@ async def initiate_skill_sync_oauth(
             resource_id=source.id,
             required_permission="EDIT",
         )
-        redirect_uri = str(request.url_for("skill_sync_oauth_callback", source_id=str(source.id)))
-        return RedirectResponse(
-            oauth_service.create_authorization_url(
-                source=source,
-                user_id=user_str_id,
-                redirect_uri=redirect_uri,
-            )
+        raise HTTPException(
+            status_code=http_status.HTTP_501_NOT_IMPLEMENTED,
+            detail=SKILL_SYNC_EXECUTION_UNAVAILABLE_DETAIL,
         )
     except HTTPException:
         raise
@@ -501,15 +370,10 @@ async def initiate_skill_sync_oauth(
 @router.get("/{source_id}/oauth/callback", name="skill_sync_oauth_callback")
 async def skill_sync_oauth_callback(
     source_id: str,
-    request: Request,
-    background_tasks: BackgroundTasks,
     code: str | None = Query(default=None),
     state: str | None = Query(default=None),
     error: str | None = Query(default=None),
     source_service=Depends(get_skill_sync_source_crud_service),
-    job_service=Depends(get_skill_sync_job_service),
-    oauth_service=Depends(get_skill_sync_oauth_service),
-    acl_service: ACLService = Depends(get_acl_service),
 ):
     error_redirect = (
         f"{settings.registry_client_url}/skill-sync-sources/{source_id}?{urlencode({'error': 'auth_failed'})}"
@@ -517,33 +381,13 @@ async def skill_sync_oauth_callback(
     if error or not code or not state:
         return RedirectResponse(error_redirect)
     try:
-        source = await _required_source(source_id, source_service)
-        redirect_uri = str(request.url_for("skill_sync_oauth_callback", source_id=str(source.id)))
-        user_id = await oauth_service.exchange_callback(
-            source=source,
-            code=code,
-            state=state,
-            redirect_uri=redirect_uri,
-        )
-        await acl_service.check_user_permission(
-            user_id=PydanticObjectId(user_id),
-            resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
-            resource_id=source.id,
-            required_permission="EDIT",
-        )
-        job = await _create_job(
-            source=source,
-            user_id=user_id,
-            job_type=SkillSyncJobType.FULL_SYNC,
-            trigger_type=SkillSyncTriggerType.OAUTH_CALLBACK,
-            source_service=source_service,
-            job_service=job_service,
-        )
-        _schedule_placeholder(background_tasks, source, job, (source_service, job_service))
+        await _required_source(source_id, source_service)
         return RedirectResponse(
-            f"{settings.registry_client_url}/skill-sync-sources/{source_id}?{urlencode({'syncTriggered': 'true'})}"
+            f"{settings.registry_client_url}/skill-sync-sources/{source_id}?{urlencode({'error': 'sync_unavailable'})}"
         )
-    except (HTTPException, httpx.HTTPError, ValueError):
+    except HTTPException:
+        return RedirectResponse(error_redirect)
+    except Exception:
         logger.exception("GitHub OAuth callback failed for skill sync source %s", source_id)
         return RedirectResponse(error_redirect)
 

--- a/registry/src/registry/api/v1/skill_sync/skill_sync_source_routes.py
+++ b/registry/src/registry/api/v1/skill_sync/skill_sync_source_routes.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from typing import NoReturn
 from urllib.parse import urlencode
 
 from beanie import PydanticObjectId
@@ -38,10 +39,12 @@ from ....schemas.skill_sync_api_schemas import (
     SkillSyncTriggerResponse,
 )
 from ....services.access_control_service import ACLService
+from ....services.skill_sync_job_service import SkillSyncJobService
 from ....services.skill_sync_service import (
     SKILL_SYNC_EXECUTION_UNAVAILABLE_DETAIL,
     SkillSyncService,
 )
+from ....services.skill_sync_source_crud_service import SkillSyncSourceCrudService
 from ....services.skill_sync_token_service import SkillSyncTokenService
 
 logger = logging.getLogger(__name__)
@@ -110,7 +113,7 @@ def _to_list_response(
 
 async def _to_detail_response(
     source: SkillSyncSource,
-    source_service,
+    source_service: SkillSyncSourceCrudService,
     permissions: ResourcePermissions | None = None,
 ) -> SkillSyncSourceDetailResponse:
     recent_jobs = await source_service.get_recent_jobs(source.id)
@@ -125,18 +128,40 @@ async def _to_detail_response(
     )
 
 
-async def _required_source(source_id: str, source_service) -> SkillSyncSource:
+async def _required_source(source_id: str, source_service: SkillSyncSourceCrudService) -> SkillSyncSource:
     source = await source_service.get_source(source_id)
     if source is None:
         raise HTTPException(http_status.HTTP_404_NOT_FOUND, detail="Skill sync source not found")
     return source
 
 
+async def _authorize_source_and_raise_unavailable(
+    source_id: str,
+    user_context: CurrentUser,
+    required_permission: str,
+    *,
+    source_service: SkillSyncSourceCrudService,
+    acl_service: ACLService,
+) -> NoReturn:
+    user_object_id = PydanticObjectId(user_context["user_id"])
+    source = await _required_source(source_id, source_service)
+    await acl_service.check_user_permission(
+        user_id=user_object_id,
+        resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+        resource_id=source.id,
+        required_permission=required_permission,
+    )
+    raise HTTPException(
+        status_code=http_status.HTTP_501_NOT_IMPLEMENTED,
+        detail=SKILL_SYNC_EXECUTION_UNAVAILABLE_DETAIL,
+    )
+
+
 @router.post("", response_model=SkillSyncSourceDetailResponse, status_code=http_status.HTTP_201_CREATED)
 async def create_source(
     data: SkillSyncSourceCreateRequest,
     user_context: CurrentUser,
-    source_service=Depends(get_skill_sync_source_crud_service),
+    source_service: SkillSyncSourceCrudService = Depends(get_skill_sync_source_crud_service),
     skill_sync_service: SkillSyncService = Depends(get_skill_sync_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
@@ -178,7 +203,7 @@ async def list_sources(
     query: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     per_page: int = Query(default=20, ge=1, le=100),
-    source_service=Depends(get_skill_sync_source_crud_service),
+    source_service: SkillSyncSourceCrudService = Depends(get_skill_sync_source_crud_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     try:
@@ -221,7 +246,7 @@ async def list_sources(
 async def get_source(
     source_id: str,
     user_context: CurrentUser,
-    source_service=Depends(get_skill_sync_source_crud_service),
+    source_service: SkillSyncSourceCrudService = Depends(get_skill_sync_source_crud_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     try:
@@ -246,7 +271,7 @@ async def update_source(
     source_id: str,
     data: SkillSyncSourceUpdateRequest,
     user_context: CurrentUser,
-    source_service=Depends(get_skill_sync_source_crud_service),
+    source_service: SkillSyncSourceCrudService = Depends(get_skill_sync_source_crud_service),
     token_service: SkillSyncTokenService = Depends(get_skill_sync_token_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
@@ -286,21 +311,16 @@ async def update_source(
 async def delete_source(
     source_id: str,
     user_context: CurrentUser,
-    source_service=Depends(get_skill_sync_source_crud_service),
+    source_service: SkillSyncSourceCrudService = Depends(get_skill_sync_source_crud_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     try:
-        user_object_id = PydanticObjectId(user_context["user_id"])
-        source = await _required_source(source_id, source_service)
-        await acl_service.check_user_permission(
-            user_id=user_object_id,
-            resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
-            resource_id=source.id,
-            required_permission="DELETE",
-        )
-        raise HTTPException(
-            status_code=http_status.HTTP_501_NOT_IMPLEMENTED,
-            detail=SKILL_SYNC_EXECUTION_UNAVAILABLE_DETAIL,
+        await _authorize_source_and_raise_unavailable(
+            source_id,
+            user_context,
+            "DELETE",
+            source_service=source_service,
+            acl_service=acl_service,
         )
     except HTTPException:
         raise
@@ -315,21 +335,16 @@ async def delete_source(
 async def sync_source(
     source_id: str,
     user_context: CurrentUser,
-    source_service=Depends(get_skill_sync_source_crud_service),
+    source_service: SkillSyncSourceCrudService = Depends(get_skill_sync_source_crud_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     try:
-        user_object_id = PydanticObjectId(user_context["user_id"])
-        source = await _required_source(source_id, source_service)
-        await acl_service.check_user_permission(
-            user_id=user_object_id,
-            resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
-            resource_id=source.id,
-            required_permission="EDIT",
-        )
-        raise HTTPException(
-            status_code=http_status.HTTP_501_NOT_IMPLEMENTED,
-            detail=SKILL_SYNC_EXECUTION_UNAVAILABLE_DETAIL,
+        await _authorize_source_and_raise_unavailable(
+            source_id,
+            user_context,
+            "EDIT",
+            source_service=source_service,
+            acl_service=acl_service,
         )
     except HTTPException:
         raise
@@ -344,21 +359,16 @@ async def sync_source(
 async def initiate_skill_sync_oauth(
     source_id: str,
     user_context: CurrentUser,
-    source_service=Depends(get_skill_sync_source_crud_service),
+    source_service: SkillSyncSourceCrudService = Depends(get_skill_sync_source_crud_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     try:
-        user_object_id = PydanticObjectId(user_context["user_id"])
-        source = await _required_source(source_id, source_service)
-        await acl_service.check_user_permission(
-            user_id=user_object_id,
-            resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
-            resource_id=source.id,
-            required_permission="EDIT",
-        )
-        raise HTTPException(
-            status_code=http_status.HTTP_501_NOT_IMPLEMENTED,
-            detail=SKILL_SYNC_EXECUTION_UNAVAILABLE_DETAIL,
+        await _authorize_source_and_raise_unavailable(
+            source_id,
+            user_context,
+            "EDIT",
+            source_service=source_service,
+            acl_service=acl_service,
         )
     except HTTPException:
         raise
@@ -373,7 +383,7 @@ async def skill_sync_oauth_callback(
     code: str | None = Query(default=None),
     state: str | None = Query(default=None),
     error: str | None = Query(default=None),
-    source_service=Depends(get_skill_sync_source_crud_service),
+    source_service: SkillSyncSourceCrudService = Depends(get_skill_sync_source_crud_service),
 ):
     error_redirect = (
         f"{settings.registry_client_url}/skill-sync-sources/{source_id}?{urlencode({'error': 'auth_failed'})}"
@@ -397,8 +407,8 @@ async def get_sync_job(
     source_id: str,
     job_id: str,
     user_context: CurrentUser,
-    source_service=Depends(get_skill_sync_source_crud_service),
-    job_service=Depends(get_skill_sync_job_service),
+    source_service: SkillSyncSourceCrudService = Depends(get_skill_sync_source_crud_service),
+    job_service: SkillSyncJobService = Depends(get_skill_sync_job_service),
     acl_service: ACLService = Depends(get_acl_service),
 ):
     try:

--- a/registry/src/registry/api/v1/skill_sync/skill_sync_source_routes.py
+++ b/registry/src/registry/api/v1/skill_sync/skill_sync_source_routes.py
@@ -1,0 +1,577 @@
+import logging
+import math
+from urllib.parse import urlencode
+
+import httpx
+from beanie import PydanticObjectId
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response
+from fastapi import status as http_status
+from fastapi.responses import RedirectResponse
+
+from registry_pkgs.database.mongodb import MongoDB
+from registry_pkgs.models import PrincipalType
+from registry_pkgs.models.enums import (
+    RoleBits,
+    SkillSyncJobType,
+    SkillSyncStateMachine,
+    SkillSyncTriggerType,
+)
+from registry_pkgs.models.extended_access_role import RegistryResourceType
+from registry_pkgs.models.skill_sync_job import SkillSyncJob
+from registry_pkgs.models.skill_sync_source import SkillSyncSource, SkillSyncSourceLastSync
+
+from ....auth.dependencies import CurrentUser
+from ....core.config import settings
+from ....deps import (
+    get_acl_service,
+    get_skill_sync_job_service,
+    get_skill_sync_oauth_service,
+    get_skill_sync_source_crud_service,
+    get_skill_sync_token_service,
+)
+from ....schemas.acl_schema import ResourcePermissions
+from ....schemas.server_api_schemas import PaginationMetadata
+from ....schemas.skill_sync_api_schemas import (
+    SkillSyncDeleteResponse,
+    SkillSyncJobResponse,
+    SkillSyncSourceCreateRequest,
+    SkillSyncSourceDetailResponse,
+    SkillSyncSourceLastSyncResponse,
+    SkillSyncSourceListItemResponse,
+    SkillSyncSourcePagedResponse,
+    SkillSyncSourceStatsResponse,
+    SkillSyncSourceUpdateRequest,
+    SkillSyncTriggerResponse,
+)
+from ....services.access_control_service import ACLService
+from ....services.skill_sync_service import run_skill_sync_background
+from ....services.skill_sync_token_service import SkillSyncTokenService
+from ....utils.crypto_utils import decrypt_value
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/skill-sync-sources", tags=["skill-sync-sources"])
+
+
+def _to_job_response(job: SkillSyncJob) -> SkillSyncJobResponse:
+    return SkillSyncJobResponse(
+        id=str(job.id),
+        sourceId=str(job.sourceId),
+        jobType=job.jobType,
+        triggerType=job.triggerType,
+        status=job.status,
+        phase=job.phase,
+        requestSnapshot=job.requestSnapshot,
+        discoverySummary=job.discoverySummary.model_dump(mode="json"),
+        applySummary=job.applySummary.model_dump(mode="json"),
+        skillErrors=[item.model_dump(mode="json") for item in job.skillErrors],
+        errorCode=job.errorCode,
+        error=job.error,
+        startedAt=job.startedAt,
+        finishedAt=job.finishedAt,
+        createdAt=job.createdAt,
+        updatedAt=job.updatedAt,
+    )
+
+
+def _to_last_sync_response(value: SkillSyncSourceLastSync | None) -> SkillSyncSourceLastSyncResponse | None:
+    if value is None:
+        return None
+    return SkillSyncSourceLastSyncResponse(
+        jobId=str(value.jobId),
+        status=value.status,
+        startedAt=value.startedAt,
+        finishedAt=value.finishedAt,
+        commitSha=value.commitSha,
+    )
+
+
+def _to_list_response(
+    source: SkillSyncSource,
+    permissions: ResourcePermissions | None = None,
+) -> SkillSyncSourceListItemResponse:
+    return SkillSyncSourceListItemResponse(
+        id=str(source.id),
+        providerType=source.providerType,
+        displayName=source.displayName,
+        description=source.description,
+        tags=source.tags,
+        owner=source.owner,
+        repo=source.repo,
+        ref=source.ref,
+        paths=source.paths,
+        skillDiscoveryDepth=source.skillDiscoveryDepth,
+        status=source.status,
+        syncStatus=source.syncStatus,
+        syncMessage=source.syncMessage,
+        stats=SkillSyncSourceStatsResponse.model_validate(source.stats),
+        lastSync=_to_last_sync_response(source.lastSync),
+        permissions=permissions,
+        createdAt=source.createdAt,
+        updatedAt=source.updatedAt,
+    )
+
+
+async def _to_detail_response(
+    source: SkillSyncSource,
+    source_service,
+    permissions: ResourcePermissions | None = None,
+) -> SkillSyncSourceDetailResponse:
+    recent_jobs = await source_service.get_recent_jobs(source.id)
+    return SkillSyncSourceDetailResponse(
+        id=str(source.id),
+        providerType=source.providerType,
+        displayName=source.displayName,
+        description=source.description,
+        tags=source.tags,
+        owner=source.owner,
+        repo=source.repo,
+        ref=source.ref,
+        paths=source.paths,
+        skillDiscoveryDepth=source.skillDiscoveryDepth,
+        status=source.status,
+        syncStatus=source.syncStatus,
+        syncMessage=source.syncMessage,
+        stats=SkillSyncSourceStatsResponse.model_validate(source.stats),
+        lastSync=_to_last_sync_response(source.lastSync),
+        permissions=permissions,
+        createdAt=source.createdAt,
+        updatedAt=source.updatedAt,
+        githubAppClientId=source.githubAppClientId,
+        hasClientSecret=bool(source.githubAppClientSecretEncrypted),
+        recentJobs=[_to_job_response(job) for job in recent_jobs],
+        createdBy=source.createdBy,
+        updatedBy=source.updatedBy,
+    )
+
+
+async def _required_source(source_id: str, source_service) -> SkillSyncSource:
+    source = await source_service.get_source(source_id)
+    if source is None:
+        raise HTTPException(http_status.HTTP_404_NOT_FOUND, detail="Skill sync source not found")
+    return source
+
+
+async def _create_job(
+    *,
+    source: SkillSyncSource,
+    user_id: str,
+    job_type: SkillSyncJobType,
+    trigger_type: SkillSyncTriggerType,
+    source_service,
+    job_service,
+) -> SkillSyncJob:
+    """Create a sync job and transition the source status atomically in one transaction."""
+    snapshot = {"owner": source.owner, "repo": source.repo, "ref": source.ref, "paths": source.paths}
+    async with MongoDB.get_client().start_session() as mongo_session:
+        async with await mongo_session.start_transaction():
+            job = await job_service.create_job(
+                source_id=source.id,
+                job_type=job_type,
+                trigger_type=trigger_type,
+                triggered_by=user_id,
+                request_snapshot=snapshot,
+                session=mongo_session,
+            )
+            if job_type == SkillSyncJobType.DELETE_SYNC:
+                await source_service.mark_deleting(source, session=mongo_session)
+            else:
+                await source_service.mark_sync_pending(source, session=mongo_session)
+    return job
+
+
+def _schedule_placeholder(
+    background_tasks: BackgroundTasks, source: SkillSyncSource, job: SkillSyncJob, services
+) -> None:
+    source_service, job_service = services
+    background_tasks.add_task(
+        run_skill_sync_background,
+        source_id=str(source.id),
+        job_id=str(job.id),
+        source_service=source_service,
+        job_service=job_service,
+    )
+
+
+@router.post("", response_model=SkillSyncSourceDetailResponse, status_code=http_status.HTTP_201_CREATED)
+async def create_source(
+    data: SkillSyncSourceCreateRequest,
+    user_context: CurrentUser,
+    source_service=Depends(get_skill_sync_source_crud_service),
+    acl_service: ACLService = Depends(get_acl_service),
+):
+    user_str_id = str(user_context["user_id"])
+    user_object_id = PydanticObjectId(user_context["user_id"])
+    try:
+        async with MongoDB.get_client().start_session() as mongo_session:
+            async with await mongo_session.start_transaction():
+                source = await source_service.create_source(
+                    display_name=data.displayName,
+                    description=data.description,
+                    tags=data.tags,
+                    owner=data.owner,
+                    repo=data.repo,
+                    ref=data.ref,
+                    paths=data.paths,
+                    skill_discovery_depth=data.skillDiscoveryDepth,
+                    github_app_client_id=data.githubAppClientId,
+                    github_app_client_secret=data.githubAppClientSecret,
+                    created_by=user_str_id,
+                    session=mongo_session,
+                )
+                await acl_service.grant_permission(
+                    principal_type=PrincipalType.USER,
+                    principal_id=user_object_id,
+                    resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+                    resource_id=source.id,
+                    perm_bits=RoleBits.OWNER,
+                    session=mongo_session,
+                )
+        return await _to_detail_response(
+            source,
+            source_service,
+            ResourcePermissions(VIEW=True, EDIT=True, DELETE=True, SHARE=True),
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to create skill sync source")
+        raise HTTPException(http_status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error") from exc
+
+
+@router.get("", response_model=SkillSyncSourcePagedResponse)
+async def list_sources(
+    user_context: CurrentUser,
+    syncStatus: str | None = Query(default=None),
+    tag: str | None = Query(default=None),
+    query: str | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    per_page: int = Query(default=20, ge=1, le=100),
+    source_service=Depends(get_skill_sync_source_crud_service),
+    acl_service: ACLService = Depends(get_acl_service),
+):
+    try:
+        user_object_id = PydanticObjectId(user_context["user_id"])
+        accessible_ids = await acl_service.get_accessible_resource_ids(
+            user_id=user_object_id,
+            resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+        )
+        items, total = await source_service.list_sources(
+            sync_status=syncStatus,
+            tag=tag,
+            keyword=query,
+            page=page,
+            page_size=per_page,
+            accessible_source_ids=accessible_ids,
+        )
+        responses = []
+        for source in items:
+            permissions = await acl_service.get_user_permissions_for_resource(
+                user_id=user_object_id,
+                resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+                resource_id=source.id,
+            )
+            responses.append(_to_list_response(source, permissions))
+        return SkillSyncSourcePagedResponse(
+            sources=responses,
+            pagination=PaginationMetadata(
+                total=total,
+                page=page,
+                perPage=per_page,
+                totalPages=math.ceil(total / per_page) if total else 0,
+            ),
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to list skill sync sources")
+        raise HTTPException(http_status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error") from exc
+
+
+@router.get("/{source_id}", response_model=SkillSyncSourceDetailResponse)
+async def get_source(
+    source_id: str,
+    user_context: CurrentUser,
+    source_service=Depends(get_skill_sync_source_crud_service),
+    acl_service: ACLService = Depends(get_acl_service),
+):
+    try:
+        user_object_id = PydanticObjectId(user_context["user_id"])
+        source = await _required_source(source_id, source_service)
+        permissions = await acl_service.check_user_permission(
+            user_id=user_object_id,
+            resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+            resource_id=source.id,
+            required_permission="VIEW",
+        )
+        return await _to_detail_response(source, source_service, permissions)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to get skill sync source %s", source_id)
+        raise HTTPException(http_status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error") from exc
+
+
+@router.put("/{source_id}", response_model=SkillSyncSourceDetailResponse)
+async def update_source(
+    source_id: str,
+    data: SkillSyncSourceUpdateRequest,
+    user_context: CurrentUser,
+    background_tasks: BackgroundTasks,
+    source_service=Depends(get_skill_sync_source_crud_service),
+    job_service=Depends(get_skill_sync_job_service),
+    token_service: SkillSyncTokenService = Depends(get_skill_sync_token_service),
+    acl_service: ACLService = Depends(get_acl_service),
+):
+    try:
+        user_object_id = PydanticObjectId(user_context["user_id"])
+        user_str_id = str(user_context["user_id"])
+        source = await _required_source(source_id, source_service)
+        permissions = await acl_service.check_user_permission(
+            user_id=user_object_id,
+            resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+            resource_id=source.id,
+            required_permission="EDIT",
+        )
+        if not SkillSyncStateMachine.can_update(source.status):
+            raise HTTPException(http_status.HTTP_409_CONFLICT, detail="Skill sync source cannot be updated")
+        changes = data.model_dump(exclude_unset=True, exclude={"syncAfterUpdate"})
+        credentials_changed = "githubAppClientId" in changes or "githubAppClientSecret" in changes
+        source = await source_service.update_source(source, changes, updated_by=user_str_id)
+        if credentials_changed:
+            await token_service.delete_source_tokens(source.id)
+        if data.syncAfterUpdate:
+            access_token = await token_service.resolve_access_token(
+                user_id=user_str_id,
+                source_id=source.id,
+                client_id=source.githubAppClientId,
+                client_secret=decrypt_value(source.githubAppClientSecretEncrypted),
+            )
+            if access_token is None:
+                raise HTTPException(http_status.HTTP_409_CONFLICT, detail="GitHub authorization is required")
+            job = await _create_job(
+                source=source,
+                user_id=user_str_id,
+                job_type=SkillSyncJobType.CONFIG_RESYNC,
+                trigger_type=SkillSyncTriggerType.MANUAL,
+                source_service=source_service,
+                job_service=job_service,
+            )
+            _schedule_placeholder(background_tasks, source, job, (source_service, job_service))
+        return await _to_detail_response(source, source_service, permissions)
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(http_status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to update skill sync source %s", source_id)
+        raise HTTPException(http_status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error") from exc
+
+
+@router.delete("/{source_id}", response_model=SkillSyncDeleteResponse, status_code=http_status.HTTP_202_ACCEPTED)
+async def delete_source(
+    source_id: str,
+    user_context: CurrentUser,
+    background_tasks: BackgroundTasks,
+    source_service=Depends(get_skill_sync_source_crud_service),
+    job_service=Depends(get_skill_sync_job_service),
+    acl_service: ACLService = Depends(get_acl_service),
+):
+    try:
+        user_object_id = PydanticObjectId(user_context["user_id"])
+        user_str_id = str(user_context["user_id"])
+        source = await _required_source(source_id, source_service)
+        await acl_service.check_user_permission(
+            user_id=user_object_id,
+            resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+            resource_id=source.id,
+            required_permission="DELETE",
+        )
+        job = await _create_job(
+            source=source,
+            user_id=user_str_id,
+            job_type=SkillSyncJobType.DELETE_SYNC,
+            trigger_type=SkillSyncTriggerType.MANUAL,
+            source_service=source_service,
+            job_service=job_service,
+        )
+        _schedule_placeholder(background_tasks, source, job, (source_service, job_service))
+        return SkillSyncDeleteResponse(sourceId=str(source.id), jobId=str(job.id), status="deleting")
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(http_status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to delete skill sync source %s", source_id)
+        raise HTTPException(http_status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error") from exc
+
+
+@router.post("/{source_id}/sync", response_model=SkillSyncTriggerResponse)
+async def sync_source(
+    source_id: str,
+    user_context: CurrentUser,
+    request: Request,
+    response: Response,
+    background_tasks: BackgroundTasks,
+    source_service=Depends(get_skill_sync_source_crud_service),
+    job_service=Depends(get_skill_sync_job_service),
+    token_service: SkillSyncTokenService = Depends(get_skill_sync_token_service),
+    oauth_service=Depends(get_skill_sync_oauth_service),
+    acl_service: ACLService = Depends(get_acl_service),
+):
+    try:
+        user_object_id = PydanticObjectId(user_context["user_id"])
+        user_str_id = str(user_context["user_id"])
+        source = await _required_source(source_id, source_service)
+        await acl_service.check_user_permission(
+            user_id=user_object_id,
+            resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+            resource_id=source.id,
+            required_permission="EDIT",
+        )
+        token = await token_service.resolve_access_token(
+            user_id=user_str_id,
+            source_id=source.id,
+            client_id=source.githubAppClientId,
+            client_secret=decrypt_value(source.githubAppClientSecretEncrypted),
+        )
+        if token is None:
+            redirect_uri = str(request.url_for("skill_sync_oauth_callback", source_id=str(source.id)))
+            authorize_url = oauth_service.create_authorization_url(
+                source=source,
+                user_id=user_str_id,
+                redirect_uri=redirect_uri,
+            )
+            response.status_code = http_status.HTTP_200_OK
+            return SkillSyncTriggerResponse(needsAuthorization=True, authorizeUrl=authorize_url)
+        job = await _create_job(
+            source=source,
+            user_id=user_str_id,
+            job_type=SkillSyncJobType.FULL_SYNC,
+            trigger_type=SkillSyncTriggerType.MANUAL,
+            source_service=source_service,
+            job_service=job_service,
+        )
+        _schedule_placeholder(background_tasks, source, job, (source_service, job_service))
+        response.status_code = http_status.HTTP_202_ACCEPTED
+        return SkillSyncTriggerResponse(job=_to_job_response(job))
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(http_status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to trigger skill sync for %s", source_id)
+        raise HTTPException(http_status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error") from exc
+
+
+@router.get("/{source_id}/oauth/initiate")
+async def initiate_skill_sync_oauth(
+    source_id: str,
+    user_context: CurrentUser,
+    request: Request,
+    source_service=Depends(get_skill_sync_source_crud_service),
+    oauth_service=Depends(get_skill_sync_oauth_service),
+    acl_service: ACLService = Depends(get_acl_service),
+):
+    try:
+        user_object_id = PydanticObjectId(user_context["user_id"])
+        user_str_id = str(user_context["user_id"])
+        source = await _required_source(source_id, source_service)
+        await acl_service.check_user_permission(
+            user_id=user_object_id,
+            resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+            resource_id=source.id,
+            required_permission="EDIT",
+        )
+        redirect_uri = str(request.url_for("skill_sync_oauth_callback", source_id=str(source.id)))
+        return RedirectResponse(
+            oauth_service.create_authorization_url(
+                source=source,
+                user_id=user_str_id,
+                redirect_uri=redirect_uri,
+            )
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to initiate GitHub OAuth for %s", source_id)
+        raise HTTPException(http_status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error") from exc
+
+
+@router.get("/{source_id}/oauth/callback", name="skill_sync_oauth_callback")
+async def skill_sync_oauth_callback(
+    source_id: str,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    code: str | None = Query(default=None),
+    state: str | None = Query(default=None),
+    error: str | None = Query(default=None),
+    source_service=Depends(get_skill_sync_source_crud_service),
+    job_service=Depends(get_skill_sync_job_service),
+    oauth_service=Depends(get_skill_sync_oauth_service),
+    acl_service: ACLService = Depends(get_acl_service),
+):
+    error_redirect = (
+        f"{settings.registry_client_url}/skill-sync-sources/{source_id}?{urlencode({'error': 'auth_failed'})}"
+    )
+    if error or not code or not state:
+        return RedirectResponse(error_redirect)
+    try:
+        source = await _required_source(source_id, source_service)
+        redirect_uri = str(request.url_for("skill_sync_oauth_callback", source_id=str(source.id)))
+        user_id = await oauth_service.exchange_callback(
+            source=source,
+            code=code,
+            state=state,
+            redirect_uri=redirect_uri,
+        )
+        await acl_service.check_user_permission(
+            user_id=PydanticObjectId(user_id),
+            resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+            resource_id=source.id,
+            required_permission="EDIT",
+        )
+        job = await _create_job(
+            source=source,
+            user_id=user_id,
+            job_type=SkillSyncJobType.FULL_SYNC,
+            trigger_type=SkillSyncTriggerType.OAUTH_CALLBACK,
+            source_service=source_service,
+            job_service=job_service,
+        )
+        _schedule_placeholder(background_tasks, source, job, (source_service, job_service))
+        return RedirectResponse(
+            f"{settings.registry_client_url}/skill-sync-sources/{source_id}?{urlencode({'syncTriggered': 'true'})}"
+        )
+    except (HTTPException, httpx.HTTPError, ValueError):
+        logger.exception("GitHub OAuth callback failed for skill sync source %s", source_id)
+        return RedirectResponse(error_redirect)
+
+
+@router.get("/{source_id}/jobs/{job_id}", response_model=SkillSyncJobResponse)
+async def get_sync_job(
+    source_id: str,
+    job_id: str,
+    user_context: CurrentUser,
+    source_service=Depends(get_skill_sync_source_crud_service),
+    job_service=Depends(get_skill_sync_job_service),
+    acl_service: ACLService = Depends(get_acl_service),
+):
+    try:
+        user_object_id = PydanticObjectId(user_context["user_id"])
+        source = await _required_source(source_id, source_service)
+        await acl_service.check_user_permission(
+            user_id=user_object_id,
+            resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+            resource_id=source.id,
+            required_permission="VIEW",
+        )
+        job = await job_service.get_job(job_id, source_id=source.id)
+        if job is None:
+            raise HTTPException(http_status.HTTP_404_NOT_FOUND, detail="Skill sync job not found")
+        return _to_job_response(job)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to get skill sync job %s", job_id)
+        raise HTTPException(http_status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error") from exc

--- a/registry/src/registry/auth/oauth/flow_state_manager.py
+++ b/registry/src/registry/auth/oauth/flow_state_manager.py
@@ -168,7 +168,10 @@ class FlowStateManager:
             authorization_url=authorization_url,
             state=state,
             code_verifier=code_verifier,
-            client_info=self._create_client_info(oauth_config, server_path),
+            client_info=self._create_client_info(
+                oauth_config,
+                server_path,
+            ),
             metadata=self._create_oauth_metadata(oauth_config),
             resource_metadata=resource_metadata,
             mcp_client_context=mcp_client_context,
@@ -399,7 +402,11 @@ class FlowStateManager:
             logger.debug(f"Found {len(user_flows)} flows in memory for {user_id}/{server_id}")
             return user_flows
 
-    def _create_client_info(self, oauth_config: dict[str, Any], server_path: str) -> OAuthClientInformation:
+    def _create_client_info(
+        self,
+        oauth_config: dict[str, Any],
+        server_path: str,
+    ) -> OAuthClientInformation:
         """
         Build OAuth client information from server configuration
         """
@@ -417,7 +424,7 @@ class FlowStateManager:
         logger.debug(f"Client info - redirect_uris: {redirect_uris}, scopes: {scope_string}")
         return OAuthClientInformation(  # type: ignore [call-arg]
             client_id=str(oauth_config.get("client_id", "")).strip(),
-            client_secret=str(oauth_config.get("client_secret")).strip(),
+            client_secret=str(oauth_config.get("client_secret")).strip() if oauth_config.get("client_secret") else None,
             redirect_uris=redirect_uris,
             scope=scope_string,
             additional_params=oauth_config.get("additional_params"),

--- a/registry/src/registry/auth/oauth/flow_state_manager.py
+++ b/registry/src/registry/auth/oauth/flow_state_manager.py
@@ -12,7 +12,6 @@ from redis import Redis
 from ...auth.oauth.oauth_utils import parse_scope, scope_to_string
 from ...auth.oauth.redis_flow_storage import RedisFlowStorage
 from ...auth.oauth.types import OAuthFlowState, StateMetadata
-from ...core.config import settings
 from ...schemas.enums import OAuthFlowStatus
 from ...schemas.oauth_schema import (
     MCPClientContext,
@@ -146,6 +145,7 @@ class FlowStateManager:
         oauth_config: dict[str, Any],
         flow_id: str,
         *,
+        redirect_uri: str,
         state_metadata: StateMetadata | None = None,
         mcp_client_context: MCPClientContext | None = None,
         device_code: str | None = None,
@@ -170,7 +170,7 @@ class FlowStateManager:
             code_verifier=code_verifier,
             client_info=self._create_client_info(
                 oauth_config,
-                server_path,
+                redirect_uri=redirect_uri,
             ),
             metadata=self._create_oauth_metadata(oauth_config),
             resource_metadata=resource_metadata,
@@ -405,26 +405,18 @@ class FlowStateManager:
     def _create_client_info(
         self,
         oauth_config: dict[str, Any],
-        server_path: str,
+        *,
+        redirect_uri: str,
     ) -> OAuthClientInformation:
         """
         Build OAuth client information from server configuration
         """
-        if oauth_config.get("redirect_uri"):
-            redirect_uri = oauth_config["redirect_uri"]
-        else:
-            base_url = settings.registry_client_url.rstrip("/")
-            normalized_path = server_path if server_path.startswith("/") else f"/{server_path}"
-            redirect_uri = f"{base_url}/api/v1/mcp{normalized_path}/oauth/callback"
-
-        redirect_uris = [redirect_uri]
-
         scope_string = scope_to_string(oauth_config.get("scope"))
-        logger.debug(f"Client info - redirect_uris: {redirect_uris}, scopes: {scope_string}")
+        logger.debug(f"Client info - redirect_uris: [{redirect_uri}], scopes: {scope_string}")
         return OAuthClientInformation(  # type: ignore [call-arg]
             client_id=str(oauth_config.get("client_id", "")).strip(),
             client_secret=str(oauth_config.get("client_secret")).strip() if oauth_config.get("client_secret") else None,
-            redirect_uris=redirect_uris,
+            redirect_uris=[redirect_uri],
             scope=scope_string,
             additional_params=oauth_config.get("additional_params"),
         )

--- a/registry/src/registry/auth/oauth/flow_state_manager.py
+++ b/registry/src/registry/auth/oauth/flow_state_manager.py
@@ -410,13 +410,12 @@ class FlowStateManager:
         """
         Build OAuth client information from server configuration
         """
-        base_url = settings.registry_client_url
-        if base_url.endswith("/"):
-            base_url = base_url.removesuffix("/")
-
-        # Ensure server_path starts with / for proper URL construction
-        normalized_path = server_path if server_path.startswith("/") else f"/{server_path}"
-        redirect_uri = f"{base_url}/api/v1/mcp{normalized_path}/oauth/callback"
+        if oauth_config.get("redirect_uri"):
+            redirect_uri = oauth_config["redirect_uri"]
+        else:
+            base_url = settings.registry_client_url.rstrip("/")
+            normalized_path = server_path if server_path.startswith("/") else f"/{server_path}"
+            redirect_uri = f"{base_url}/api/v1/mcp{normalized_path}/oauth/callback"
 
         redirect_uris = [redirect_uri]
 

--- a/registry/src/registry/container.py
+++ b/registry/src/registry/container.py
@@ -54,6 +54,10 @@ from .services.search.service import SearchService
 from .services.security_scanner import SecurityScannerService
 from .services.server_service import ServerServiceV1
 from .services.skill_service import SkillService
+from .services.skill_sync_job_service import SkillSyncJobService
+from .services.skill_sync_oauth_service import SkillSyncOAuthService
+from .services.skill_sync_source_crud_service import SkillSyncSourceCrudService
+from .services.skill_sync_token_service import SkillSyncTokenService
 from .services.user_service import UserService
 from .services.workflow_control_service import WorkflowControlService
 from .services.workflow_mcp_headers_provider import McpHeadersProvider, make_mcp_headers_provider
@@ -369,6 +373,26 @@ class RegistryContainer:
     @cached_property
     def federation_job_service(self) -> FederationJobService:
         return FederationJobService()
+
+    @cached_property
+    def skill_sync_source_crud_service(self) -> SkillSyncSourceCrudService:
+        return SkillSyncSourceCrudService()
+
+    @cached_property
+    def skill_sync_job_service(self) -> SkillSyncJobService:
+        return SkillSyncJobService()
+
+    @cached_property
+    def skill_sync_token_service(self) -> SkillSyncTokenService:
+        return SkillSyncTokenService(self.mcp_proxy_client)
+
+    @cached_property
+    def skill_sync_oauth_service(self) -> SkillSyncOAuthService:
+        return SkillSyncOAuthService(
+            flow_state_manager=self.flow_state_manager,
+            token_service=self.skill_sync_token_service,
+            http_client=self.mcp_proxy_client,
+        )
 
     @cached_property
     def federation_sync_service(self) -> FederationSyncService:

--- a/registry/src/registry/container.py
+++ b/registry/src/registry/container.py
@@ -56,6 +56,7 @@ from .services.server_service import ServerServiceV1
 from .services.skill_service import SkillService
 from .services.skill_sync_job_service import SkillSyncJobService
 from .services.skill_sync_oauth_service import SkillSyncOAuthService
+from .services.skill_sync_service import SkillSyncService
 from .services.skill_sync_source_crud_service import SkillSyncSourceCrudService
 from .services.skill_sync_token_service import SkillSyncTokenService
 from .services.user_service import UserService
@@ -377,6 +378,10 @@ class RegistryContainer:
     @cached_property
     def skill_sync_source_crud_service(self) -> SkillSyncSourceCrudService:
         return SkillSyncSourceCrudService()
+
+    @cached_property
+    def skill_sync_service(self) -> SkillSyncService:
+        return SkillSyncService(self.skill_sync_source_crud_service)
 
     @cached_property
     def skill_sync_job_service(self) -> SkillSyncJobService:

--- a/registry/src/registry/deps.py
+++ b/registry/src/registry/deps.py
@@ -28,6 +28,7 @@ from .services.server_service import ServerServiceV1
 from .services.skill_service import SkillService
 from .services.skill_sync_job_service import SkillSyncJobService
 from .services.skill_sync_oauth_service import SkillSyncOAuthService
+from .services.skill_sync_service import SkillSyncService
 from .services.skill_sync_source_crud_service import SkillSyncSourceCrudService
 from .services.skill_sync_token_service import SkillSyncTokenService
 from .services.user_service import UserService
@@ -119,6 +120,10 @@ def get_skill_sync_source_crud_service(
     container: RegistryContainer = Depends(get_container),
 ) -> SkillSyncSourceCrudService:
     return container.skill_sync_source_crud_service
+
+
+def get_skill_sync_service(container: RegistryContainer = Depends(get_container)) -> SkillSyncService:
+    return container.skill_sync_service
 
 
 def get_skill_sync_job_service(container: RegistryContainer = Depends(get_container)) -> SkillSyncJobService:

--- a/registry/src/registry/deps.py
+++ b/registry/src/registry/deps.py
@@ -26,6 +26,10 @@ from .services.oauth.token_service import TokenService
 from .services.search.service import SearchService
 from .services.server_service import ServerServiceV1
 from .services.skill_service import SkillService
+from .services.skill_sync_job_service import SkillSyncJobService
+from .services.skill_sync_oauth_service import SkillSyncOAuthService
+from .services.skill_sync_source_crud_service import SkillSyncSourceCrudService
+from .services.skill_sync_token_service import SkillSyncTokenService
 from .services.user_service import UserService
 from .services.workflow_control_service import WorkflowControlService
 from .services.workflow_service import WorkflowService
@@ -109,6 +113,24 @@ def get_federation_crud_service(container: RegistryContainer = Depends(get_conta
 
 def get_federation_job_service(container: RegistryContainer = Depends(get_container)) -> FederationJobService:
     return container.federation_job_service
+
+
+def get_skill_sync_source_crud_service(
+    container: RegistryContainer = Depends(get_container),
+) -> SkillSyncSourceCrudService:
+    return container.skill_sync_source_crud_service
+
+
+def get_skill_sync_job_service(container: RegistryContainer = Depends(get_container)) -> SkillSyncJobService:
+    return container.skill_sync_job_service
+
+
+def get_skill_sync_token_service(container: RegistryContainer = Depends(get_container)) -> SkillSyncTokenService:
+    return container.skill_sync_token_service
+
+
+def get_skill_sync_oauth_service(container: RegistryContainer = Depends(get_container)) -> SkillSyncOAuthService:
+    return container.skill_sync_oauth_service
 
 
 def get_federation_sync_service(container: RegistryContainer = Depends(get_container)) -> FederationSyncService:

--- a/registry/src/registry/middleware/auth.py
+++ b/registry/src/registry/middleware/auth.py
@@ -92,6 +92,7 @@ class UnifiedAuthMiddleware:
                 "/api/auth/providers",
                 "/api/auth/config",
                 f"/api/{settings.api_version}/mcp/{{server_name}}/oauth/callback",  # OAuth callback is public
+                f"/api/{settings.api_version}/skill-sync-sources/{{source_id}}/oauth/callback",
                 f"/api/{settings.api_version}/mcp/downstream/oauth/device/{{user_id}}/{{server_path:path}}",
                 f"/api/{settings.api_version}/mcp/downstream/oauth/token/{{user_id}}/{{server_path:path}}",
                 f"/api/{settings.api_version}/mcp/consent/device/resolve",

--- a/registry/src/registry/routers.py
+++ b/registry/src/registry/routers.py
@@ -14,6 +14,7 @@ from .api.v1.meta_routes import router as meta_router
 from .api.v1.search_routes import router as search_router
 from .api.v1.server.server_routes import router as servers_router_v1
 from .api.v1.skill.skill_routes import router as skill_router
+from .api.v1.skill_sync.skill_sync_source_routes import router as skill_sync_source_router
 from .api.v1.token_routes import router as token_router
 from .api.v1.workflow.control_routes import router as workflow_control_router
 from .api.v1.workflow.workflow_routes import router as workflow_router
@@ -48,4 +49,9 @@ def register_routers(app: FastAPI) -> None:
     app.include_router(system_router)
     app.include_router(auth_provider_router, tags=["Authentication"])
     app.include_router(skill_router, prefix=f"/api/{settings.api_version}", tags=["Skills Management"])
+    app.include_router(
+        skill_sync_source_router,
+        prefix=f"/api/{settings.api_version}",
+        tags=["Skill Sync Source Management"],
+    )
     app.include_router(proxy_router, prefix="/proxy", tags=["MCP Proxy"])

--- a/registry/src/registry/schemas/skill_sync_api_schemas.py
+++ b/registry/src/registry/schemas/skill_sync_api_schemas.py
@@ -1,0 +1,168 @@
+from datetime import datetime
+from pathlib import PurePosixPath
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from registry_pkgs.models.enums import (
+    SkillSyncJobPhase,
+    SkillSyncJobStatus,
+    SkillSyncJobType,
+    SkillSyncProviderType,
+    SkillSyncSourceStatus,
+    SkillSyncStatus,
+    SkillSyncTriggerType,
+)
+
+from .acl_schema import ResourcePermissions
+from .server_api_schemas import PaginationMetadata
+
+
+def _validate_relative_path(value: str) -> str:
+    normalized = value.strip()
+    path = PurePosixPath(normalized)
+    if not normalized or normalized.startswith("/") or ".." in path.parts or "\\" in normalized:
+        raise ValueError("paths must contain safe repository-relative POSIX paths")
+    return normalized.rstrip("/") or "."
+
+
+class SkillSyncSourceCreateRequest(BaseModel):
+    displayName: str = Field(min_length=1, max_length=128)
+    description: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    owner: str = Field(min_length=1, max_length=39, pattern=r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
+    repo: str = Field(min_length=1, max_length=100, pattern=r"^[A-Za-z0-9._-]+$")
+    ref: str = Field(default="main", min_length=1, max_length=255, pattern=r"^[A-Za-z0-9._/-]+$")
+    paths: list[str] = Field(min_length=1)
+    skillDiscoveryDepth: int = Field(default=2, ge=0, le=10)
+    githubAppClientId: str = Field(min_length=1)
+    githubAppClientSecret: str = Field(min_length=1)
+
+    @field_validator("paths")
+    @classmethod
+    def validate_paths(cls, values: list[str]) -> list[str]:
+        normalized = [_validate_relative_path(value) for value in values]
+        if len(normalized) != len(set(normalized)):
+            raise ValueError("paths must not contain duplicates")
+        return normalized
+
+    @field_validator("ref")
+    @classmethod
+    def validate_ref(cls, value: str) -> str:
+        if value.startswith("/") or any(part in value for part in ("..", "//", "@{", "\\")):
+            raise ValueError("ref must be a safe Git ref")
+        return value
+
+
+class SkillSyncSourceUpdateRequest(BaseModel):
+    displayName: str | None = Field(default=None, min_length=1, max_length=128)
+    description: str | None = None
+    tags: list[str] | None = None
+    owner: str | None = Field(
+        default=None, min_length=1, max_length=39, pattern=r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$"
+    )
+    repo: str | None = Field(default=None, min_length=1, max_length=100, pattern=r"^[A-Za-z0-9._-]+$")
+    ref: str | None = Field(default=None, min_length=1, max_length=255, pattern=r"^[A-Za-z0-9._/-]+$")
+    paths: list[str] | None = Field(default=None, min_length=1)
+    skillDiscoveryDepth: int | None = Field(default=None, ge=0, le=10)
+    githubAppClientId: str | None = Field(default=None, min_length=1)
+    githubAppClientSecret: str | None = Field(default=None, min_length=1)
+    syncAfterUpdate: bool = False
+
+    @field_validator("paths")
+    @classmethod
+    def validate_paths(cls, values: list[str] | None) -> list[str] | None:
+        if values is None:
+            return None
+        normalized = [_validate_relative_path(value) for value in values]
+        if len(normalized) != len(set(normalized)):
+            raise ValueError("paths must not contain duplicates")
+        return normalized
+
+    @field_validator("ref")
+    @classmethod
+    def validate_ref(cls, value: str | None) -> str | None:
+        if value is not None and (value.startswith("/") or any(part in value for part in ("..", "//", "@{", "\\"))):
+            raise ValueError("ref must be a safe Git ref")
+        return value
+
+
+class SkillSyncSourceStatsResponse(BaseModel):
+    skillCount: int = 0
+    fileCount: int = 0
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SkillSyncSourceLastSyncResponse(BaseModel):
+    jobId: str
+    status: SkillSyncJobStatus
+    startedAt: datetime | None = None
+    finishedAt: datetime | None = None
+    commitSha: str | None = None
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
+
+
+class SkillSyncJobResponse(BaseModel):
+    id: str
+    sourceId: str
+    jobType: SkillSyncJobType
+    triggerType: SkillSyncTriggerType
+    status: SkillSyncJobStatus
+    phase: SkillSyncJobPhase
+    requestSnapshot: dict = Field(default_factory=dict)
+    discoverySummary: dict = Field(default_factory=dict)
+    applySummary: dict = Field(default_factory=dict)
+    skillErrors: list[dict] = Field(default_factory=list)
+    errorCode: str | None = None
+    error: str | None = None
+    startedAt: datetime | None = None
+    finishedAt: datetime | None = None
+    createdAt: datetime
+    updatedAt: datetime
+    model_config = ConfigDict(use_enum_values=True)
+
+
+class SkillSyncSourceListItemResponse(BaseModel):
+    id: str
+    providerType: SkillSyncProviderType
+    displayName: str
+    description: str | None = None
+    tags: list[str]
+    owner: str
+    repo: str
+    ref: str
+    paths: list[str]
+    skillDiscoveryDepth: int
+    status: SkillSyncSourceStatus
+    syncStatus: SkillSyncStatus
+    syncMessage: str | None = None
+    stats: SkillSyncSourceStatsResponse
+    lastSync: SkillSyncSourceLastSyncResponse | None = None
+    permissions: ResourcePermissions | None = None
+    createdAt: datetime
+    updatedAt: datetime
+    model_config = ConfigDict(use_enum_values=True)
+
+
+class SkillSyncSourceDetailResponse(SkillSyncSourceListItemResponse):
+    githubAppClientId: str
+    hasClientSecret: bool
+    recentJobs: list[SkillSyncJobResponse] = Field(default_factory=list)
+    createdBy: str | None = None
+    updatedBy: str | None = None
+
+
+class SkillSyncSourcePagedResponse(BaseModel):
+    sources: list[SkillSyncSourceListItemResponse]
+    pagination: PaginationMetadata
+
+
+class SkillSyncTriggerResponse(BaseModel):
+    job: SkillSyncJobResponse | None = None
+    needsAuthorization: bool = False
+    authorizeUrl: str | None = None
+
+
+class SkillSyncDeleteResponse(BaseModel):
+    sourceId: str
+    jobId: str
+    status: str

--- a/registry/src/registry/services/oauth/oauth_service.py
+++ b/registry/src/registry/services/oauth/oauth_service.py
@@ -279,6 +279,7 @@ class MCPOAuthService:
                 code_verifier=code_verifier,
                 oauth_config=oauth_config,
                 flow_id=flow_id,
+                redirect_uri=get_default_redirect_uri(path=server.path),
                 state_metadata=state_metadata,
                 mcp_client_context=mcp_client_context,
                 device_code=device_code,

--- a/registry/src/registry/services/skill_sync_job_service.py
+++ b/registry/src/registry/services/skill_sync_job_service.py
@@ -1,0 +1,70 @@
+from datetime import UTC, datetime
+from typing import Any
+
+from beanie import PydanticObjectId
+from bson.errors import InvalidId
+from pymongo.asynchronous.client_session import AsyncClientSession
+
+from registry_pkgs.models.enums import (
+    SkillSyncJobErrorCode,
+    SkillSyncJobPhase,
+    SkillSyncJobStateMachine,
+    SkillSyncJobStatus,
+    SkillSyncJobType,
+    SkillSyncTriggerType,
+)
+from registry_pkgs.models.skill_sync_job import SkillSyncJob
+
+
+class SkillSyncJobService:
+    async def get_job(self, job_id: str, *, source_id: PydanticObjectId) -> SkillSyncJob | None:
+        try:
+            object_id = PydanticObjectId(job_id)
+        except (InvalidId, TypeError, ValueError):
+            return None
+        return await SkillSyncJob.find_one({"_id": object_id, "sourceId": source_id})
+
+    async def get_active_job(
+        self,
+        source_id: PydanticObjectId,
+        session: AsyncClientSession | None = None,
+    ) -> SkillSyncJob | None:
+        return await SkillSyncJob.find_one(
+            {
+                "sourceId": source_id,
+                "status": {"$in": [SkillSyncJobStatus.PENDING.value, SkillSyncJobStatus.SYNCING.value]},
+            },
+            sort=[("createdAt", -1)],
+            session=session,
+        )
+
+    async def create_job(
+        self,
+        *,
+        source_id: PydanticObjectId,
+        job_type: SkillSyncJobType,
+        trigger_type: SkillSyncTriggerType,
+        triggered_by: str,
+        request_snapshot: dict[str, Any],
+        session: AsyncClientSession | None = None,
+    ) -> SkillSyncJob:
+        if await self.get_active_job(source_id, session=session):
+            raise ValueError("Skill sync source already has an active sync job")
+        job = SkillSyncJob(
+            sourceId=source_id,
+            jobType=job_type,
+            triggerType=trigger_type,
+            triggeredBy=triggered_by,
+            requestSnapshot=request_snapshot,
+        )
+        await job.insert(session=session)
+        return job
+
+    async def mark_not_implemented(self, job: SkillSyncJob) -> SkillSyncJob:
+        job.status = SkillSyncJobStateMachine.transition_to_failed(job.status)
+        job.phase = SkillSyncJobPhase.FAILED
+        job.errorCode = SkillSyncJobErrorCode.SYNC_NOT_IMPLEMENTED.value
+        job.error = "Skill sync execution is not implemented yet"
+        job.finishedAt = datetime.now(UTC)
+        await job.save()
+        return job

--- a/registry/src/registry/services/skill_sync_oauth_service.py
+++ b/registry/src/registry/services/skill_sync_oauth_service.py
@@ -1,0 +1,104 @@
+import base64
+import hashlib
+import secrets
+from urllib.parse import urlencode
+
+import httpx
+
+from registry.auth.oauth.flow_state_manager import FlowStateManager
+from registry.schemas.oauth_schema import OAuthTokens
+from registry.utils.crypto_utils import decrypt_value
+from registry_pkgs.models.skill_sync_source import SkillSyncSource
+
+from .skill_sync_token_service import SkillSyncTokenService
+
+_GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+_GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
+
+
+class SkillSyncOAuthService:
+    def __init__(
+        self,
+        *,
+        flow_state_manager: FlowStateManager,
+        token_service: SkillSyncTokenService,
+        http_client: httpx.AsyncClient,
+    ) -> None:
+        self._flow_state_manager = flow_state_manager
+        self._token_service = token_service
+        self._http_client = http_client
+
+    def create_authorization_url(
+        self,
+        *,
+        source: SkillSyncSource,
+        user_id: str,
+        redirect_uri: str,
+    ) -> str:
+        code_verifier = secrets.token_urlsafe(64)
+        digest = hashlib.sha256(code_verifier.encode()).digest()
+        code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+        flow_id = f"skillsync:{user_id}:{source.id}:{secrets.token_urlsafe(8)}"
+        oauth_config = {
+            "client_id": source.githubAppClientId,
+            "client_secret": decrypt_value(source.githubAppClientSecretEncrypted),
+            "redirect_uri": redirect_uri,
+            "authorization_url": _GITHUB_AUTHORIZE_URL,
+            "token_url": _GITHUB_TOKEN_URL,
+            "scope": "",
+        }
+        metadata = self._flow_state_manager.create_flow_metadata(
+            server_name="github-skill-sync",
+            server_path=str(source.id),
+            server_id=str(source.id),
+            user_id=user_id,
+            authorization_url=_GITHUB_AUTHORIZE_URL,
+            code_verifier=code_verifier,
+            oauth_config=oauth_config,
+            flow_id=flow_id,
+        )
+        authorization_url = f"{_GITHUB_AUTHORIZE_URL}?{
+            urlencode(
+                {
+                    'client_id': source.githubAppClientId,
+                    'redirect_uri': redirect_uri,
+                    'state': metadata.state,
+                    'code_challenge': code_challenge,
+                    'code_challenge_method': 'S256',
+                }
+            )
+        }"
+        metadata.authorization_url = authorization_url
+        self._flow_state_manager.create_flow(flow_id, str(source.id), user_id, code_verifier, metadata)
+        return authorization_url
+
+    async def exchange_callback(
+        self,
+        *,
+        source: SkillSyncSource,
+        code: str,
+        state: str,
+        redirect_uri: str,
+    ) -> str:
+        decoded = self._flow_state_manager.decode_state(state)
+        flow = self._flow_state_manager.consume_flow(decoded["flow_id"], state)
+        if flow is None or flow.server_id != str(source.id):
+            raise ValueError("OAuth state is invalid or expired")
+        response = await self._http_client.post(
+            _GITHUB_TOKEN_URL,
+            headers={"Accept": "application/json"},
+            data={
+                "client_id": source.githubAppClientId,
+                "client_secret": decrypt_value(source.githubAppClientSecretEncrypted),
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "code_verifier": flow.code_verifier,
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if payload.get("error") or not payload.get("access_token"):
+            raise ValueError(payload.get("error_description") or "GitHub OAuth token exchange failed")
+        tokens = OAuthTokens(**payload)
+        await self._token_service.store_tokens(user_id=flow.user_id, source_id=source.id, tokens=tokens)
+        return flow.user_id

--- a/registry/src/registry/services/skill_sync_oauth_service.py
+++ b/registry/src/registry/services/skill_sync_oauth_service.py
@@ -1,9 +1,8 @@
-import base64
-import hashlib
 import secrets
 from urllib.parse import urlencode
 
 import httpx
+from authlib.oauth2.rfc7636 import create_s256_code_challenge
 
 from registry.auth.oauth.flow_state_manager import FlowStateManager
 from registry.schemas.oauth_schema import OAuthTokens
@@ -35,9 +34,8 @@ class SkillSyncOAuthService:
         user_id: str,
         redirect_uri: str,
     ) -> str:
-        code_verifier = secrets.token_urlsafe(64)
-        digest = hashlib.sha256(code_verifier.encode()).digest()
-        code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+        code_verifier = secrets.token_urlsafe(32)
+        code_challenge = create_s256_code_challenge(code_verifier)
         flow_id = f"skillsync:{user_id}:{source.id}:{secrets.token_urlsafe(8)}"
         oauth_config = {
             "client_id": source.githubAppClientId,

--- a/registry/src/registry/services/skill_sync_oauth_service.py
+++ b/registry/src/registry/services/skill_sync_oauth_service.py
@@ -39,7 +39,6 @@ class SkillSyncOAuthService:
         flow_id = f"skillsync:{user_id}:{source.id}:{secrets.token_urlsafe(8)}"
         oauth_config = {
             "client_id": source.githubAppClientId,
-            "client_secret": decrypt_value(source.githubAppClientSecretEncrypted),
             "redirect_uri": redirect_uri,
             "authorization_url": _GITHUB_AUTHORIZE_URL,
             "token_url": _GITHUB_TOKEN_URL,
@@ -55,17 +54,16 @@ class SkillSyncOAuthService:
             oauth_config=oauth_config,
             flow_id=flow_id,
         )
-        authorization_url = f"{_GITHUB_AUTHORIZE_URL}?{
-            urlencode(
-                {
-                    'client_id': source.githubAppClientId,
-                    'redirect_uri': redirect_uri,
-                    'state': metadata.state,
-                    'code_challenge': code_challenge,
-                    'code_challenge_method': 'S256',
-                }
-            )
-        }"
+        params = urlencode(
+            {
+                "client_id": source.githubAppClientId,
+                "redirect_uri": redirect_uri,
+                "state": metadata.state,
+                "code_challenge": code_challenge,
+                "code_challenge_method": "S256",
+            }
+        )
+        authorization_url = f"{_GITHUB_AUTHORIZE_URL}?{params}"
         metadata.authorization_url = authorization_url
         self._flow_state_manager.create_flow(flow_id, str(source.id), user_id, code_verifier, metadata)
         return authorization_url

--- a/registry/src/registry/services/skill_sync_oauth_service.py
+++ b/registry/src/registry/services/skill_sync_oauth_service.py
@@ -39,7 +39,6 @@ class SkillSyncOAuthService:
         flow_id = f"skillsync:{user_id}:{source.id}:{secrets.token_urlsafe(8)}"
         oauth_config = {
             "client_id": source.githubAppClientId,
-            "redirect_uri": redirect_uri,
             "authorization_url": _GITHUB_AUTHORIZE_URL,
             "token_url": _GITHUB_TOKEN_URL,
             "scope": "",
@@ -53,6 +52,7 @@ class SkillSyncOAuthService:
             code_verifier=code_verifier,
             oauth_config=oauth_config,
             flow_id=flow_id,
+            redirect_uri=redirect_uri,
         )
         params = urlencode(
             {

--- a/registry/src/registry/services/skill_sync_service.py
+++ b/registry/src/registry/services/skill_sync_service.py
@@ -1,31 +1,62 @@
-import logging
+from __future__ import annotations
 
-from registry_pkgs.models.enums import SkillSyncJobType
+from beanie import PydanticObjectId
 
-from .skill_sync_job_service import SkillSyncJobService
+from registry_pkgs.database.mongodb import MongoDB
+from registry_pkgs.models import PrincipalType
+from registry_pkgs.models.enums import RoleBits
+from registry_pkgs.models.extended_access_role import RegistryResourceType
+from registry_pkgs.models.skill_sync_source import SkillSyncSource
+
+from .access_control_service import ACLService
 from .skill_sync_source_crud_service import SkillSyncSourceCrudService
 
-logger = logging.getLogger(__name__)
+SKILL_SYNC_EXECUTION_UNAVAILABLE_DETAIL = "Skill sync execution is not available yet"
 
 
-async def run_skill_sync_background(
-    *,
-    source_id: str,
-    job_id: str,
-    source_service: SkillSyncSourceCrudService,
-    job_service: SkillSyncJobService,
-) -> None:
-    source = await source_service.get_source(source_id)
-    if source is None:
-        logger.error("Skill sync source %s disappeared before placeholder job execution", source_id)
-        return
-    job = await job_service.get_job(job_id, source_id=source.id)
-    if job is None:
-        logger.error("Skill sync job %s disappeared before placeholder execution", job_id)
-        return
-    await job_service.mark_not_implemented(job)
-    message = "Skill sync execution is not implemented yet"
-    if job.jobType == SkillSyncJobType.DELETE_SYNC:
-        await source_service.restore_after_delete_failure(source, message)
-        return
-    await source_service.mark_sync_failed(source, message)
+class SkillSyncService:
+    def __init__(self, source_crud_service: SkillSyncSourceCrudService) -> None:
+        self._source_crud_service = source_crud_service
+
+    async def create_source_with_owner_acl(
+        self,
+        *,
+        display_name: str,
+        description: str | None,
+        tags: list[str],
+        owner: str,
+        repo: str,
+        ref: str,
+        paths: list[str],
+        skill_discovery_depth: int,
+        github_app_client_id: str,
+        github_app_client_secret: str,
+        created_by: str,
+        principal_id: PydanticObjectId,
+        acl_service: ACLService,
+    ) -> SkillSyncSource:
+        async with MongoDB.get_client().start_session() as mongo_session:
+            async with await mongo_session.start_transaction():
+                source = await self._source_crud_service.create_source(
+                    display_name=display_name,
+                    description=description,
+                    tags=tags,
+                    owner=owner,
+                    repo=repo,
+                    ref=ref,
+                    paths=paths,
+                    skill_discovery_depth=skill_discovery_depth,
+                    github_app_client_id=github_app_client_id,
+                    github_app_client_secret=github_app_client_secret,
+                    created_by=created_by,
+                    session=mongo_session,
+                )
+                await acl_service.grant_permission(
+                    principal_type=PrincipalType.USER,
+                    principal_id=principal_id,
+                    resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+                    resource_id=source.id,
+                    perm_bits=RoleBits.OWNER,
+                    session=mongo_session,
+                )
+        return source

--- a/registry/src/registry/services/skill_sync_service.py
+++ b/registry/src/registry/services/skill_sync_service.py
@@ -1,0 +1,31 @@
+import logging
+
+from registry_pkgs.models.enums import SkillSyncJobType
+
+from .skill_sync_job_service import SkillSyncJobService
+from .skill_sync_source_crud_service import SkillSyncSourceCrudService
+
+logger = logging.getLogger(__name__)
+
+
+async def run_skill_sync_background(
+    *,
+    source_id: str,
+    job_id: str,
+    source_service: SkillSyncSourceCrudService,
+    job_service: SkillSyncJobService,
+) -> None:
+    source = await source_service.get_source(source_id)
+    if source is None:
+        logger.error("Skill sync source %s disappeared before placeholder job execution", source_id)
+        return
+    job = await job_service.get_job(job_id, source_id=source.id)
+    if job is None:
+        logger.error("Skill sync job %s disappeared before placeholder execution", job_id)
+        return
+    await job_service.mark_not_implemented(job)
+    message = "Skill sync execution is not implemented yet"
+    if job.jobType == SkillSyncJobType.DELETE_SYNC:
+        await source_service.restore_after_delete_failure(source, message)
+        return
+    await source_service.mark_sync_failed(source, message)

--- a/registry/src/registry/services/skill_sync_source_crud_service.py
+++ b/registry/src/registry/services/skill_sync_source_crud_service.py
@@ -1,0 +1,177 @@
+from datetime import UTC, datetime
+from typing import Any
+
+from beanie import PydanticObjectId
+from bson.errors import InvalidId
+from pydantic import BaseModel
+from pymongo.asynchronous.client_session import AsyncClientSession
+
+from registry.utils.crypto_utils import encrypt_value, is_encrypted
+from registry_pkgs.models.enums import (
+    SkillSyncProviderType,
+    SkillSyncSourceStatus,
+    SkillSyncStateMachine,
+    SkillSyncStatus,
+)
+from registry_pkgs.models.skill_sync_job import SkillSyncJob
+from registry_pkgs.models.skill_sync_source import SkillSyncSource, SkillSyncSourceStats
+
+
+class SkillSyncSourceCrudService:
+    @staticmethod
+    def _encrypt_secret(secret: str) -> str:
+        return secret if is_encrypted(secret) else encrypt_value(secret)
+
+    async def create_source(
+        self,
+        *,
+        display_name: str,
+        description: str | None,
+        tags: list[str],
+        owner: str,
+        repo: str,
+        ref: str,
+        paths: list[str],
+        skill_discovery_depth: int,
+        github_app_client_id: str,
+        github_app_client_secret: str,
+        created_by: str | None,
+        session: AsyncClientSession | None = None,
+    ) -> SkillSyncSource:
+        source = SkillSyncSource(
+            providerType=SkillSyncProviderType.GITHUB,
+            displayName=display_name,
+            description=description,
+            tags=tags,
+            owner=owner,
+            repo=repo,
+            ref=ref,
+            paths=paths,
+            skillDiscoveryDepth=skill_discovery_depth,
+            githubAppClientId=github_app_client_id,
+            githubAppClientSecretEncrypted=self._encrypt_secret(github_app_client_secret),
+            status=SkillSyncSourceStatus.ACTIVE,
+            syncStatus=SkillSyncStatus.IDLE,
+            stats=SkillSyncSourceStats(),
+            createdBy=created_by,
+            updatedBy=created_by,
+        )
+        await source.insert(session=session)
+        return source
+
+    async def get_source(
+        self,
+        source_id: str,
+        session: AsyncClientSession | None = None,
+    ) -> SkillSyncSource | None:
+        try:
+            object_id = PydanticObjectId(source_id)
+        except (InvalidId, TypeError, ValueError):
+            return None
+        source = await SkillSyncSource.get(object_id, session=session)
+        if source is None or source.status == SkillSyncSourceStatus.DELETED or source.deletedAt is not None:
+            return None
+        return source
+
+    async def list_sources(
+        self,
+        *,
+        sync_status: str | None = None,
+        tag: str | None = None,
+        keyword: str | None = None,
+        page: int = 1,
+        page_size: int = 20,
+        accessible_source_ids: list[str] | None = None,
+    ) -> tuple[list[SkillSyncSource], int]:
+        filters: list[dict[str, Any]] = [{"$or": [{"deletedAt": None}, {"deletedAt": {"$exists": False}}]}]
+        if sync_status:
+            filters.append({"syncStatus": sync_status})
+        if tag:
+            filters.append({"tags": tag})
+        if keyword:
+            filters.append({"$text": {"$search": keyword}})
+        if accessible_source_ids is not None:
+            if not accessible_source_ids:
+                return [], 0
+            filters.append({"_id": {"$in": [PydanticObjectId(value) for value in accessible_source_ids]}})
+        query: dict[str, Any] = filters[0] if len(filters) == 1 else {"$and": filters}
+        finder = SkillSyncSource.find(query)
+        total = await finder.count()
+        items = await finder.sort("-updatedAt").skip((page - 1) * page_size).limit(page_size).to_list()
+        return items, total
+
+    async def get_recent_jobs(self, source_id: PydanticObjectId, limit: int = 10) -> list[BaseModel]:
+        return await SkillSyncJob.find({"sourceId": source_id}).sort("-createdAt").limit(limit).to_list()
+
+    async def update_source(
+        self,
+        source: SkillSyncSource,
+        changes: dict[str, Any],
+        *,
+        updated_by: str | None,
+        session: AsyncClientSession | None = None,
+    ) -> SkillSyncSource:
+        if not SkillSyncStateMachine.can_update(source.status):
+            raise ValueError(f"Skill sync source in status '{source.status}' cannot be updated")
+        field_map = {
+            "displayName": "displayName",
+            "description": "description",
+            "tags": "tags",
+            "owner": "owner",
+            "repo": "repo",
+            "ref": "ref",
+            "paths": "paths",
+            "skillDiscoveryDepth": "skillDiscoveryDepth",
+            "githubAppClientId": "githubAppClientId",
+        }
+        for input_name, model_name in field_map.items():
+            if input_name in changes:
+                setattr(source, model_name, changes[input_name])
+        if "githubAppClientSecret" in changes:
+            source.githubAppClientSecretEncrypted = self._encrypt_secret(changes["githubAppClientSecret"])
+        source.updatedBy = updated_by
+        await source.save(session=session)
+        return source
+
+    async def mark_sync_pending(
+        self,
+        source: SkillSyncSource,
+        *,
+        session: AsyncClientSession | None = None,
+    ) -> SkillSyncSource:
+        source.syncStatus = SkillSyncStateMachine.transition_to_sync_pending(source.status, source.syncStatus)
+        source.syncMessage = None
+        await source.save(session=session)
+        return source
+
+    async def mark_sync_failed(
+        self,
+        source: SkillSyncSource,
+        message: str,
+        *,
+        session: AsyncClientSession | None = None,
+    ) -> SkillSyncSource:
+        source.syncStatus = SkillSyncStateMachine.transition_to_sync_failed(source.syncStatus)
+        source.syncMessage = message
+        await source.save(session=session)
+        return source
+
+    async def mark_deleting(
+        self,
+        source: SkillSyncSource,
+        *,
+        session: AsyncClientSession | None = None,
+    ) -> SkillSyncSource:
+        source.syncStatus = SkillSyncStateMachine.transition_to_sync_pending(source.status, source.syncStatus)
+        source.status = SkillSyncStateMachine.transition_to_deleting(source.status)
+        source.syncMessage = None
+        await source.save(session=session)
+        return source
+
+    async def restore_after_delete_failure(self, source: SkillSyncSource, message: str) -> SkillSyncSource:
+        source.status = SkillSyncSourceStatus.ACTIVE
+        source.syncStatus = SkillSyncStatus.FAILED
+        source.syncMessage = message
+        source.updatedAt = datetime.now(UTC)
+        await source.save()
+        return source

--- a/registry/src/registry/services/skill_sync_source_crud_service.py
+++ b/registry/src/registry/services/skill_sync_source_crud_service.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from beanie import PydanticObjectId
 from bson.errors import InvalidId
-from pydantic import BaseModel
 from pymongo.asynchronous.client_session import AsyncClientSession
 
 from registry.utils.crypto_utils import encrypt_value, is_encrypted
@@ -100,7 +99,7 @@ class SkillSyncSourceCrudService:
         items = await finder.sort("-updatedAt").skip((page - 1) * page_size).limit(page_size).to_list()
         return items, total
 
-    async def get_recent_jobs(self, source_id: PydanticObjectId, limit: int = 10) -> list[BaseModel]:
+    async def get_recent_jobs(self, source_id: PydanticObjectId, limit: int = 10) -> list[SkillSyncJob]:
         return await SkillSyncJob.find({"sourceId": source_id}).sort("-createdAt").limit(limit).to_list()
 
     async def update_source(

--- a/registry/src/registry/services/skill_sync_token_service.py
+++ b/registry/src/registry/services/skill_sync_token_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -103,25 +104,31 @@ class SkillSyncTokenService:
     ) -> None:
         identifier = build_skill_sync_token_identifier(source_id)
         user_object_id = PydanticObjectId(user_id)
+        coros = []
         if tokens.access_token:
-            await self._upsert_token(
-                user_id=user_object_id,
-                token_type=TokenType.SKILL_SYNC_GITHUB_ACCESS,
-                identifier=identifier,
-                value=tokens.access_token,
-                expires_in=tokens.expires_in,
-                default_lifetime=_DEFAULT_ACCESS_TOKEN_LIFETIME,
+            coros.append(
+                self._upsert_token(
+                    user_id=user_object_id,
+                    token_type=TokenType.SKILL_SYNC_GITHUB_ACCESS,
+                    identifier=identifier,
+                    value=tokens.access_token,
+                    expires_in=tokens.expires_in,
+                    default_lifetime=_DEFAULT_ACCESS_TOKEN_LIFETIME,
+                )
             )
         if tokens.refresh_token:
-            refresh_expires_in = None
-            await self._upsert_token(
-                user_id=user_object_id,
-                token_type=TokenType.SKILL_SYNC_GITHUB_REFRESH,
-                identifier=identifier,
-                value=tokens.refresh_token,
-                expires_in=refresh_expires_in,
-                default_lifetime=_DEFAULT_REFRESH_TOKEN_LIFETIME,
+            coros.append(
+                self._upsert_token(
+                    user_id=user_object_id,
+                    token_type=TokenType.SKILL_SYNC_GITHUB_REFRESH,
+                    identifier=identifier,
+                    value=tokens.refresh_token,
+                    expires_in=None,
+                    default_lifetime=_DEFAULT_REFRESH_TOKEN_LIFETIME,
+                )
             )
+        if coros:
+            await asyncio.gather(*coros)
 
     async def _upsert_token(
         self,

--- a/registry/src/registry/services/skill_sync_token_service.py
+++ b/registry/src/registry/services/skill_sync_token_service.py
@@ -1,0 +1,163 @@
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+from beanie import PydanticObjectId
+
+from registry.schemas.oauth_schema import OAuthTokens
+from registry.utils.crypto_utils import decrypt_value, encrypt_value
+from registry_pkgs.models import Token
+from registry_pkgs.models.token_type import TokenType
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
+# GitHub Apps without "user-to-server token expiration" return no expires_in;
+# these large defaults effectively mean "never expire on our side".
+_DEFAULT_ACCESS_TOKEN_LIFETIME = timedelta(days=3650)
+_DEFAULT_REFRESH_TOKEN_LIFETIME = timedelta(days=365)
+
+
+def build_skill_sync_token_identifier(source_id: str | PydanticObjectId) -> str:
+    return f"skillsync:{source_id}"
+
+
+class SkillSyncTokenService:
+    def __init__(self, http_client: httpx.AsyncClient) -> None:
+        self._http_client = http_client
+
+    async def resolve_access_token(
+        self,
+        *,
+        user_id: str,
+        source_id: str | PydanticObjectId,
+        client_id: str,
+        client_secret: str,
+    ) -> str | None:
+        """Try access token → refresh fallback → None (caller must re-authorize)."""
+        user_object_id = PydanticObjectId(user_id)
+        identifier = build_skill_sync_token_identifier(source_id)
+        access = await Token.find_one(
+            {
+                "userId": user_object_id,
+                "type": TokenType.SKILL_SYNC_GITHUB_ACCESS.value,
+                "identifier": identifier,
+            }
+        )
+        now = datetime.now(UTC)
+        if access is not None and access.expiresAt > now:
+            return decrypt_value(access.token)
+
+        refresh = await Token.find_one(
+            {
+                "userId": user_object_id,
+                "type": TokenType.SKILL_SYNC_GITHUB_REFRESH.value,
+                "identifier": identifier,
+                "expiresAt": {"$gt": now},
+            }
+        )
+        if refresh is None:
+            return None
+        try:
+            tokens = await self.refresh_tokens(
+                client_id=client_id,
+                client_secret=client_secret,
+                refresh_token=decrypt_value(refresh.token),
+            )
+        except (httpx.HTTPError, ValueError):
+            logger.exception("Failed to refresh GitHub token for skill sync source %s", source_id)
+            return None
+        await self.store_tokens(user_id=user_id, source_id=source_id, tokens=tokens)
+        return tokens.access_token
+
+    async def refresh_tokens(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        refresh_token: str,
+    ) -> OAuthTokens:
+        response = await self._http_client.post(
+            _GITHUB_TOKEN_URL,
+            headers={"Accept": "application/json"},
+            data={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if payload.get("error") or not payload.get("access_token"):
+            raise ValueError(payload.get("error_description") or "GitHub token refresh failed")
+        return OAuthTokens(**payload)
+
+    async def store_tokens(
+        self,
+        *,
+        user_id: str,
+        source_id: str | PydanticObjectId,
+        tokens: OAuthTokens,
+    ) -> None:
+        identifier = build_skill_sync_token_identifier(source_id)
+        user_object_id = PydanticObjectId(user_id)
+        if tokens.access_token:
+            await self._upsert_token(
+                user_id=user_object_id,
+                token_type=TokenType.SKILL_SYNC_GITHUB_ACCESS,
+                identifier=identifier,
+                value=tokens.access_token,
+                expires_in=tokens.expires_in,
+                default_lifetime=_DEFAULT_ACCESS_TOKEN_LIFETIME,
+            )
+        if tokens.refresh_token:
+            refresh_expires_in = None
+            await self._upsert_token(
+                user_id=user_object_id,
+                token_type=TokenType.SKILL_SYNC_GITHUB_REFRESH,
+                identifier=identifier,
+                value=tokens.refresh_token,
+                expires_in=refresh_expires_in,
+                default_lifetime=_DEFAULT_REFRESH_TOKEN_LIFETIME,
+            )
+
+    async def _upsert_token(
+        self,
+        *,
+        user_id: PydanticObjectId,
+        token_type: TokenType,
+        identifier: str,
+        value: str,
+        expires_in: int | None,
+        default_lifetime: timedelta,
+    ) -> None:
+        expires_at = datetime.now(UTC) + (timedelta(seconds=expires_in) if expires_in else default_lifetime)
+        query: dict[str, Any] = {"userId": user_id, "type": token_type.value, "identifier": identifier}
+        token = await Token.find_one(query)
+        if token is None:
+            await Token(
+                userId=user_id,
+                type=token_type.value,
+                identifier=identifier,
+                token=encrypt_value(value),
+                expiresAt=expires_at,
+            ).insert()
+            return
+        token.token = encrypt_value(value)
+        token.expiresAt = expires_at
+        await token.save()
+
+    async def delete_source_tokens(self, source_id: str | PydanticObjectId) -> None:
+        await Token.find(
+            {
+                "identifier": build_skill_sync_token_identifier(source_id),
+                "type": {
+                    "$in": [
+                        TokenType.SKILL_SYNC_GITHUB_ACCESS.value,
+                        TokenType.SKILL_SYNC_GITHUB_REFRESH.value,
+                    ]
+                },
+            }
+        ).delete()

--- a/registry/tests/integration/test_skill_sync_source_routes.py
+++ b/registry/tests/integration/test_skill_sync_source_routes.py
@@ -27,6 +27,7 @@ from registry_pkgs.models.enums import (
     SkillSyncStatus,
     SkillSyncTriggerType,
 )
+from registry_pkgs.models.extended_access_role import RegistryResourceType
 from registry_pkgs.models.skill_sync_job import SkillSyncApplySummary, SkillSyncDiscoverySummary
 from registry_pkgs.models.skill_sync_source import SkillSyncSourceStats
 
@@ -85,6 +86,15 @@ def _make_job(source_id, **overrides):
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
+
+
+def _assert_permission_checked(ctx: SimpleNamespace, required_permission: str) -> None:
+    ctx.acl_service.check_user_permission.assert_awaited_once_with(
+        user_id=PydanticObjectId(USER_ID),
+        resource_type=RegistryResourceType.SKILL_SYNC_SOURCE,
+        resource_id=ctx.source.id,
+        required_permission=required_permission,
+    )
 
 
 @pytest.fixture
@@ -147,6 +157,7 @@ def test_sync_returns_501_without_creating_job(skill_sync_route_context) -> None
     response = ctx.client.post(f"/skill-sync-sources/{ctx.source.id}/sync")
     assert response.status_code == 501
     assert response.json()["detail"] == "Skill sync execution is not available yet"
+    _assert_permission_checked(ctx, "EDIT")
     ctx.job_service.create_job.assert_not_awaited()
 
 
@@ -211,6 +222,7 @@ def test_oauth_initiate_returns_501(skill_sync_route_context) -> None:
         follow_redirects=False,
     )
     assert response.status_code == 501
+    _assert_permission_checked(ctx, "EDIT")
 
 
 def test_create_source_delegates_transaction_to_service(skill_sync_route_context) -> None:
@@ -233,6 +245,7 @@ def test_delete_returns_501_without_creating_job(skill_sync_route_context) -> No
     ctx = skill_sync_route_context
     response = ctx.client.delete(f"/skill-sync-sources/{ctx.source.id}")
     assert response.status_code == 501
+    _assert_permission_checked(ctx, "DELETE")
     ctx.job_service.create_job.assert_not_awaited()
 
 

--- a/registry/tests/integration/test_skill_sync_source_routes.py
+++ b/registry/tests/integration/test_skill_sync_source_routes.py
@@ -1,0 +1,255 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from beanie import PydanticObjectId
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from registry.api.v1.skill_sync.skill_sync_source_routes import router
+from registry.auth.dependencies import get_current_user
+from registry.deps import (
+    get_acl_service,
+    get_skill_sync_job_service,
+    get_skill_sync_oauth_service,
+    get_skill_sync_source_crud_service,
+    get_skill_sync_token_service,
+)
+from registry.schemas.acl_schema import ResourcePermissions
+from registry_pkgs.models.enums import (
+    SkillSyncJobPhase,
+    SkillSyncJobStatus,
+    SkillSyncJobType,
+    SkillSyncProviderType,
+    SkillSyncSourceStatus,
+    SkillSyncStatus,
+    SkillSyncTriggerType,
+)
+from registry_pkgs.models.skill_sync_job import SkillSyncApplySummary, SkillSyncDiscoverySummary
+from registry_pkgs.models.skill_sync_source import SkillSyncSourceStats
+
+USER_ID = "000000000000000000000111"
+_VIEW_PERMS = ResourcePermissions(VIEW=True)
+
+
+def _make_source(source_id=None, **overrides):
+    now = datetime.now(UTC)
+    defaults = {
+        "id": source_id or PydanticObjectId(),
+        "providerType": SkillSyncProviderType.GITHUB,
+        "displayName": "Skills",
+        "description": None,
+        "tags": [],
+        "owner": "octocat",
+        "repo": "skills",
+        "ref": "main",
+        "paths": ["skills"],
+        "skillDiscoveryDepth": 2,
+        "githubAppClientId": "client",
+        "githubAppClientSecretEncrypted": "encrypted",
+        "status": SkillSyncSourceStatus.ACTIVE,
+        "syncStatus": SkillSyncStatus.IDLE,
+        "syncMessage": None,
+        "stats": SkillSyncSourceStats(),
+        "lastSync": None,
+        "createdBy": USER_ID,
+        "updatedBy": USER_ID,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_job(source_id, **overrides):
+    now = datetime.now(UTC)
+    defaults = {
+        "id": PydanticObjectId(),
+        "sourceId": source_id,
+        "jobType": SkillSyncJobType.FULL_SYNC,
+        "triggerType": SkillSyncTriggerType.MANUAL,
+        "status": SkillSyncJobStatus.PENDING,
+        "phase": SkillSyncJobPhase.QUEUED,
+        "requestSnapshot": {},
+        "discoverySummary": SkillSyncDiscoverySummary(),
+        "applySummary": SkillSyncApplySummary(),
+        "skillErrors": [],
+        "errorCode": None,
+        "error": None,
+        "startedAt": None,
+        "finishedAt": None,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture
+def skill_sync_route_context():
+    app = FastAPI()
+    app.include_router(router)
+    source = _make_source()
+    job = _make_job(source.id)
+    source_service = MagicMock()
+    source_service.get_source = AsyncMock(return_value=source)
+    source_service.get_recent_jobs = AsyncMock(return_value=[])
+    source_service.list_sources = AsyncMock(return_value=([source], 1))
+    source_service.update_source = AsyncMock(return_value=source)
+    source_service.mark_sync_pending = AsyncMock(return_value=source)
+    source_service.mark_sync_failed = AsyncMock(return_value=source)
+    source_service.mark_deleting = AsyncMock(return_value=source)
+    source_service.restore_after_delete_failure = AsyncMock(return_value=source)
+    job_service = MagicMock()
+    job_service.get_job = AsyncMock(return_value=job)
+    job_service.get_active_job = AsyncMock(return_value=None)
+    job_service.create_job = AsyncMock(return_value=job)
+    job_service.mark_not_implemented = AsyncMock(return_value=job)
+    token_service = MagicMock()
+    token_service.resolve_access_token = AsyncMock(return_value=None)
+    token_service.delete_source_tokens = AsyncMock()
+    oauth_service = MagicMock()
+    oauth_service.create_authorization_url.return_value = "https://github.com/login/oauth/authorize?state=test"
+    acl_service = MagicMock()
+    acl_service.check_user_permission = AsyncMock(return_value=_VIEW_PERMS)
+    acl_service.get_accessible_resource_ids = AsyncMock(return_value=[str(source.id)])
+    acl_service.get_user_permissions_for_resource = AsyncMock(return_value=None)
+
+    app.dependency_overrides[get_current_user] = lambda: {"user_id": USER_ID}
+    app.dependency_overrides[get_skill_sync_source_crud_service] = lambda: source_service
+    app.dependency_overrides[get_skill_sync_job_service] = lambda: job_service
+    app.dependency_overrides[get_skill_sync_token_service] = lambda: token_service
+    app.dependency_overrides[get_skill_sync_oauth_service] = lambda: oauth_service
+    app.dependency_overrides[get_acl_service] = lambda: acl_service
+
+    with TestClient(app) as client:
+        yield SimpleNamespace(
+            client=client,
+            source=source,
+            job=job,
+            source_service=source_service,
+            job_service=job_service,
+            token_service=token_service,
+            oauth_service=oauth_service,
+            acl_service=acl_service,
+        )
+
+
+def test_sync_without_token_returns_authorization_url(skill_sync_route_context) -> None:
+    response = skill_sync_route_context.client.post(f"/skill-sync-sources/{skill_sync_route_context.source.id}/sync")
+    assert response.status_code == 200
+    assert response.json() == {
+        "job": None,
+        "needsAuthorization": True,
+        "authorizeUrl": "https://github.com/login/oauth/authorize?state=test",
+    }
+
+
+def test_job_polling_is_scoped_to_source(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    response = ctx.client.get(f"/skill-sync-sources/{ctx.source.id}/jobs/{ctx.job.id}")
+    assert response.status_code == 200
+    assert response.json()["sourceId"] == str(ctx.source.id)
+    assert response.json()["status"] == "pending"
+
+
+def test_get_source_returns_detail(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    response = ctx.client.get(f"/skill-sync-sources/{ctx.source.id}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == str(ctx.source.id)
+    assert body["displayName"] == "Skills"
+    assert body["githubAppClientId"] == "client"
+    assert body["hasClientSecret"] is True
+
+
+def test_get_source_not_found(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    ctx.source_service.get_source = AsyncMock(return_value=None)
+    response = ctx.client.get(f"/skill-sync-sources/{PydanticObjectId()}")
+    assert response.status_code == 404
+
+
+def test_list_sources_returns_paged(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    response = ctx.client.get("/skill-sync-sources")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pagination"]["total"] == 1
+    assert len(body["sources"]) == 1
+    assert body["sources"][0]["owner"] == "octocat"
+
+
+def test_list_sources_empty(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    ctx.source_service.list_sources = AsyncMock(return_value=([], 0))
+    response = ctx.client.get("/skill-sync-sources")
+    assert response.status_code == 200
+    assert response.json()["pagination"]["total"] == 0
+    assert response.json()["sources"] == []
+
+
+def test_get_job_not_found(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    ctx.job_service.get_job = AsyncMock(return_value=None)
+    response = ctx.client.get(f"/skill-sync-sources/{ctx.source.id}/jobs/{PydanticObjectId()}")
+    assert response.status_code == 404
+
+
+def test_oauth_initiate_redirects(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    response = ctx.client.get(
+        f"/skill-sync-sources/{ctx.source.id}/oauth/initiate",
+        follow_redirects=False,
+    )
+    assert response.status_code == 307
+    assert "github.com/login/oauth/authorize" in response.headers["location"]
+
+
+def _mock_mongodb():
+    """Patch MongoDB.get_client to return a fake async session + transaction context."""
+
+    class FakeTx:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *a):
+            pass
+
+    class FakeSession:
+        async def start_transaction(self):
+            return FakeTx()
+
+    class FakeSessionCtx:
+        async def __aenter__(self):
+            return FakeSession()
+
+        async def __aexit__(self, *a):
+            pass
+
+    mock_client = MagicMock()
+    mock_client.start_session = MagicMock(return_value=FakeSessionCtx())
+    return patch(
+        "registry.api.v1.skill_sync.skill_sync_source_routes.MongoDB.get_client",
+        return_value=mock_client,
+    )
+
+
+def test_sync_with_token_returns_job(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    ctx.token_service.resolve_access_token = AsyncMock(return_value="ghp_token123")
+    with _mock_mongodb():
+        response = ctx.client.post(f"/skill-sync-sources/{ctx.source.id}/sync")
+    assert response.status_code == 202
+    body = response.json()
+    assert body["job"] is not None
+    assert body["needsAuthorization"] is False
+
+
+def test_acl_forbidden_returns_403(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    ctx.acl_service.check_user_permission = AsyncMock(side_effect=HTTPException(status_code=403, detail="Forbidden"))
+    response = ctx.client.get(f"/skill-sync-sources/{ctx.source.id}")
+    assert response.status_code == 403

--- a/registry/tests/integration/test_skill_sync_source_routes.py
+++ b/registry/tests/integration/test_skill_sync_source_routes.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from beanie import PydanticObjectId
@@ -13,6 +13,7 @@ from registry.deps import (
     get_acl_service,
     get_skill_sync_job_service,
     get_skill_sync_oauth_service,
+    get_skill_sync_service,
     get_skill_sync_source_crud_service,
     get_skill_sync_token_service,
 )
@@ -115,12 +116,16 @@ def skill_sync_route_context():
     acl_service.check_user_permission = AsyncMock(return_value=_VIEW_PERMS)
     acl_service.get_accessible_resource_ids = AsyncMock(return_value=[str(source.id)])
     acl_service.get_user_permissions_for_resource = AsyncMock(return_value=None)
+    acl_service.get_user_permissions_for_resources = AsyncMock(return_value={source.id: ResourcePermissions(VIEW=True)})
+    skill_sync_service = MagicMock()
+    skill_sync_service.create_source_with_owner_acl = AsyncMock(return_value=source)
 
     app.dependency_overrides[get_current_user] = lambda: {"user_id": USER_ID}
     app.dependency_overrides[get_skill_sync_source_crud_service] = lambda: source_service
     app.dependency_overrides[get_skill_sync_job_service] = lambda: job_service
     app.dependency_overrides[get_skill_sync_token_service] = lambda: token_service
     app.dependency_overrides[get_skill_sync_oauth_service] = lambda: oauth_service
+    app.dependency_overrides[get_skill_sync_service] = lambda: skill_sync_service
     app.dependency_overrides[get_acl_service] = lambda: acl_service
 
     with TestClient(app) as client:
@@ -132,18 +137,17 @@ def skill_sync_route_context():
             job_service=job_service,
             token_service=token_service,
             oauth_service=oauth_service,
+            skill_sync_service=skill_sync_service,
             acl_service=acl_service,
         )
 
 
-def test_sync_without_token_returns_authorization_url(skill_sync_route_context) -> None:
-    response = skill_sync_route_context.client.post(f"/skill-sync-sources/{skill_sync_route_context.source.id}/sync")
-    assert response.status_code == 200
-    assert response.json() == {
-        "job": None,
-        "needsAuthorization": True,
-        "authorizeUrl": "https://github.com/login/oauth/authorize?state=test",
-    }
+def test_sync_returns_501_without_creating_job(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    response = ctx.client.post(f"/skill-sync-sources/{ctx.source.id}/sync")
+    assert response.status_code == 501
+    assert response.json()["detail"] == "Skill sync execution is not available yet"
+    ctx.job_service.create_job.assert_not_awaited()
 
 
 def test_job_polling_is_scoped_to_source(skill_sync_route_context) -> None:
@@ -180,6 +184,8 @@ def test_list_sources_returns_paged(skill_sync_route_context) -> None:
     assert body["pagination"]["total"] == 1
     assert len(body["sources"]) == 1
     assert body["sources"][0]["owner"] == "octocat"
+    ctx.acl_service.get_user_permissions_for_resources.assert_awaited_once()
+    ctx.acl_service.get_user_permissions_for_resource.assert_not_awaited()
 
 
 def test_list_sources_empty(skill_sync_route_context) -> None:
@@ -198,54 +204,64 @@ def test_get_job_not_found(skill_sync_route_context) -> None:
     assert response.status_code == 404
 
 
-def test_oauth_initiate_redirects(skill_sync_route_context) -> None:
+def test_oauth_initiate_returns_501(skill_sync_route_context) -> None:
     ctx = skill_sync_route_context
     response = ctx.client.get(
         f"/skill-sync-sources/{ctx.source.id}/oauth/initiate",
         follow_redirects=False,
     )
-    assert response.status_code == 307
-    assert "github.com/login/oauth/authorize" in response.headers["location"]
+    assert response.status_code == 501
 
 
-def _mock_mongodb():
-    """Patch MongoDB.get_client to return a fake async session + transaction context."""
-
-    class FakeTx:
-        async def __aenter__(self):
-            return None
-
-        async def __aexit__(self, *a):
-            pass
-
-    class FakeSession:
-        async def start_transaction(self):
-            return FakeTx()
-
-    class FakeSessionCtx:
-        async def __aenter__(self):
-            return FakeSession()
-
-        async def __aexit__(self, *a):
-            pass
-
-    mock_client = MagicMock()
-    mock_client.start_session = MagicMock(return_value=FakeSessionCtx())
-    return patch(
-        "registry.api.v1.skill_sync.skill_sync_source_routes.MongoDB.get_client",
-        return_value=mock_client,
-    )
-
-
-def test_sync_with_token_returns_job(skill_sync_route_context) -> None:
+def test_create_source_delegates_transaction_to_service(skill_sync_route_context) -> None:
     ctx = skill_sync_route_context
-    ctx.token_service.resolve_access_token = AsyncMock(return_value="ghp_token123")
-    with _mock_mongodb():
-        response = ctx.client.post(f"/skill-sync-sources/{ctx.source.id}/sync")
-    assert response.status_code == 202
-    body = response.json()
-    assert body["job"] is not None
-    assert body["needsAuthorization"] is False
+    payload = {
+        "displayName": "Skills",
+        "owner": "octocat",
+        "repo": "skills",
+        "paths": ["skills"],
+        "githubAppClientId": "client",
+        "githubAppClientSecret": "secret",
+    }
+    response = ctx.client.post("/skill-sync-sources", json=payload)
+    assert response.status_code == 201
+    ctx.skill_sync_service.create_source_with_owner_acl.assert_awaited_once()
+    ctx.source_service.create_source.assert_not_called()
+
+
+def test_delete_returns_501_without_creating_job(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    response = ctx.client.delete(f"/skill-sync-sources/{ctx.source.id}")
+    assert response.status_code == 501
+    ctx.job_service.create_job.assert_not_awaited()
+
+
+def test_update_with_sync_returns_501_without_modifying_source(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    response = ctx.client.put(
+        f"/skill-sync-sources/{ctx.source.id}",
+        json={"displayName": "Renamed", "syncAfterUpdate": True},
+    )
+    assert response.status_code == 501
+    ctx.source_service.update_source.assert_not_awaited()
+
+
+def test_list_sources_maps_acl_runtime_error_to_500(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    ctx.acl_service.get_user_permissions_for_resources = AsyncMock(side_effect=RuntimeError("acl unavailable"))
+    response = ctx.client.get("/skill-sync-sources")
+    assert response.status_code == 500
+
+
+def test_oauth_callback_redirects_when_sync_is_unavailable(skill_sync_route_context) -> None:
+    ctx = skill_sync_route_context
+    response = ctx.client.get(
+        f"/skill-sync-sources/{ctx.source.id}/oauth/callback?code=code&state=state",
+        follow_redirects=False,
+    )
+    assert response.status_code == 307
+    assert "error=sync_unavailable" in response.headers["location"]
+    ctx.oauth_service.exchange_callback.assert_not_called()
 
 
 def test_acl_forbidden_returns_403(skill_sync_route_context) -> None:

--- a/registry/tests/unit/auth/test_flow_state_manager.py
+++ b/registry/tests/unit/auth/test_flow_state_manager.py
@@ -39,6 +39,7 @@ class TestCreateFlowMetadataResourceResolution:
             code_verifier="code_verifier_value",
             oauth_config=oauth_config,
             flow_id="flow_789",
+            redirect_uri="https://example.com/api/v1/mcp/test/oauth/callback",
         )
 
     # ------------------------------------------------------------------

--- a/registry/tests/unit/oauth/test_flow_manager.py
+++ b/registry/tests/unit/oauth/test_flow_manager.py
@@ -129,6 +129,7 @@ class TestFlowStateManager:
             code_verifier,
             oauth_config,
             flow_id,
+            redirect_uri="https://example.com/api/v1/mcp/test-server/oauth/callback",
             state_metadata=state_metadata,
             device_code="device-1",
         )
@@ -173,6 +174,7 @@ class TestFlowStateManager:
             code_verifier,
             oauth_config,
             flow_id,
+            redirect_uri="https://example.com/api/v1/mcp/test-server/oauth/callback",
         )
 
         flow = manager.create_flow(flow_id, server_id, user_id, code_verifier, metadata)
@@ -207,6 +209,7 @@ class TestFlowStateManager:
             code_verifier,
             oauth_config,
             flow_id,
+            redirect_uri="https://example.com/api/v1/mcp/test-server/oauth/callback",
         )
         manager.create_flow(flow_id, server_id, user_id, code_verifier, metadata)
 
@@ -251,6 +254,7 @@ class TestFlowStateManager:
             code_verifier,
             oauth_config,
             flow_id,
+            redirect_uri="https://example.com/api/v1/mcp/test-server/oauth/callback",
         )
         flow = manager.create_flow(flow_id, server_id, user_id, code_verifier, metadata)
 
@@ -286,6 +290,7 @@ class TestFlowStateManager:
             code_verifier,
             oauth_config,
             flow_id,
+            redirect_uri="https://example.com/api/v1/mcp/test-server/oauth/callback",
         )
         manager.create_flow(flow_id, server_id, user_id, code_verifier, metadata)
 
@@ -339,6 +344,7 @@ class TestFlowStateManager:
             code_verifier,
             oauth_config,
             flow_id,
+            redirect_uri="https://example.com/api/v1/mcp/test-server/oauth/callback",
         )
         manager.create_flow(flow_id, server_id, user_id, code_verifier, metadata)
 
@@ -385,6 +391,7 @@ class TestFlowStateManager:
             code_verifier,
             oauth_config,
             flow_id,
+            redirect_uri="https://example.com/api/v1/mcp/test-server/oauth/callback",
         )
         manager.create_flow(flow_id, server_id, user_id, code_verifier, metadata)
 
@@ -422,6 +429,7 @@ class TestFlowStateManager:
             code_verifier,
             oauth_config,
             flow_id,
+            redirect_uri="https://example.com/api/v1/mcp/test-server/oauth/callback",
         )
         manager.create_flow(flow_id, server_id, user_id, code_verifier, metadata)
 
@@ -461,6 +469,7 @@ class TestFlowStateManager:
                 code_verifier,
                 oauth_config,
                 flow_id,
+                redirect_uri="https://example.com/api/v1/mcp/test-server/oauth/callback",
             )
             manager.create_flow(flow_id, server_id, user_id, code_verifier, metadata)
 
@@ -501,6 +510,7 @@ class TestFlowStateManager:
                 code_verifier,
                 oauth_config,
                 flow_id,
+                redirect_uri="https://example.com/api/v1/mcp/test-server/oauth/callback",
             )
             flow = manager.create_flow(flow_id, server_id, user_id, code_verifier, metadata)
             # Make first flow expired
@@ -546,6 +556,7 @@ class TestFlowStateManagerIntegration:
             code_verifier,
             oauth_config,
             flow_id,
+            redirect_uri="https://example.com/api/v1/mcp/test-server/oauth/callback",
         )
         manager.create_flow(flow_id, server_id, user_id, code_verifier, metadata)
 
@@ -601,6 +612,7 @@ class TestFlowStateManagerIntegration:
                 code_verifier,
                 oauth_config,
                 flow_id,
+                redirect_uri="https://example.com/api/v1/mcp/test-server/oauth/callback",
             )
             manager.create_flow(flow_id, server_id, user_id, code_verifier, metadata)
             flows.append(flow_id)

--- a/registry/tests/unit/schemas/test_skill_sync_api_schemas.py
+++ b/registry/tests/unit/schemas/test_skill_sync_api_schemas.py
@@ -1,0 +1,46 @@
+import pytest
+from pydantic import ValidationError
+
+from registry.schemas.skill_sync_api_schemas import (
+    SkillSyncSourceCreateRequest,
+    SkillSyncSourceUpdateRequest,
+)
+
+
+def _valid_create_payload() -> dict:
+    return {
+        "displayName": "Company skills",
+        "owner": "ascending-ai",
+        "repo": "skills.repo",
+        "paths": ["skills/core"],
+        "githubAppClientId": "client-id",
+        "githubAppClientSecret": "secret",
+    }
+
+
+def test_create_request_normalizes_paths() -> None:
+    request = SkillSyncSourceCreateRequest(**_valid_create_payload())
+    assert request.paths == ["skills/core"]
+    assert request.ref == "main"
+
+
+@pytest.mark.parametrize("path", ["../skills", "/skills", "skills\\core", ""])
+def test_create_request_rejects_unsafe_paths(path: str) -> None:
+    payload = _valid_create_payload()
+    payload["paths"] = [path]
+    with pytest.raises(ValidationError):
+        SkillSyncSourceCreateRequest(**payload)
+
+
+@pytest.mark.parametrize("ref", ["../main", "/main", "feature//bad", "feature@{bad"])
+def test_create_request_rejects_unsafe_refs(ref: str) -> None:
+    payload = _valid_create_payload()
+    payload["ref"] = ref
+    with pytest.raises(ValidationError):
+        SkillSyncSourceCreateRequest(**payload)
+
+
+def test_update_secret_is_optional() -> None:
+    request = SkillSyncSourceUpdateRequest(displayName="Renamed")
+    assert request.githubAppClientSecret is None
+    assert request.model_dump(exclude_unset=True) == {"displayName": "Renamed"}

--- a/registry/tests/unit/services/test_skill_sync_job_service.py
+++ b/registry/tests/unit/services/test_skill_sync_job_service.py
@@ -1,0 +1,179 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from beanie import PydanticObjectId
+
+from registry.services.skill_sync_job_service import SkillSyncJobService
+from registry_pkgs.models.enums import (
+    SkillSyncJobErrorCode,
+    SkillSyncJobPhase,
+    SkillSyncJobStatus,
+    SkillSyncJobType,
+    SkillSyncTriggerType,
+)
+
+
+def _make_job(status: SkillSyncJobStatus = SkillSyncJobStatus.PENDING):
+    return SimpleNamespace(
+        status=status,
+        phase=SkillSyncJobPhase.QUEUED,
+        errorCode=None,
+        error=None,
+        finishedAt=None,
+        save=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_job_returns_none_for_invalid_id(monkeypatch):
+    service = SkillSyncJobService()
+    find_one = AsyncMock()
+    monkeypatch.setattr("registry.services.skill_sync_job_service.SkillSyncJob.find_one", find_one)
+
+    result = await service.get_job("not-an-object-id", source_id=PydanticObjectId())
+
+    assert result is None
+    find_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_job_returns_job_when_found(monkeypatch):
+    service = SkillSyncJobService()
+    job_id = PydanticObjectId()
+    source_id = PydanticObjectId()
+    expected_job = _make_job()
+    find_one = AsyncMock(return_value=expected_job)
+    monkeypatch.setattr("registry.services.skill_sync_job_service.SkillSyncJob.find_one", find_one)
+
+    result = await service.get_job(str(job_id), source_id=source_id)
+
+    assert result is expected_job
+    find_one.assert_awaited_once_with({"_id": job_id, "sourceId": source_id})
+
+
+@pytest.mark.asyncio
+async def test_get_active_job_queries_pending_and_syncing_statuses(monkeypatch):
+    service = SkillSyncJobService()
+    source_id = PydanticObjectId()
+    expected_job = _make_job(SkillSyncJobStatus.SYNCING)
+    find_one = AsyncMock(return_value=expected_job)
+    monkeypatch.setattr("registry.services.skill_sync_job_service.SkillSyncJob.find_one", find_one)
+
+    result = await service.get_active_job(source_id)
+
+    assert result is expected_job
+    find_one.assert_awaited_once_with(
+        {
+            "sourceId": source_id,
+            "status": {"$in": [SkillSyncJobStatus.PENDING.value, SkillSyncJobStatus.SYNCING.value]},
+        },
+        sort=[("createdAt", -1)],
+        session=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_active_job_returns_none_when_no_active_job(monkeypatch):
+    service = SkillSyncJobService()
+    find_one = AsyncMock(return_value=None)
+    monkeypatch.setattr("registry.services.skill_sync_job_service.SkillSyncJob.find_one", find_one)
+
+    result = await service.get_active_job(PydanticObjectId())
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_create_job_raises_when_active_job_exists(monkeypatch):
+    service = SkillSyncJobService()
+    find_one = AsyncMock(return_value=_make_job())
+    monkeypatch.setattr("registry.services.skill_sync_job_service.SkillSyncJob.find_one", find_one)
+
+    with pytest.raises(ValueError, match="already has an active sync job"):
+        await service.create_job(
+            source_id=PydanticObjectId(),
+            job_type=SkillSyncJobType.FULL_SYNC,
+            trigger_type=SkillSyncTriggerType.MANUAL,
+            triggered_by="user-1",
+            request_snapshot={},
+        )
+
+
+class _FakeSkillSyncJob:
+    """Stand-in for the Beanie ``SkillSyncJob`` document that skips collection init."""
+
+    find_one = None  # patched per-test
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        self.insert = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_create_job_inserts_new_job_when_no_active_job(monkeypatch):
+    service = SkillSyncJobService()
+    source_id = PydanticObjectId()
+    find_one = AsyncMock(return_value=None)
+    monkeypatch.setattr("registry.services.skill_sync_job_service.SkillSyncJob", _FakeSkillSyncJob)
+    monkeypatch.setattr(_FakeSkillSyncJob, "find_one", find_one)
+
+    job = await service.create_job(
+        source_id=source_id,
+        job_type=SkillSyncJobType.FULL_SYNC,
+        trigger_type=SkillSyncTriggerType.MANUAL,
+        triggered_by="user-1",
+        request_snapshot={"foo": "bar"},
+    )
+
+    assert job.sourceId == source_id
+    assert job.jobType == SkillSyncJobType.FULL_SYNC
+    assert job.triggerType == SkillSyncTriggerType.MANUAL
+    assert job.triggeredBy == "user-1"
+    assert job.requestSnapshot == {"foo": "bar"}
+    job.insert.assert_awaited_once_with(session=None)
+
+
+@pytest.mark.asyncio
+async def test_create_job_passes_session_through(monkeypatch):
+    service = SkillSyncJobService()
+    source_id = PydanticObjectId()
+    session = object()
+    find_one = AsyncMock(return_value=None)
+    monkeypatch.setattr("registry.services.skill_sync_job_service.SkillSyncJob", _FakeSkillSyncJob)
+    monkeypatch.setattr(_FakeSkillSyncJob, "find_one", find_one)
+
+    job = await service.create_job(
+        source_id=source_id,
+        job_type=SkillSyncJobType.DELETE_SYNC,
+        trigger_type=SkillSyncTriggerType.API,
+        triggered_by="user-2",
+        request_snapshot={},
+        session=session,
+    )
+
+    find_one.assert_awaited_once_with(
+        {
+            "sourceId": source_id,
+            "status": {"$in": [SkillSyncJobStatus.PENDING.value, SkillSyncJobStatus.SYNCING.value]},
+        },
+        sort=[("createdAt", -1)],
+        session=session,
+    )
+    job.insert.assert_awaited_once_with(session=session)
+
+
+@pytest.mark.asyncio
+async def test_mark_not_implemented_sets_failed_state():
+    service = SkillSyncJobService()
+    job = _make_job(SkillSyncJobStatus.SYNCING)
+
+    result = await service.mark_not_implemented(job)
+
+    assert result.status == SkillSyncJobStatus.FAILED
+    assert result.phase == SkillSyncJobPhase.FAILED
+    assert result.errorCode == SkillSyncJobErrorCode.SYNC_NOT_IMPLEMENTED.value
+    assert result.error == "Skill sync execution is not implemented yet"
+    assert result.finishedAt is not None
+    job.save.assert_awaited_once()

--- a/registry/tests/unit/services/test_skill_sync_oauth_service.py
+++ b/registry/tests/unit/services/test_skill_sync_oauth_service.py
@@ -36,6 +36,7 @@ def test_authorization_url_uses_pkce_and_persists_flow() -> None:
     assert "code_challenge_method=S256" in url
     assert "state=encoded-state" in url
     flow_manager.create_flow.assert_called_once()
+    assert "include_client_secret" not in flow_manager.create_flow_metadata.call_args.kwargs
 
 
 @pytest.mark.asyncio

--- a/registry/tests/unit/services/test_skill_sync_oauth_service.py
+++ b/registry/tests/unit/services/test_skill_sync_oauth_service.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from beanie import PydanticObjectId
+from httpx import Response
+
+from registry.services.skill_sync_oauth_service import SkillSyncOAuthService
+from registry.utils.crypto_utils import encrypt_value
+
+
+def _source():
+    return SimpleNamespace(
+        id=PydanticObjectId(),
+        githubAppClientId="client-id",
+        githubAppClientSecretEncrypted=encrypt_value("client-secret"),
+    )
+
+
+def test_authorization_url_uses_pkce_and_persists_flow() -> None:
+    flow_manager = MagicMock()
+    flow_manager.create_flow_metadata.return_value = SimpleNamespace(state="encoded-state", authorization_url="")
+    service = SkillSyncOAuthService(
+        flow_state_manager=flow_manager,
+        token_service=MagicMock(),
+        http_client=MagicMock(),
+    )
+
+    url = service.create_authorization_url(
+        source=_source(),
+        user_id="000000000000000000000001",
+        redirect_uri="https://registry.example/callback",
+    )
+
+    assert "code_challenge=" in url
+    assert "code_challenge_method=S256" in url
+    assert "state=encoded-state" in url
+    flow_manager.create_flow.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_callback_consumes_state_and_stores_tokens() -> None:
+    source = _source()
+    flow_manager = MagicMock()
+    flow_manager.decode_state.return_value = {"flow_id": "flow", "security_token": "token"}
+    flow_manager.consume_flow.return_value = SimpleNamespace(
+        server_id=str(source.id),
+        user_id="000000000000000000000001",
+        code_verifier="verifier",
+    )
+    response = Response(
+        200,
+        json={"access_token": "access", "refresh_token": "refresh", "expires_in": 3600},
+        request=MagicMock(),
+    )
+    http_client = MagicMock()
+    http_client.post = AsyncMock(return_value=response)
+    token_service = MagicMock()
+    token_service.store_tokens = AsyncMock()
+    service = SkillSyncOAuthService(
+        flow_state_manager=flow_manager,
+        token_service=token_service,
+        http_client=http_client,
+    )
+
+    user_id = await service.exchange_callback(
+        source=source,
+        code="code",
+        state="state",
+        redirect_uri="https://registry.example/callback",
+    )
+
+    assert user_id == "000000000000000000000001"
+    token_service.store_tokens.assert_awaited_once()
+    assert token_service.store_tokens.await_args.kwargs["tokens"].access_token == "access"

--- a/registry/tests/unit/services/test_skill_sync_service.py
+++ b/registry/tests/unit/services/test_skill_sync_service.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from beanie import PydanticObjectId
+
+from registry.services.skill_sync_service import SkillSyncService
+
+
+class _FakeTransaction:
+    async def __aenter__(self):
+        return None
+
+    async def __aexit__(self, *args):
+        return None
+
+
+class _FakeSession:
+    def __init__(self):
+        self.transaction = _FakeTransaction()
+
+    async def start_transaction(self):
+        return self.transaction
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, *args):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_create_source_with_owner_acl_uses_one_transaction(monkeypatch):
+    session = _FakeSession()
+    client = MagicMock()
+    client.start_session.return_value = _FakeSessionContext(session)
+    monkeypatch.setattr("registry.services.skill_sync_service.MongoDB.get_client", lambda: client)
+
+    source = SimpleNamespace(id=PydanticObjectId())
+    source_service = MagicMock()
+    source_service.create_source = AsyncMock(return_value=source)
+    acl_service = MagicMock()
+    acl_service.grant_permission = AsyncMock()
+    service = SkillSyncService(source_service)
+
+    result = await service.create_source_with_owner_acl(
+        display_name="Skills",
+        description=None,
+        tags=["official"],
+        owner="octocat",
+        repo="skills",
+        ref="main",
+        paths=["skills"],
+        skill_discovery_depth=2,
+        github_app_client_id="client",
+        github_app_client_secret="secret",
+        created_by="user-1",
+        principal_id=PydanticObjectId(),
+        acl_service=acl_service,
+    )
+
+    assert result is source
+    source_session = source_service.create_source.await_args.kwargs["session"]
+    acl_session = acl_service.grant_permission.await_args.kwargs["session"]
+    assert source_session is session
+    assert acl_session is session

--- a/registry/tests/unit/services/test_skill_sync_source_crud_service.py
+++ b/registry/tests/unit/services/test_skill_sync_source_crud_service.py
@@ -1,0 +1,348 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from beanie import PydanticObjectId
+
+from registry.services.skill_sync_source_crud_service import SkillSyncSourceCrudService
+from registry_pkgs.models.enums import SkillSyncProviderType, SkillSyncSourceStatus, SkillSyncStatus
+from registry_pkgs.models.skill_sync_source import SkillSyncSourceStats
+
+MODULE = "registry.services.skill_sync_source_crud_service"
+
+
+def _make_source(
+    *,
+    status: SkillSyncSourceStatus = SkillSyncSourceStatus.ACTIVE,
+    sync_status: SkillSyncStatus = SkillSyncStatus.IDLE,
+    deleted_at=None,
+):
+    return SimpleNamespace(
+        id=PydanticObjectId(),
+        providerType=SkillSyncProviderType.GITHUB,
+        displayName="Demo",
+        description=None,
+        tags=[],
+        owner="acme",
+        repo="skills",
+        ref="main",
+        paths=[],
+        skillDiscoveryDepth=2,
+        githubAppClientId="client-id",
+        githubAppClientSecretEncrypted="encrypted-secret",
+        status=status,
+        syncStatus=sync_status,
+        syncMessage=None,
+        stats=SkillSyncSourceStats(),
+        updatedBy=None,
+        deletedAt=deleted_at,
+        save=AsyncMock(),
+    )
+
+
+class _FakeFinder:
+    def __init__(self, items):
+        self._items = items
+
+    def sort(self, *_args, **_kwargs):
+        return self
+
+    def skip(self, *_args, **_kwargs):
+        return self
+
+    def limit(self, *_args, **_kwargs):
+        return self
+
+    async def to_list(self):
+        return self._items
+
+    async def count(self):
+        return len(self._items)
+
+
+@pytest.fixture(autouse=True)
+def crypto_stub(monkeypatch):
+    monkeypatch.setattr(f"{MODULE}.is_encrypted", lambda value: value.startswith("encrypted:"))
+    monkeypatch.setattr(f"{MODULE}.encrypt_value", lambda value: f"encrypted:{value}")
+
+
+class _StubSource:
+    """Stand-in for the Beanie SkillSyncSource document (avoids needing DB init in unit tests)."""
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        self.insert = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_create_source_encrypts_secret_and_inserts(monkeypatch):
+    monkeypatch.setattr(f"{MODULE}.SkillSyncSource", _StubSource)
+
+    service = SkillSyncSourceCrudService()
+    source = await service.create_source(
+        display_name="Demo",
+        description="desc",
+        tags=["a"],
+        owner="acme",
+        repo="skills",
+        ref="main",
+        paths=["skills/"],
+        skill_discovery_depth=3,
+        github_app_client_id="client-id",
+        github_app_client_secret="plaintext-secret",
+        created_by="user-1",
+    )
+
+    assert source.githubAppClientSecretEncrypted == "encrypted:plaintext-secret"
+    assert source.status == SkillSyncSourceStatus.ACTIVE
+    assert source.syncStatus == SkillSyncStatus.IDLE
+    assert source.createdBy == "user-1"
+    assert source.updatedBy == "user-1"
+    source.insert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_source_does_not_reencrypt_already_encrypted_secret(monkeypatch):
+    monkeypatch.setattr(f"{MODULE}.SkillSyncSource", _StubSource)
+
+    service = SkillSyncSourceCrudService()
+    source = await service.create_source(
+        display_name="Demo",
+        description=None,
+        tags=[],
+        owner="acme",
+        repo="skills",
+        ref="main",
+        paths=[],
+        skill_discovery_depth=2,
+        github_app_client_id="client-id",
+        github_app_client_secret="encrypted:already",
+        created_by=None,
+    )
+
+    assert source.githubAppClientSecretEncrypted == "encrypted:already"
+
+
+@pytest.mark.asyncio
+async def test_get_source_returns_none_for_invalid_id():
+    service = SkillSyncSourceCrudService()
+
+    result = await service.get_source("not-an-object-id")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_source_returns_none_when_not_found(monkeypatch):
+    monkeypatch.setattr(f"{MODULE}.SkillSyncSource.get", AsyncMock(return_value=None))
+
+    service = SkillSyncSourceCrudService()
+    result = await service.get_source(str(PydanticObjectId()))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_source_returns_none_when_status_deleted(monkeypatch):
+    source = _make_source(status=SkillSyncSourceStatus.DELETED)
+    monkeypatch.setattr(f"{MODULE}.SkillSyncSource.get", AsyncMock(return_value=source))
+
+    service = SkillSyncSourceCrudService()
+    result = await service.get_source(str(source.id))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_source_returns_none_when_deleted_at_set(monkeypatch):
+    from datetime import UTC, datetime
+
+    source = _make_source(deleted_at=datetime.now(UTC))
+    monkeypatch.setattr(f"{MODULE}.SkillSyncSource.get", AsyncMock(return_value=source))
+
+    service = SkillSyncSourceCrudService()
+    result = await service.get_source(str(source.id))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_source_returns_source_when_active(monkeypatch):
+    source = _make_source()
+    monkeypatch.setattr(f"{MODULE}.SkillSyncSource.get", AsyncMock(return_value=source))
+
+    service = SkillSyncSourceCrudService()
+    result = await service.get_source(str(source.id))
+
+    assert result is source
+
+
+@pytest.mark.asyncio
+async def test_list_sources_returns_items_and_count(monkeypatch):
+    items = [_make_source(), _make_source()]
+    finder = _FakeFinder(items)
+    monkeypatch.setattr(f"{MODULE}.SkillSyncSource.find", lambda *_a, **_kw: finder)
+
+    service = SkillSyncSourceCrudService()
+    result_items, total = await service.list_sources()
+
+    assert result_items == items
+    assert total == 2
+
+
+@pytest.mark.asyncio
+async def test_list_sources_filters_by_sync_status_tag_and_keyword(monkeypatch):
+    captured = {}
+
+    def _find(query):
+        captured["query"] = query
+        return _FakeFinder([])
+
+    monkeypatch.setattr(f"{MODULE}.SkillSyncSource.find", _find)
+
+    service = SkillSyncSourceCrudService()
+    await service.list_sources(sync_status="failed", tag="prod", keyword="deploy")
+
+    filters = captured["query"]["$and"]
+    assert {"syncStatus": "failed"} in filters
+    assert {"tags": "prod"} in filters
+    assert {"$text": {"$search": "deploy"}} in filters
+
+
+@pytest.mark.asyncio
+async def test_list_sources_returns_empty_for_empty_accessible_ids(monkeypatch):
+    monkeypatch.setattr(f"{MODULE}.SkillSyncSource.find", lambda *_a, **_kw: _FakeFinder([]))
+
+    service = SkillSyncSourceCrudService()
+    items, total = await service.list_sources(accessible_source_ids=[])
+
+    assert items == []
+    assert total == 0
+
+
+@pytest.mark.asyncio
+async def test_list_sources_filters_by_accessible_source_ids(monkeypatch):
+    captured = {}
+    source_id = str(PydanticObjectId())
+
+    def _find(query):
+        captured["query"] = query
+        return _FakeFinder([])
+
+    monkeypatch.setattr(f"{MODULE}.SkillSyncSource.find", _find)
+
+    service = SkillSyncSourceCrudService()
+    await service.list_sources(accessible_source_ids=[source_id])
+
+    filters = captured["query"]["$and"]
+    assert any("_id" in flt for flt in filters)
+
+
+@pytest.mark.asyncio
+async def test_update_source_maps_fields_and_saves():
+    source = _make_source()
+    service = SkillSyncSourceCrudService()
+
+    result = await service.update_source(
+        source,
+        {"displayName": "New Name", "tags": ["x", "y"]},
+        updated_by="user-2",
+    )
+
+    assert result.displayName == "New Name"
+    assert result.tags == ["x", "y"]
+    assert result.updatedBy == "user-2"
+    source.save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_source_encrypts_changed_secret():
+    source = _make_source()
+    service = SkillSyncSourceCrudService()
+
+    result = await service.update_source(
+        source,
+        {"githubAppClientSecret": "new-plaintext"},
+        updated_by=None,
+    )
+
+    assert result.githubAppClientSecretEncrypted == "encrypted:new-plaintext"
+
+
+@pytest.mark.asyncio
+async def test_update_source_rejects_non_active_status():
+    source = _make_source(status=SkillSyncSourceStatus.DELETING)
+    service = SkillSyncSourceCrudService()
+
+    with pytest.raises(ValueError, match="cannot be updated"):
+        await service.update_source(source, {"displayName": "x"}, updated_by=None)
+
+
+@pytest.mark.asyncio
+async def test_mark_sync_pending_transitions_and_clears_message():
+    source = _make_source(sync_status=SkillSyncStatus.FAILED)
+    source.syncMessage = "old error"
+    service = SkillSyncSourceCrudService()
+
+    result = await service.mark_sync_pending(source)
+
+    assert result.syncStatus == SkillSyncStatus.PENDING
+    assert result.syncMessage is None
+    source.save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_mark_sync_pending_rejects_when_source_not_active():
+    source = _make_source(status=SkillSyncSourceStatus.DELETING)
+    service = SkillSyncSourceCrudService()
+
+    with pytest.raises(ValueError, match="cannot start a sync"):
+        await service.mark_sync_pending(source)
+
+
+@pytest.mark.asyncio
+async def test_mark_sync_failed_sets_status_and_message():
+    source = _make_source(sync_status=SkillSyncStatus.SYNCING)
+    service = SkillSyncSourceCrudService()
+
+    result = await service.mark_sync_failed(source, "boom")
+
+    assert result.syncStatus == SkillSyncStatus.FAILED
+    assert result.syncMessage == "boom"
+    source.save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_mark_deleting_transitions_status_and_sync_status():
+    source = _make_source(status=SkillSyncSourceStatus.ACTIVE, sync_status=SkillSyncStatus.IDLE)
+    service = SkillSyncSourceCrudService()
+
+    result = await service.mark_deleting(source)
+
+    assert result.status == SkillSyncSourceStatus.DELETING
+    assert result.syncStatus == SkillSyncStatus.PENDING
+    assert result.syncMessage is None
+    source.save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_mark_deleting_rejects_when_already_deleting():
+    source = _make_source(status=SkillSyncSourceStatus.DELETING)
+    service = SkillSyncSourceCrudService()
+
+    with pytest.raises(ValueError, match="cannot start a sync"):
+        await service.mark_deleting(source)
+
+
+@pytest.mark.asyncio
+async def test_restore_after_delete_failure_sets_active_and_failed():
+    source = _make_source(status=SkillSyncSourceStatus.DELETING, sync_status=SkillSyncStatus.SYNCING)
+    service = SkillSyncSourceCrudService()
+
+    result = await service.restore_after_delete_failure(source, "delete failed")
+
+    assert result.status == SkillSyncSourceStatus.ACTIVE
+    assert result.syncStatus == SkillSyncStatus.FAILED
+    assert result.syncMessage == "delete failed"
+    source.save.assert_awaited_once()

--- a/registry/tests/unit/services/test_skill_sync_token_service.py
+++ b/registry/tests/unit/services/test_skill_sync_token_service.py
@@ -1,0 +1,220 @@
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from beanie import PydanticObjectId
+
+from registry.schemas.oauth_schema import OAuthTokens
+from registry.services.skill_sync_token_service import SkillSyncTokenService, build_skill_sync_token_identifier
+from registry_pkgs.models.token_type import TokenType
+
+
+def _make_token(token: str = "encrypted-value", expires_in_seconds: int = 3600):
+    return SimpleNamespace(
+        token=token,
+        expiresAt=datetime.now(UTC) + timedelta(seconds=expires_in_seconds),
+        save=AsyncMock(),
+    )
+
+
+@pytest.fixture
+def service():
+    return SkillSyncTokenService(http_client=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_resolve_access_token_returns_decrypted_value_when_valid(monkeypatch, service):
+    user_id = str(PydanticObjectId())
+    source_id = PydanticObjectId()
+    access_token = _make_token()
+    find_one = AsyncMock(return_value=access_token)
+    monkeypatch.setattr("registry.services.skill_sync_token_service.Token.find_one", find_one)
+    monkeypatch.setattr(
+        "registry.services.skill_sync_token_service.decrypt_value",
+        lambda value: f"decrypted-{value}",
+    )
+
+    result = await service.resolve_access_token(
+        user_id=user_id,
+        source_id=source_id,
+        client_id="client-id",
+        client_secret="client-secret",
+    )
+
+    assert result == "decrypted-encrypted-value"
+    find_one.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_access_token_refreshes_when_access_expired(monkeypatch, service):
+    user_id = str(PydanticObjectId())
+    source_id = PydanticObjectId()
+    expired_access = _make_token(expires_in_seconds=-60)
+    refresh_token = _make_token(token="encrypted-refresh")
+
+    find_one = AsyncMock(side_effect=[expired_access, refresh_token])
+    monkeypatch.setattr("registry.services.skill_sync_token_service.Token.find_one", find_one)
+    monkeypatch.setattr(
+        "registry.services.skill_sync_token_service.decrypt_value",
+        lambda value: f"decrypted-{value}",
+    )
+    new_tokens = OAuthTokens(access_token="new-access", refresh_token="new-refresh", expires_in=3600)
+    monkeypatch.setattr(service, "refresh_tokens", AsyncMock(return_value=new_tokens))
+    monkeypatch.setattr(service, "store_tokens", AsyncMock())
+
+    result = await service.resolve_access_token(
+        user_id=user_id,
+        source_id=source_id,
+        client_id="client-id",
+        client_secret="client-secret",
+    )
+
+    assert result == "new-access"
+    service.refresh_tokens.assert_awaited_once_with(
+        client_id="client-id",
+        client_secret="client-secret",
+        refresh_token="decrypted-encrypted-refresh",
+    )
+    service.store_tokens.assert_awaited_once_with(user_id=user_id, source_id=source_id, tokens=new_tokens)
+
+
+@pytest.mark.asyncio
+async def test_resolve_access_token_returns_none_when_no_valid_tokens(monkeypatch, service):
+    user_id = str(PydanticObjectId())
+    source_id = PydanticObjectId()
+    find_one = AsyncMock(side_effect=[None, None])
+    monkeypatch.setattr("registry.services.skill_sync_token_service.Token.find_one", find_one)
+
+    result = await service.resolve_access_token(
+        user_id=user_id,
+        source_id=source_id,
+        client_id="client-id",
+        client_secret="client-secret",
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_access_token_returns_none_when_refresh_fails(monkeypatch, service):
+    import httpx
+
+    user_id = str(PydanticObjectId())
+    source_id = PydanticObjectId()
+    expired_access = _make_token(expires_in_seconds=-60)
+    refresh_token = _make_token(token="encrypted-refresh")
+    find_one = AsyncMock(side_effect=[expired_access, refresh_token])
+    monkeypatch.setattr("registry.services.skill_sync_token_service.Token.find_one", find_one)
+    monkeypatch.setattr(
+        "registry.services.skill_sync_token_service.decrypt_value",
+        lambda value: f"decrypted-{value}",
+    )
+    monkeypatch.setattr(service, "refresh_tokens", AsyncMock(side_effect=httpx.HTTPError("boom")))
+
+    result = await service.resolve_access_token(
+        user_id=user_id,
+        source_id=source_id,
+        client_id="client-id",
+        client_secret="client-secret",
+    )
+
+    assert result is None
+
+
+class _FakeToken:
+    """Stand-in for the Beanie ``Token`` document that skips collection init."""
+
+    find_one = None  # patched per-test
+    created: list["_FakeToken"] = []
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        self.insert = AsyncMock()
+        _FakeToken.created.append(self)
+
+
+@pytest.mark.asyncio
+async def test_store_tokens_upserts_access_and_refresh(monkeypatch, service):
+    user_id = str(PydanticObjectId())
+    source_id = PydanticObjectId()
+    find_one = AsyncMock(return_value=None)
+    _FakeToken.created = []
+    monkeypatch.setattr("registry.services.skill_sync_token_service.Token", _FakeToken)
+    monkeypatch.setattr(_FakeToken, "find_one", find_one)
+    monkeypatch.setattr(
+        "registry.services.skill_sync_token_service.encrypt_value",
+        lambda value: f"encrypted-{value}",
+    )
+    tokens = OAuthTokens(access_token="access-1", refresh_token="refresh-1", expires_in=3600)
+
+    await service.store_tokens(user_id=user_id, source_id=source_id, tokens=tokens)
+
+    assert find_one.await_count == 2
+    assert len(_FakeToken.created) == 2
+    for created_token in _FakeToken.created:
+        created_token.insert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_store_tokens_updates_existing_token(monkeypatch, service):
+    user_id = str(PydanticObjectId())
+    source_id = PydanticObjectId()
+    existing_token = _make_token()
+    find_one = AsyncMock(return_value=existing_token)
+    monkeypatch.setattr("registry.services.skill_sync_token_service.Token.find_one", find_one)
+    monkeypatch.setattr(
+        "registry.services.skill_sync_token_service.encrypt_value",
+        lambda value: f"encrypted-{value}",
+    )
+    tokens = OAuthTokens(access_token="access-1", expires_in=3600)
+
+    await service.store_tokens(user_id=user_id, source_id=source_id, tokens=tokens)
+
+    assert existing_token.token == "encrypted-access-1"
+    existing_token.save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_store_tokens_skips_missing_refresh_token(monkeypatch, service):
+    user_id = str(PydanticObjectId())
+    source_id = PydanticObjectId()
+    find_one = AsyncMock(return_value=None)
+    _FakeToken.created = []
+    monkeypatch.setattr("registry.services.skill_sync_token_service.Token", _FakeToken)
+    monkeypatch.setattr(_FakeToken, "find_one", find_one)
+    monkeypatch.setattr(
+        "registry.services.skill_sync_token_service.encrypt_value",
+        lambda value: f"encrypted-{value}",
+    )
+    tokens = OAuthTokens(access_token="access-only", expires_in=3600)
+
+    await service.store_tokens(user_id=user_id, source_id=source_id, tokens=tokens)
+
+    assert find_one.await_count == 1
+    assert len(_FakeToken.created) == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_source_tokens_deletes_matching_tokens(monkeypatch, service):
+    source_id = PydanticObjectId()
+    delete_mock = AsyncMock()
+    find_result = SimpleNamespace(delete=delete_mock)
+    find_mock = MagicMock(return_value=find_result)
+    monkeypatch.setattr("registry.services.skill_sync_token_service.Token.find", find_mock)
+
+    await service.delete_source_tokens(source_id)
+
+    find_mock.assert_called_once_with(
+        {
+            "identifier": build_skill_sync_token_identifier(source_id),
+            "type": {
+                "$in": [
+                    TokenType.SKILL_SYNC_GITHUB_ACCESS.value,
+                    TokenType.SKILL_SYNC_GITHUB_REFRESH.value,
+                ]
+            },
+        }
+    )
+    delete_mock.assert_awaited_once()

--- a/scripts/seed_access_roles_standalone.py
+++ b/scripts/seed_access_roles_standalone.py
@@ -121,7 +121,7 @@ async def seed_access_roles(collection, session):
             "__v": 0,
         },
         {
-            "accessRoleId": "skillSyncSource_viewer",
+            "accessRoleId": "skill_sync_source_viewer",
             "resourceType": "skillSyncSource",
             "name": "com_ui_skill_sync_source_role_viewer",
             "description": "com_ui_skill_sync_source_viewer_desc",
@@ -131,7 +131,7 @@ async def seed_access_roles(collection, session):
             "__v": 0,
         },
         {
-            "accessRoleId": "skillSyncSource_editor",
+            "accessRoleId": "skill_sync_source_editor",
             "resourceType": "skillSyncSource",
             "name": "com_ui_skill_sync_source_role_editor",
             "description": "com_ui_skill_sync_source_editor_desc",
@@ -141,7 +141,7 @@ async def seed_access_roles(collection, session):
             "__v": 0,
         },
         {
-            "accessRoleId": "skillSyncSource_owner",
+            "accessRoleId": "skill_sync_source_owner",
             "resourceType": "skillSyncSource",
             "name": "com_ui_skill_sync_source_role_owner",
             "description": "com_ui_skill_sync_source_owner_desc",

--- a/scripts/seed_access_roles_standalone.py
+++ b/scripts/seed_access_roles_standalone.py
@@ -26,7 +26,7 @@ async def seed_access_roles(collection, session):
     Uses direct MongoDB operations instead of Beanie ORM to avoid
     triggering A2AAgent model initialization.
     """
-    print("=== Seeding Federation, Workflow & Skill AccessRoles ===\n")
+    print("=== Seeding Federation, Workflow, Skill & Skill Sync Source AccessRoles ===\n")
 
     # Chat handles its own resource types. Registry owns these additional role catalogs.
     roles_data = [
@@ -115,6 +115,36 @@ async def seed_access_roles(collection, session):
             "resourceType": "skill",
             "name": "com_ui_skill_role_owner",
             "description": "com_ui_skill_owner_desc",
+            "permBits": 15,
+            "createdAt": datetime.now(UTC),
+            "updatedAt": datetime.now(UTC),
+            "__v": 0,
+        },
+        {
+            "accessRoleId": "skillSyncSource_viewer",
+            "resourceType": "skillSyncSource",
+            "name": "com_ui_skill_sync_source_role_viewer",
+            "description": "com_ui_skill_sync_source_viewer_desc",
+            "permBits": 1,
+            "createdAt": datetime.now(UTC),
+            "updatedAt": datetime.now(UTC),
+            "__v": 0,
+        },
+        {
+            "accessRoleId": "skillSyncSource_editor",
+            "resourceType": "skillSyncSource",
+            "name": "com_ui_skill_sync_source_role_editor",
+            "description": "com_ui_skill_sync_source_editor_desc",
+            "permBits": 3,
+            "createdAt": datetime.now(UTC),
+            "updatedAt": datetime.now(UTC),
+            "__v": 0,
+        },
+        {
+            "accessRoleId": "skillSyncSource_owner",
+            "resourceType": "skillSyncSource",
+            "name": "com_ui_skill_sync_source_role_owner",
+            "description": "com_ui_skill_sync_source_owner_desc",
             "permBits": 15,
             "createdAt": datetime.now(UTC),
             "updatedAt": datetime.now(UTC),

--- a/scripts/test_skill_sync_source_e2e.py
+++ b/scripts/test_skill_sync_source_e2e.py
@@ -1,0 +1,373 @@
+"""
+End-to-end test for Skill Sync Source CRUD + OAuth callback APIs.
+
+Env vars:
+    COOKIE                    Session cookie (required)
+    CSRF                      CSRF token (auto-extracted from COOKIE if missing)
+    GITHUB_CLIENT_ID          GitHub App OAuth client ID (required)
+    GITHUB_CLIENT_SECRET      GitHub App client secret (required)
+    BASE_URL                  Registry base URL (default: http://localhost)
+    GITHUB_OWNER              GitHub owner (default: ascending-llc)
+    GITHUB_REPO               GitHub repo (default: jarvis-skill)
+
+Usage:
+    uv run python scripts/test_skill_sync_source_e2e.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+
+import dotenv
+import httpx
+
+dotenv.load_dotenv()
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("skill_sync_e2e")
+
+PASS = 0
+FAIL = 0
+
+
+def _result(name: str, passed: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if passed:
+        PASS += 1
+        logger.info("[PASS] %s %s", name, detail)
+    else:
+        FAIL += 1
+        logger.error("[FAIL] %s %s", name, detail)
+
+
+def _pp(data: dict | list) -> str:
+    return json.dumps(data, indent=2, default=str)
+
+
+class SkillSyncE2E:
+    def __init__(self) -> None:
+        base_url = os.environ.get("BASE_URL", "http://localhost")
+        cookie = os.environ.get("COOKIE", "")
+        csrf = os.environ.get("CSRF", "")
+
+        if not cookie:
+            logger.error("COOKIE env var required")
+            sys.exit(1)
+
+        if not csrf:
+            for part in cookie.split(";"):
+                part = part.strip()
+                if part.startswith("jarvis_registry_csrf="):
+                    csrf = part.split("=", 1)[1]
+                    logger.info("Auto-extracted CSRF from cookie string")
+                    break
+        if not csrf:
+            logger.error("CSRF env var required (or include jarvis_registry_csrf in COOKIE)")
+            sys.exit(1)
+
+        self.github_client_id = os.environ.get("GITHUB_CLIENT_ID", "")
+        self.github_client_secret = os.environ.get("GITHUB_CLIENT_SECRET", "")
+        if not self.github_client_id or not self.github_client_secret:
+            logger.error("GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET env vars required")
+            sys.exit(1)
+
+        self.github_owner = os.environ.get("GITHUB_OWNER", "ascending-llc")
+        self.github_repo = os.environ.get("GITHUB_REPO", "jarvis-skill")
+
+        self.api = f"{base_url.rstrip('/')}/api/v1/skill-sync-sources"
+        self.client = httpx.Client(
+            headers={
+                "Content-Type": "application/json",
+                "Cookie": cookie,
+                "X-Jarvis-CSRF": csrf,
+            },
+            follow_redirects=False,
+            timeout=30,
+        )
+        self.created_ids: list[str] = []
+
+    def run_all(self) -> None:
+        logger.info("=" * 60)
+        logger.info("Skill Sync Source E2E Tests")
+        logger.info("=" * 60)
+
+        self.test_create_source()
+        self.test_create_validation_errors()
+        self.test_get_source()
+        self.test_get_source_not_found()
+        self.test_list_sources()
+        self.test_list_sources_pagination()
+        self.test_list_sources_filters()
+        self.test_update_source()
+        self.test_update_validation_errors()
+        self.test_sync_returns_501()
+        self.test_delete_returns_501()
+        self.test_oauth_initiate_returns_501()
+        self.test_oauth_callback_missing_params()
+        self.test_oauth_callback_error_param()
+        self.test_get_job_not_found()
+
+        self.cleanup()
+
+        logger.info("=" * 60)
+        logger.info("Results: %d passed, %d failed", PASS, FAIL)
+        logger.info("=" * 60)
+
+    def _create_source(self, display_name: str = "E2E Test Source", **overrides) -> dict | None:
+        payload = {
+            "displayName": display_name,
+            "owner": self.github_owner,
+            "repo": self.github_repo,
+            "ref": "main",
+            "paths": ["jarvis-registry-backend-practices"],
+            "githubAppClientId": self.github_client_id,
+            "githubAppClientSecret": self.github_client_secret,
+            **overrides,
+        }
+        r = self.client.post(self.api, json=payload)
+        if r.status_code == 201:
+            body = r.json()
+            self.created_ids.append(body["id"])
+            return body
+        return None
+
+    def _require_source(self) -> str | None:
+        if self.created_ids:
+            return self.created_ids[0]
+        return None
+
+    def test_create_source(self) -> None:
+        body = self._create_source(
+            display_name="E2E Test Source",
+            description="Automated e2e test",
+            tags=["e2e", "test"],
+            skillDiscoveryDepth=2,
+        )
+        _result("CREATE source → 201", body is not None)
+        if body is None:
+            return
+
+        _result("CREATE id present", bool(body["id"]))
+        _result("CREATE displayName", body["displayName"] == "E2E Test Source")
+        _result("CREATE owner/repo", body["owner"] == self.github_owner and body["repo"] == self.github_repo)
+        _result("CREATE status=active", body["status"] == "active")
+        _result("CREATE syncStatus=idle", body["syncStatus"] == "idle")
+        _result("CREATE hasClientSecret=true", body["hasClientSecret"] is True)
+        _result("CREATE githubAppClientId", body["githubAppClientId"] == self.github_client_id)
+        _result(
+            "CREATE permissions=owner",
+            body.get("permissions", {}).get("VIEW") is True and body.get("permissions", {}).get("DELETE") is True,
+        )
+        _result("CREATE createdBy set", body.get("createdBy") is not None)
+        _result("CREATE recentJobs empty", body.get("recentJobs") == [])
+        logger.info("  Created source: %s", body["id"])
+
+    def test_create_validation_errors(self) -> None:
+        base = {
+            "displayName": "Validation Test",
+            "owner": self.github_owner,
+            "repo": self.github_repo,
+            "ref": "main",
+            "paths": ["skills"],
+            "githubAppClientId": "test-client",
+            "githubAppClientSecret": "test-secret",
+        }
+        cases = [
+            ("empty displayName", {**base, "displayName": ""}),
+            ("empty paths", {**base, "paths": []}),
+            ("path traversal", {**base, "paths": ["../etc/passwd"]}),
+            ("absolute path", {**base, "paths": ["/absolute"]}),
+            ("duplicate paths", {**base, "paths": ["skills", "skills"]}),
+            ("bad ref", {**base, "ref": "refs/../hack"}),
+            ("bad owner", {**base, "owner": "-invalid"}),
+            ("missing required", {"displayName": "missing fields"}),
+            ("depth > 10", {**base, "skillDiscoveryDepth": 99}),
+        ]
+        for label, payload in cases:
+            r = self.client.post(self.api, json=payload)
+            _result(f"VALIDATE {label} → 422", r.status_code == 422, f"status={r.status_code}")
+
+    def test_get_source(self) -> None:
+        sid = self._require_source()
+        if not sid:
+            _result("GET source", False, "no source created")
+            return
+        r = self.client.get(f"{self.api}/{sid}")
+        _result("GET source → 200", r.status_code == 200, f"status={r.status_code}")
+        if r.status_code != 200:
+            return
+        body = r.json()
+        _result("GET id match", body["id"] == sid)
+        _result("GET has detail fields", "githubAppClientId" in body and "recentJobs" in body)
+
+    def test_get_source_not_found(self) -> None:
+        r = self.client.get(f"{self.api}/000000000000000000000000")
+        _result("GET nonexistent → 404", r.status_code == 404, f"status={r.status_code}")
+
+        r = self.client.get(f"{self.api}/not-an-objectid")
+        _result("GET invalid id → 404 or 422", r.status_code in (404, 422), f"status={r.status_code}")
+
+    def test_list_sources(self) -> None:
+        r = self.client.get(self.api)
+        _result("LIST → 200", r.status_code == 200, f"status={r.status_code}")
+        if r.status_code != 200:
+            return
+        body = r.json()
+        _result("LIST has sources array", isinstance(body.get("sources"), list))
+        _result("LIST has pagination", "pagination" in body)
+        _result("LIST total >= 1", body["pagination"]["total"] >= 1)
+        if body["sources"]:
+            item = body["sources"][0]
+            _result("LIST item has owner", "owner" in item)
+            _result(
+                "LIST no secret exposed",
+                "githubAppClientSecret" not in item and "githubAppClientSecretEncrypted" not in item,
+            )
+
+    def test_list_sources_pagination(self) -> None:
+        r = self.client.get(self.api, params={"page": 1, "per_page": 1})
+        _result("LIST per_page=1 → 200", r.status_code == 200, f"status={r.status_code}")
+        if r.status_code == 200:
+            body = r.json()
+            _result("LIST returns at most 1", len(body["sources"]) <= 1)
+            _result("LIST pagination.perPage=1", body["pagination"]["perPage"] == 1)
+
+        r = self.client.get(self.api, params={"page": 9999})
+        _result(
+            "LIST high page → empty",
+            r.status_code == 200 and len(r.json()["sources"]) == 0,
+            f"status={r.status_code}",
+        )
+
+    def test_list_sources_filters(self) -> None:
+        r = self.client.get(self.api, params={"tag": "e2e"})
+        _result("LIST tag=e2e → 200", r.status_code == 200, f"status={r.status_code}")
+        if r.status_code == 200:
+            _result("LIST tag filter >=1", r.json()["pagination"]["total"] >= 1)
+
+        r = self.client.get(self.api, params={"query": "E2E Test"})
+        _result("LIST query filter → 200", r.status_code == 200, f"status={r.status_code}")
+
+        r = self.client.get(self.api, params={"syncStatus": "idle"})
+        _result("LIST syncStatus=idle → 200", r.status_code == 200, f"status={r.status_code}")
+
+    # ── UPDATE ────────────────────────────────────────────────
+
+    def test_update_source(self) -> None:
+        sid = self._require_source()
+        if not sid:
+            _result("UPDATE source", False, "no source created")
+            return
+
+        r = self.client.put(
+            f"{self.api}/{sid}",
+            json={"displayName": "E2E Updated Name", "description": "Updated", "tags": ["e2e", "updated"]},
+        )
+        _result("UPDATE → 200", r.status_code == 200, f"status={r.status_code}")
+        if r.status_code != 200:
+            return
+        body = r.json()
+        _result("UPDATE displayName", body["displayName"] == "E2E Updated Name")
+        _result("UPDATE tags", body["tags"] == ["e2e", "updated"])
+        _result("UPDATE owner unchanged", body["owner"] == self.github_owner)
+
+        # partial update — only ref
+        r = self.client.put(f"{self.api}/{sid}", json={"ref": "develop"})
+        _result("UPDATE partial ref", r.status_code == 200 and r.json()["ref"] == "develop", f"status={r.status_code}")
+
+        # restore
+        self.client.put(f"{self.api}/{sid}", json={"ref": "main"})
+
+        # syncAfterUpdate=true → 501
+        r = self.client.put(f"{self.api}/{sid}", json={"displayName": "Sync After", "syncAfterUpdate": True})
+        _result("UPDATE syncAfterUpdate=true → 501", r.status_code == 501, f"status={r.status_code}")
+
+    def test_update_validation_errors(self) -> None:
+        sid = self._require_source()
+        if not sid:
+            _result("UPDATE validation", False, "no source created")
+            return
+
+        cases = [
+            ("empty displayName", {"displayName": ""}),
+            ("path traversal", {"paths": ["../escape"]}),
+            ("bad ref", {"ref": "refs/../hack"}),
+            ("negative depth", {"skillDiscoveryDepth": -1}),
+        ]
+        for label, payload in cases:
+            r = self.client.put(f"{self.api}/{sid}", json=payload)
+            _result(f"UPDATE {label} → 422", r.status_code == 422, f"status={r.status_code}")
+
+        r = self.client.put(f"{self.api}/000000000000000000000000", json={"displayName": "ghost"})
+        _result("UPDATE nonexistent → 404", r.status_code == 404, f"status={r.status_code}")
+
+    def test_sync_returns_501(self) -> None:
+        sid = self._require_source()
+        if not sid:
+            _result("SYNC 501", False, "no source created")
+            return
+        r = self.client.post(f"{self.api}/{sid}/sync")
+        _result("SYNC → 501", r.status_code == 501, f"status={r.status_code}")
+
+    def test_delete_returns_501(self) -> None:
+        sid = self._require_source()
+        if not sid:
+            _result("DELETE 501", False, "no source created")
+            return
+        r = self.client.delete(f"{self.api}/{sid}")
+        _result("DELETE → 501", r.status_code == 501, f"status={r.status_code}")
+
+    def test_oauth_initiate_returns_501(self) -> None:
+        sid = self._require_source()
+        if not sid:
+            _result("OAUTH initiate 501", False, "no source created")
+            return
+        r = self.client.get(f"{self.api}/{sid}/oauth/initiate")
+        _result("OAUTH initiate → 501", r.status_code == 501, f"status={r.status_code}")
+
+    def test_oauth_callback_missing_params(self) -> None:
+        sid = self._require_source()
+        if not sid:
+            _result("OAUTH callback", False, "no source created")
+            return
+        r = self.client.get(f"{self.api}/{sid}/oauth/callback")
+        _result("OAUTH callback no params → 307", r.status_code == 307, f"status={r.status_code}")
+        if r.status_code == 307:
+            _result("OAUTH callback → error redirect", "error=auth_failed" in r.headers.get("location", ""))
+
+    def test_oauth_callback_error_param(self) -> None:
+        sid = self._require_source()
+        if not sid:
+            _result("OAUTH callback error", False, "no source created")
+            return
+        r = self.client.get(f"{self.api}/{sid}/oauth/callback", params={"error": "access_denied"})
+        _result(
+            "OAUTH callback error param → redirect",
+            r.status_code == 307 and "error=auth_failed" in r.headers.get("location", ""),
+            f"status={r.status_code}",
+        )
+
+    def test_get_job_not_found(self) -> None:
+        sid = self._require_source()
+        if not sid:
+            _result("GET job", False, "no source created")
+            return
+        r = self.client.get(f"{self.api}/{sid}/jobs/000000000000000000000000")
+        _result("GET nonexistent job → 404", r.status_code == 404, f"status={r.status_code}")
+
+    def cleanup(self) -> None:
+        logger.info("--- Cleanup ---")
+        for source_id in self.created_ids:
+            logger.info("  Created source (manual cleanup needed): %s", source_id)
+
+
+def main() -> None:
+    runner = SkillSyncE2E()
+    runner.run_all()
+    sys.exit(1 if FAIL > 0 else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

Add skill sync source management: models, CRUD, OAuth, and API routes for syncing skills from GitHub repositories.

# What's included
1.SkillSyncSource / SkillSyncJob Beanie models with state machine enums
2.CRUD service with ACL access control, pagination, full-text search
3.API design doc: **docs/design/skill-sync-source-api.md**,  gituhb oauth has a specific **Flow Sequence** description

# TEST
1. For the GitHub App registration process, please refer to skill-sync-source-api.md
2. COOKIE=xxxx GITHUB_CLIENT_ID=test GITHUB_CLIENT_SECRET=test uv run python scripts/test_skill_sync_source_e2e.py
