### PR TITLE
Feat/langfuse tracing followup

### DIFF
--- a/docs/features/observability.md
+++ b/docs/features/observability.md
@@ -99,7 +99,7 @@ Two environment settings keep the fleet consistent:
 
 By default, LLM instrumentation can record the full prompt and completion text as span attributes. The agent pipeline disables this so user payloads never reach any backend:
 
-- **`TRACELOOP_TRACE_CONTENT=false`** — records only metadata (model, token counts, latency) and drops prompt/completion content (`gen_ai.input.messages`, `gen_ai.output.messages`, and prompt/completion attributes).
+- **`TRACELOOP_TRACE_CONTENT=false`** — records only metadata (model, token counts, latency) and drops prompt/completion content (`gen_ai.input.messages`, `gen_ai.output.messages`, and prompt/completion attributes). Set it to `true` only in approved environments because doing so allows supported LLM instrumentations to include prompts and completions in exported telemetry spans.
 
 Content is suppressed **at the source**, so it is never transmitted to the collector — and therefore never to any downstream vendor. Token counts and model metadata are unaffected, so usage and cost views keep working. The platform metrics path carries no content by design (counts and durations only).
 

--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
@@ -25,7 +25,7 @@ from a2a.types import (
 )
 from a2a.utils.artifact import get_artifact_text
 from a2a.utils.message import get_message_text
-from opentelemetry.propagate import inject
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from registry_pkgs.core.agentcore_jwt import mint_agentcore_runtime_jwt
 from registry_pkgs.core.config import JwtSigningConfig
@@ -45,6 +45,8 @@ _A2A_JWT_TTL_SECONDS = _A2A_TASK_BUDGET_SECONDS + 300
 _A2A_HTTP_TIMEOUT = httpx.Timeout(30.0, read=_A2A_TASK_BUDGET_SECONDS)
 # Preemptive backstop: a still-streaming send never reaches the poll loop's own check.
 _A2A_HARD_TIMEOUT_SECONDS = _A2A_TASK_BUDGET_SECONDS + 60
+_TRACE_CONTEXT_PROPAGATOR = TraceContextTextMapPropagator()
+_TRACE_CONTEXT_HEADERS = frozenset({"baggage", "traceparent", "tracestate"})
 
 HeadersProvider = Callable[[A2AAgent], Awaitable[dict[str, str]]]
 ClientProvider = Callable[[A2AAgent], Awaitable[httpx.AsyncClient]]
@@ -190,6 +192,17 @@ def _extra_call_headers(agent: A2AAgent) -> dict[str, str]:
     if is_agentcore_runtime(agent):
         return {"X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": str(uuid.uuid4())}
     return {}
+
+
+def _inject_traceparent(headers: dict[str, str]) -> dict[str, str]:
+    """Return copied request headers containing only the current W3C traceparent."""
+    outbound_headers = {key: value for key, value in headers.items() if key.lower() not in _TRACE_CONTEXT_HEADERS}
+    try:
+        _TRACE_CONTEXT_PROPAGATOR.inject(outbound_headers)
+    except Exception:
+        logger.warning("Failed to inject trace context into A2A request headers", exc_info=True)
+    outbound_headers.pop("tracestate", None)
+    return outbound_headers
 
 
 def _create_message(text: str) -> Message:
@@ -455,10 +468,7 @@ async def call_a2a(
         headers = build_headers(agent, jwt_config=jwt_config)
     else:
         headers = _extra_call_headers(agent)
-    try:
-        inject(headers)
-    except Exception:
-        logger.warning("Failed to inject trace context into A2A request headers", exc_info=True)
+    headers = _inject_traceparent(headers)
     context = ClientCallContext(
         state={
             "http_kwargs": {

--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
@@ -25,6 +25,7 @@ from a2a.types import (
 )
 from a2a.utils.artifact import get_artifact_text
 from a2a.utils.message import get_message_text
+from opentelemetry.propagate import inject
 
 from registry_pkgs.core.agentcore_jwt import mint_agentcore_runtime_jwt
 from registry_pkgs.core.config import JwtSigningConfig
@@ -448,6 +449,10 @@ async def call_a2a(
         headers = build_headers(agent, jwt_config=jwt_config)
     else:
         headers = _extra_call_headers(agent)
+    try:
+        inject(headers)
+    except Exception:
+        logger.warning("Failed to inject trace context into A2A request headers", exc_info=True)
     context = ClientCallContext(
         state={
             "http_kwargs": {

--- a/registry-pkgs/tests/unit/workflow/test_a2a_client.py
+++ b/registry-pkgs/tests/unit/workflow/test_a2a_client.py
@@ -22,6 +22,7 @@ from a2a.types import (
     TransportProtocol,
 )
 from beanie import PydanticObjectId
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState, use_span
 
 from registry_pkgs.core.config import JwtSigningConfig
 from registry_pkgs.models.a2a_agent import A2AAgent, AgentConfig
@@ -808,18 +809,27 @@ async def test_call_a2a_does_not_build_credentials_itself():
 async def test_call_a2a_injects_current_trace_context_into_request_headers():
     agent = _make_agent()
     mock_factory, mock_client = _mock_client([_msg("ok")])
+    provided_headers = {
+        "Authorization": "Bearer test-token",
+        "Baggage": "environment=demo",
+        "Traceparent": "00-00000000000000000000000000000002-0000000000000002-01",
+        "Tracestate": "old=value",
+    }
 
     async def headers_provider(_: A2AAgent) -> dict[str, str]:
-        return {"Authorization": "Bearer test-token"}
+        return provided_headers
 
-    def inject_trace_context(headers: dict[str, str]) -> None:
-        headers["traceparent"] = "00-00000000000000000000000000000001-0000000000000001-01"
+    span_context = SpanContext(
+        trace_id=1,
+        span_id=1,
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        trace_state=TraceState([("vendor", "state")]),
+    )
 
-    with (
-        patch("registry_pkgs.workflows.a2a_client.ClientFactory", return_value=mock_factory),
-        patch("registry_pkgs.workflows.a2a_client.inject", side_effect=inject_trace_context) as mock_inject,
-    ):
-        result = await call_a2a(agent, "test", headers_provider=headers_provider)
+    with patch("registry_pkgs.workflows.a2a_client.ClientFactory", return_value=mock_factory):
+        with use_span(NonRecordingSpan(span_context), end_on_exit=False):
+            result = await call_a2a(agent, "test", headers_provider=headers_provider)
 
     assert result.success is True
     send_context = mock_client.send_message.call_args.kwargs["context"]
@@ -828,7 +838,12 @@ async def test_call_a2a_injects_current_trace_context_into_request_headers():
         "Authorization": "Bearer test-token",
         "traceparent": "00-00000000000000000000000000000001-0000000000000001-01",
     }
-    mock_inject.assert_called_once_with(headers)
+    assert provided_headers == {
+        "Authorization": "Bearer test-token",
+        "Baggage": "environment=demo",
+        "Traceparent": "00-00000000000000000000000000000002-0000000000000002-01",
+        "Tracestate": "old=value",
+    }
 
 
 @pytest.mark.asyncio
@@ -841,7 +856,10 @@ async def test_call_a2a_continues_when_trace_context_injection_fails(caplog: pyt
 
     with (
         patch("registry_pkgs.workflows.a2a_client.ClientFactory", return_value=mock_factory),
-        patch("registry_pkgs.workflows.a2a_client.inject", side_effect=RuntimeError("propagator unavailable")),
+        patch(
+            "registry_pkgs.workflows.a2a_client._TRACE_CONTEXT_PROPAGATOR.inject",
+            side_effect=RuntimeError("propagator unavailable"),
+        ),
         caplog.at_level("WARNING", logger="registry_pkgs.workflows.a2a_client"),
     ):
         result = await call_a2a(agent, "test", headers_provider=headers_provider)

--- a/registry-pkgs/tests/unit/workflow/test_a2a_client.py
+++ b/registry-pkgs/tests/unit/workflow/test_a2a_client.py
@@ -733,6 +733,54 @@ async def test_call_a2a_does_not_build_credentials_itself():
     build_headers_spy.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_call_a2a_injects_current_trace_context_into_request_headers():
+    agent = _make_agent()
+    mock_factory, mock_client = _mock_client([_msg("ok")])
+
+    async def headers_provider(_: A2AAgent) -> dict[str, str]:
+        return {"Authorization": "Bearer test-token"}
+
+    def inject_trace_context(headers: dict[str, str]) -> None:
+        headers["traceparent"] = "00-00000000000000000000000000000001-0000000000000001-01"
+
+    with (
+        patch("registry_pkgs.workflows.a2a_client.ClientFactory", return_value=mock_factory),
+        patch("registry_pkgs.workflows.a2a_client.inject", side_effect=inject_trace_context) as mock_inject,
+    ):
+        result = await call_a2a(agent, "test", headers_provider=headers_provider)
+
+    assert result.success is True
+    send_context = mock_client.send_message.call_args.kwargs["context"]
+    headers = send_context.state["http_kwargs"]["headers"]
+    assert headers == {
+        "Authorization": "Bearer test-token",
+        "traceparent": "00-00000000000000000000000000000001-0000000000000001-01",
+    }
+    mock_inject.assert_called_once_with(headers)
+
+
+@pytest.mark.asyncio
+async def test_call_a2a_continues_when_trace_context_injection_fails(caplog: pytest.LogCaptureFixture):
+    agent = _make_agent()
+    mock_factory, mock_client = _mock_client([_msg("ok")])
+
+    async def headers_provider(_: A2AAgent) -> dict[str, str]:
+        return {"Authorization": "Bearer test-token"}
+
+    with (
+        patch("registry_pkgs.workflows.a2a_client.ClientFactory", return_value=mock_factory),
+        patch("registry_pkgs.workflows.a2a_client.inject", side_effect=RuntimeError("propagator unavailable")),
+        caplog.at_level("WARNING", logger="registry_pkgs.workflows.a2a_client"),
+    ):
+        result = await call_a2a(agent, "test", headers_provider=headers_provider)
+
+    assert result.success is True
+    send_context = mock_client.send_message.call_args.kwargs["context"]
+    assert send_context.state["http_kwargs"]["headers"] == {"Authorization": "Bearer test-token"}
+    assert "Failed to inject trace context into A2A request headers" in caplog.text
+
+
 def test_extra_call_headers_returns_agentcore_session_header_only():
     agent = _make_agent()
     agent.federationMetadata = make_agentcore_a2a_metadata()

--- a/registry/src/registry/mcpgw/tools/search.py
+++ b/registry/src/registry/mcpgw/tools/search.py
@@ -12,16 +12,19 @@ from ...auth.dependencies import UserContextDict
 from ...core.exceptions import InternalServerException
 from ...services.search.service import SearchRequest
 from ..core.types import McpAppContext
+from ..tracing import DiscoveryKind, trace_discovery
 
 logger = logging.getLogger(__name__)
 
 
+@trace_discovery
 async def _run_search(
     ctx: Context[ServerSession, McpAppContext],
     query: str,
     top_n: int,
     search_type: str,
     type_list: list[str],
+    discovery_kind: DiscoveryKind,
 ) -> list[dict[str, Any]]:
     logger.info("🔍 Searching type_list=%s query='%s' top_n=%d", type_list, query, top_n)
     try:
@@ -104,7 +107,7 @@ def get_tools() -> list[tuple[str, Callable]]:
         fit, ask the user to clarify. If none fit, refine the query or call with
         query='' top_n=20 to survey all capabilities — then group mentally by server_name
         and retry with that server name in the query to get exact identifiers."""
-        return await _run_search(ctx, query, top_n, "hybrid", type_list)
+        return await _run_search(ctx, query, top_n, "hybrid", type_list, "mcp")
 
     async def discover_agents(
         ctx: Context[ServerSession, McpAppContext],
@@ -159,7 +162,7 @@ def get_tools() -> list[tuple[str, Callable]]:
         result fits, delegate to it. If multiple agents plausibly fit, ask the user
         which domain they prefer. If none fit, broaden the query or call with
         query='' top_n=20 to survey all registered agents."""
-        return await _run_search(ctx, query, top_n, "hybrid", type_list)
+        return await _run_search(ctx, query, top_n, "hybrid", type_list, "a2a")
 
     return [
         ("discover_servers", discover_servers),

--- a/registry/src/registry/mcpgw/tracing.py
+++ b/registry/src/registry/mcpgw/tracing.py
@@ -144,8 +144,8 @@ def _set_span_attributes(span: Span, attributes: dict[str, Any]) -> None:
             return
         for key, value in _clean_attributes(attributes).items():
             span.set_attribute(key, value)
-    except Exception:
-        return
+    except Exception as exc:
+        logger.warning("Failed to set trace attributes (%s)", type(exc).__name__)
 
 
 def _extract_caller_identity(ctx: Context[ServerSession, McpAppContext]) -> dict[str, Any]:
@@ -199,6 +199,25 @@ def _caller_attributes(ctx: Context[ServerSession, McpAppContext]) -> dict[str, 
             "registry.caller.authenticated": identity.get("authenticated"),
         }
     )
+
+
+def _build_trace_attributes(
+    ctx: Context[ServerSession, McpAppContext],
+    *,
+    observation_type: str,
+    trace_name: str,
+    tags: list[str],
+    operation_type: str,
+) -> dict[str, Any]:
+    return {
+        **_caller_attributes(ctx),
+        "langfuse.observation.type": observation_type,
+        "langfuse.trace.name": trace_name,
+        "langfuse.trace.tags": tags,
+        "langfuse.trace.metadata.app": _TRACE_APP,
+        "langfuse.trace.metadata.operationType": operation_type,
+        "registry.operation.type": operation_type,
+    }
 
 
 def _trace_tags(operation: str) -> list[str]:
@@ -266,13 +285,13 @@ def trace_discovery(
         span_name, trace_name, tool_name, tag = _DISCOVERY_OPERATIONS[discovery_kind]
         operation_type = f"{discovery_kind}_discovery"
         attributes = {
-            **_caller_attributes(ctx),
-            "langfuse.observation.type": "tool",
-            "langfuse.trace.name": trace_name,
-            "langfuse.trace.tags": [*_trace_tags(tag), "discovery"],
-            "langfuse.trace.metadata.app": _TRACE_APP,
-            "langfuse.trace.metadata.operationType": operation_type,
-            "registry.operation.type": operation_type,
+            **_build_trace_attributes(
+                ctx,
+                observation_type="tool",
+                trace_name=trace_name,
+                tags=[*_trace_tags(tag), "discovery"],
+                operation_type=operation_type,
+            ),
             "mcp.tool.name": tool_name,
         }
         trace_input = {
@@ -314,13 +333,13 @@ def trace_tool_execution(
         server_id: str,
     ) -> CallToolResult:
         attributes = {
-            **_caller_attributes(ctx),
-            "langfuse.observation.type": "tool",
-            "langfuse.trace.name": _TOOL_TRACE_NAME,
-            "langfuse.trace.tags": _trace_tags("mcp"),
-            "langfuse.trace.metadata.app": _TRACE_APP,
-            "langfuse.trace.metadata.operationType": "mcp_tool",
-            "registry.operation.type": "mcp_tool",
+            **_build_trace_attributes(
+                ctx,
+                observation_type="tool",
+                trace_name=_TOOL_TRACE_NAME,
+                tags=_trace_tags("mcp"),
+                operation_type="mcp_tool",
+            ),
             "mcp.tool.name": tool_name,
             "mcp.server.id": server_id,
         }
@@ -355,13 +374,13 @@ def trace_agent_execution[AgentMessageT](
         ctx: Context[ServerSession, McpAppContext],
     ) -> CallToolResult:
         attributes = {
-            **_caller_attributes(ctx),
-            "langfuse.observation.type": "agent",
-            "langfuse.trace.name": _AGENT_TRACE_NAME,
-            "langfuse.trace.tags": _trace_tags("agent"),
-            "langfuse.trace.metadata.app": _TRACE_APP,
-            "langfuse.trace.metadata.operationType": "a2a_agent",
-            "registry.operation.type": "a2a_agent",
+            **_build_trace_attributes(
+                ctx,
+                observation_type="agent",
+                trace_name=_AGENT_TRACE_NAME,
+                tags=_trace_tags("agent"),
+                operation_type="a2a_agent",
+            ),
             "a2a.agent.id": agent_id,
         }
         with _TRACER.start_as_current_span(_AGENT_SPAN_NAME, attributes=_clean_attributes(attributes)) as span:

--- a/registry/src/registry/mcpgw/tracing.py
+++ b/registry/src/registry/mcpgw/tracing.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from enum import Enum
 from functools import wraps
-from typing import Any
+from typing import Any, Literal
 
 from a2a.types import DataPart, FilePart, FileWithBytes, FileWithUri, TextPart
 from mcp.server.fastmcp import Context
@@ -31,8 +31,17 @@ from .core.types import McpAppContext
 
 logger = logging.getLogger(__name__)
 
-_TOOL_SPAN_NAME = "registry.mcp.tool.execute"
-_AGENT_SPAN_NAME = "registry.a2a.agent.execute"
+DiscoveryKind = Literal["mcp", "a2a"]
+
+_TOOL_SPAN_NAME = "mcp.tool.execute"
+_TOOL_TRACE_NAME = "McpRun"
+_AGENT_SPAN_NAME = "a2a.agent.execute"
+_AGENT_TRACE_NAME = "AgentRun"
+_DISCOVERY_OPERATIONS = {
+    "mcp": ("mcp.discovery", "McpDiscovery", "discover_servers", "mcp"),
+    "a2a": ("a2a.discovery", "AgentDiscovery", "discover_agents", "agent"),
+}
+_TRACE_APP = "registry"
 _TRACER = trace.get_tracer("registry.mcpgw")
 _RAW_PYTHON_BYTES_OMITTED = "[RAW PYTHON BYTES OMITTED]"
 _TRACE_MODEL_FIELDS: dict[type[BaseModel], tuple[str, ...]] = {
@@ -119,10 +128,14 @@ def _serialize_trace_value(value: Any) -> str:
     return json.dumps(serialized, ensure_ascii=False, separators=(",", ":"))
 
 
-def _clean_attributes(attributes: dict[str, Any]) -> dict[str, bool | int | float | str]:
-    return {
-        key: value for key, value in attributes.items() if isinstance(value, (bool, int, float, str)) and value != ""
-    }
+def _clean_attributes(attributes: dict[str, Any]) -> dict[str, bool | int | float | str | list[str]]:
+    cleaned: dict[str, bool | int | float | str | list[str]] = {}
+    for key, value in attributes.items():
+        if (isinstance(value, (bool, int, float, str)) and value != "") or (
+            isinstance(value, list) and value and all(isinstance(item, str) and item != "" for item in value)
+        ):
+            cleaned[key] = value
+    return cleaned
 
 
 def _set_span_attributes(span: Span, attributes: dict[str, Any]) -> None:
@@ -188,6 +201,10 @@ def _caller_attributes(ctx: Context[ServerSession, McpAppContext]) -> dict[str, 
     )
 
 
+def _trace_tags(operation: str) -> list[str]:
+    return [_TRACE_APP, operation]
+
+
 def _set_serialized_attribute(
     span: Span,
     key: str,
@@ -226,6 +243,58 @@ def _record_result(span: Span, result: CallToolResult) -> None:
         return
 
 
+def trace_discovery(
+    func: Callable[
+        [Context[ServerSession, McpAppContext], str, int, str, list[str], DiscoveryKind],
+        Awaitable[list[dict[str, Any]]],
+    ],
+) -> Callable[
+    [Context[ServerSession, McpAppContext], str, int, str, list[str], DiscoveryKind],
+    Awaitable[list[dict[str, Any]]],
+]:
+    """Trace one Registry MCP or A2A capability discovery operation."""
+
+    @wraps(func)
+    async def wrapper(
+        ctx: Context[ServerSession, McpAppContext],
+        query: str,
+        top_n: int,
+        search_type: str,
+        type_list: list[str],
+        discovery_kind: DiscoveryKind,
+    ) -> list[dict[str, Any]]:
+        span_name, trace_name, tool_name, tag = _DISCOVERY_OPERATIONS[discovery_kind]
+        operation_type = f"{discovery_kind}_discovery"
+        attributes = {
+            **_caller_attributes(ctx),
+            "langfuse.observation.type": "tool",
+            "langfuse.trace.name": trace_name,
+            "langfuse.trace.tags": [*_trace_tags(tag), "discovery"],
+            "langfuse.trace.metadata.app": _TRACE_APP,
+            "langfuse.trace.metadata.operationType": operation_type,
+            "registry.operation.type": operation_type,
+            "mcp.tool.name": tool_name,
+        }
+        trace_input = {
+            "query": query,
+            "search_type": search_type,
+            "top_n": top_n,
+            "type_list": type_list,
+        }
+        with _TRACER.start_as_current_span(span_name, attributes=_clean_attributes(attributes)) as span:
+            _set_serialized_attribute(span, "langfuse.observation.input", trace_input)
+            success = False
+            try:
+                results = await func(ctx, query, top_n, search_type, type_list, discovery_kind)
+                _set_serialized_attribute(span, "langfuse.observation.output", results)
+                success = True
+                return results
+            finally:
+                _set_span_attributes(span, {"registry.operation.success": success})
+
+    return wrapper
+
+
 def trace_tool_execution(
     func: Callable[
         [Context[ServerSession, McpAppContext], str, dict[str, Any], str],
@@ -246,8 +315,10 @@ def trace_tool_execution(
     ) -> CallToolResult:
         attributes = {
             **_caller_attributes(ctx),
-            "langfuse.observation.type": "span",
-            "langfuse.trace.name": _TOOL_SPAN_NAME,
+            "langfuse.observation.type": "tool",
+            "langfuse.trace.name": _TOOL_TRACE_NAME,
+            "langfuse.trace.tags": _trace_tags("mcp"),
+            "langfuse.trace.metadata.app": _TRACE_APP,
             "langfuse.trace.metadata.operationType": "mcp_tool",
             "registry.operation.type": "mcp_tool",
             "mcp.tool.name": tool_name,
@@ -285,8 +356,10 @@ def trace_agent_execution[AgentMessageT](
     ) -> CallToolResult:
         attributes = {
             **_caller_attributes(ctx),
-            "langfuse.observation.type": "span",
-            "langfuse.trace.name": _AGENT_SPAN_NAME,
+            "langfuse.observation.type": "agent",
+            "langfuse.trace.name": _AGENT_TRACE_NAME,
+            "langfuse.trace.tags": _trace_tags("agent"),
+            "langfuse.trace.metadata.app": _TRACE_APP,
             "langfuse.trace.metadata.operationType": "a2a_agent",
             "registry.operation.type": "a2a_agent",
             "a2a.agent.id": agent_id,

--- a/registry/src/registry/mcpgw/tracing.py
+++ b/registry/src/registry/mcpgw/tracing.py
@@ -250,16 +250,16 @@ def _set_serialized_attribute(
             logger.warning("Failed to record trace attribute error event for %s", key, exc_info=True)
 
 
-def _record_result(span: Span, result: CallToolResult) -> None:
+def _record_result(span: Span, result: CallToolResult) -> bool:
     success = result.isError is not True
     _set_serialized_attribute(span, "langfuse.observation.output", result)
-    _set_span_attributes(span, {"registry.operation.success": success})
     if success:
-        return
+        return True
     try:
         span.set_status(Status(StatusCode.ERROR, "MCP operation returned an error result"))
     except Exception:
-        return
+        pass
+    return False
 
 
 def trace_discovery(
@@ -349,9 +349,13 @@ def trace_tool_execution(
                 "langfuse.observation.input",
                 projection=lambda: _build_tool_trace_input(tool_name, server_id, arguments),
             )
-            result = await func(ctx, tool_name, arguments, server_id)
-            _record_result(span, result)
-            return result
+            success = False
+            try:
+                result = await func(ctx, tool_name, arguments, server_id)
+                success = _record_result(span, result)
+                return result
+            finally:
+                _set_span_attributes(span, {"registry.operation.success": success})
 
     return wrapper
 
@@ -389,8 +393,12 @@ def trace_agent_execution[AgentMessageT](
                 "langfuse.observation.input",
                 projection=lambda: _build_agent_trace_input(agent_id, message),
             )
-            result = await func(agent_id, message, ctx)
-            _record_result(span, result)
-            return result
+            success = False
+            try:
+                result = await func(agent_id, message, ctx)
+                success = _record_result(span, result)
+                return result
+            finally:
+                _set_span_attributes(span, {"registry.operation.success": success})
 
     return wrapper

--- a/registry/tests/unit/mcpgw/test_tracing.py
+++ b/registry/tests/unit/mcpgw/test_tracing.py
@@ -32,6 +32,7 @@ from registry.mcpgw.tracing import (
     _build_tool_trace_input,
     _extract_caller_identity,
     _serialize_trace_value,
+    _set_span_attributes,
     trace_agent_execution,
     trace_discovery,
     trace_tool_execution,
@@ -422,6 +423,21 @@ def test_caller_identity_failure_is_logged_without_request_data(caplog: pytest.L
     assert identity == {}
     assert "Failed to extract caller identity for tracing" in caplog.text
     assert "DO_NOT_LOG_CALLER_CONTEXT" not in caplog.text
+
+
+@pytest.mark.unit
+@pytest.mark.telemetry
+def test_span_attribute_failure_is_logged_without_attribute_data(caplog: pytest.LogCaptureFixture) -> None:
+    span = MagicMock()
+    span.is_recording.return_value = True
+    span.set_attribute.side_effect = RuntimeError("attribute rejected")
+
+    with caplog.at_level("WARNING", logger="registry.mcpgw.tracing"):
+        _set_span_attributes(span, {"sensitive-key": "DO_NOT_LOG_ATTRIBUTE_VALUE"})
+
+    assert "Failed to set trace attributes (RuntimeError)" in caplog.text
+    assert "sensitive-key" not in caplog.text
+    assert "DO_NOT_LOG_ATTRIBUTE_VALUE" not in caplog.text
 
 
 @pytest.mark.unit

--- a/registry/tests/unit/mcpgw/test_tracing.py
+++ b/registry/tests/unit/mcpgw/test_tracing.py
@@ -27,11 +27,13 @@ from mcp.types import (
 from registry.mcpgw.tools.agent import AgentMessageInput
 from registry.mcpgw.tracing import (
     _TRACE_MODEL_FIELDS,
+    DiscoveryKind,
     _build_agent_trace_input,
     _build_tool_trace_input,
     _extract_caller_identity,
     _serialize_trace_value,
     trace_agent_execution,
+    trace_discovery,
     trace_tool_execution,
 )
 
@@ -334,7 +336,11 @@ async def test_tool_trace_records_caller_target_and_complete_io() -> None:
     attributes = tracer.start_as_current_span.call_args.kwargs["attributes"]
     input_calls = [call for call in span.set_attribute.call_args_list if call.args[0] == "langfuse.observation.input"]
     input_value = json.loads(input_calls[0].args[1])
-    assert span_name == "registry.mcp.tool.execute"
+    assert span_name == "mcp.tool.execute"
+    assert attributes["langfuse.observation.type"] == "tool"
+    assert attributes["langfuse.trace.name"] == "McpRun"
+    assert attributes["langfuse.trace.tags"] == ["registry", "mcp"]
+    assert attributes["langfuse.trace.metadata.app"] == "registry"
     assert attributes["langfuse.user.id"] == "507f1f77bcf86cd799439011"
     assert attributes["langfuse.trace.metadata.username"] == "kelvin"
     assert attributes["langfuse.trace.metadata.oauthClientId"] == "mcp-client-123"
@@ -396,6 +402,7 @@ async def test_tool_trace_omits_unavailable_caller_attributes() -> None:
     assert "langfuse.trace.metadata.authSource" not in attributes
     assert "langfuse.trace.metadata.mcpClientName" not in attributes
     assert "langfuse.trace.metadata.mcpClientVersion" not in attributes
+    assert attributes["langfuse.trace.tags"] == ["registry", "mcp"]
     assert all(value is not None and value != "" for value in attributes.values())
 
 
@@ -420,6 +427,82 @@ def test_caller_identity_failure_is_logged_without_request_data(caplog: pytest.L
 @pytest.mark.unit
 @pytest.mark.telemetry
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("discovery_kind", "expected_span_name", "expected_trace_name", "expected_tool_name", "expected_tags"),
+    [
+        ("mcp", "mcp.discovery", "McpDiscovery", "discover_servers", ["registry", "mcp", "discovery"]),
+        ("a2a", "a2a.discovery", "AgentDiscovery", "discover_agents", ["registry", "agent", "discovery"]),
+    ],
+)
+async def test_discovery_trace_records_caller_search_and_results(
+    discovery_kind: DiscoveryKind,
+    expected_span_name: str,
+    expected_trace_name: str,
+    expected_tool_name: str,
+    expected_tags: list[str],
+) -> None:
+    results = [{"entity_type": "tool", "server_id": "server-123", "tool_name": "search"}]
+
+    @trace_discovery
+    async def discover(ctx, query, top_n, search_type, type_list, kind):
+        return results
+
+    span = MagicMock()
+    span.is_recording.return_value = True
+    with patch("registry.mcpgw.tracing._TRACER") as tracer:
+        tracer.start_as_current_span.return_value = nullcontext(span)
+        returned = await discover(_make_ctx(), "search tools", 3, "hybrid", ["tool"], discovery_kind)
+
+    assert returned is results
+    (span_name,) = tracer.start_as_current_span.call_args.args
+    attributes = tracer.start_as_current_span.call_args.kwargs["attributes"]
+    assert span_name == expected_span_name
+    assert attributes["langfuse.observation.type"] == "tool"
+    assert attributes["langfuse.trace.name"] == expected_trace_name
+    assert attributes["langfuse.trace.tags"] == expected_tags
+    assert attributes["langfuse.trace.metadata.app"] == "registry"
+    assert attributes["mcp.tool.name"] == expected_tool_name
+    assert attributes["registry.operation.type"] == f"{discovery_kind}_discovery"
+    input_call = next(
+        call for call in span.set_attribute.call_args_list if call.args[0] == "langfuse.observation.input"
+    )
+    output_call = next(
+        call for call in span.set_attribute.call_args_list if call.args[0] == "langfuse.observation.output"
+    )
+    assert json.loads(input_call.args[1]) == {
+        "query": "search tools",
+        "search_type": "hybrid",
+        "top_n": 3,
+        "type_list": ["tool"],
+    }
+    assert json.loads(output_call.args[1]) == results
+    span.set_attribute.assert_any_call("registry.operation.success", True)
+
+
+@pytest.mark.unit
+@pytest.mark.telemetry
+@pytest.mark.asyncio
+async def test_discovery_trace_preserves_search_failure() -> None:
+    error = RuntimeError("search unavailable")
+
+    @trace_discovery
+    async def discover(ctx, query, top_n, search_type, type_list, kind):
+        raise error
+
+    span = MagicMock()
+    span.is_recording.return_value = True
+    with patch("registry.mcpgw.tracing._TRACER") as tracer:
+        tracer.start_as_current_span.return_value = nullcontext(span)
+        with pytest.raises(RuntimeError) as exc_info:
+            await discover(_make_ctx(), "search tools", 3, "hybrid", ["tool"], "mcp")
+
+    assert exc_info.value is error
+    span.set_attribute.assert_any_call("registry.operation.success", False)
+
+
+@pytest.mark.unit
+@pytest.mark.telemetry
+@pytest.mark.asyncio
 async def test_agent_trace_marks_error_result_as_failure() -> None:
     result = CallToolResult(content=[TextContent(type="text", text="denied")], isError=True)
     message = AgentMessageInput(parts=[TextPart(kind="text", text="run")])
@@ -435,7 +518,13 @@ async def test_agent_trace_marks_error_result_as_failure() -> None:
         returned = await execute("agent-123", message, _make_ctx())
 
     assert returned is result
+    (span_name,) = tracer.start_as_current_span.call_args.args
     attributes = tracer.start_as_current_span.call_args.kwargs["attributes"]
+    assert span_name == "a2a.agent.execute"
+    assert attributes["langfuse.observation.type"] == "agent"
+    assert attributes["langfuse.trace.name"] == "AgentRun"
+    assert attributes["langfuse.trace.tags"] == ["registry", "agent"]
+    assert attributes["langfuse.trace.metadata.app"] == "registry"
     assert attributes["registry.operation.type"] == "a2a_agent"
     assert attributes["a2a.agent.id"] == "agent-123"
     input_call = next(

--- a/registry/tests/unit/mcpgw/test_tracing.py
+++ b/registry/tests/unit/mcpgw/test_tracing.py
@@ -577,6 +577,34 @@ async def test_tool_trace_marks_cancellation_and_reraises() -> None:
         "server_id": "server-123",
         "tool_name": "search",
     }
+    span.set_attribute.assert_any_call("registry.operation.success", False)
+
+
+@pytest.mark.unit
+@pytest.mark.telemetry
+@pytest.mark.asyncio
+async def test_agent_trace_marks_cancellation_and_reraises() -> None:
+    message = AgentMessageInput(parts=[TextPart(kind="text", text="run")])
+
+    @trace_agent_execution
+    async def execute(agent_id, message, ctx):
+        raise asyncio.CancelledError
+
+    span = MagicMock()
+    span.is_recording.return_value = True
+    with patch("registry.mcpgw.tracing._TRACER") as tracer:
+        tracer.start_as_current_span.return_value = nullcontext(span)
+        with pytest.raises(asyncio.CancelledError):
+            await execute("agent-123", message, _make_ctx())
+
+    input_call = next(
+        call for call in span.set_attribute.call_args_list if call.args[0] == "langfuse.observation.input"
+    )
+    assert json.loads(input_call.args[1]) == {
+        "agent_id": "agent-123",
+        "message": {"parts": [{"kind": "text", "text": "run"}]},
+    }
+    span.set_attribute.assert_any_call("registry.operation.success", False)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

This PR extends Registry-side OpenTelemetry tracing with discovery observability, standardized Langfuse trace structure, and W3C trace-context propagation for downstream A2A calls.

## What changed

- Added structured Registry discovery traces for:
  - `mcp.discovery` with trace name `McpDiscovery`
  - `a2a.discovery` with trace name `AgentDiscovery`
- Standardized execution trace and observation names:
  - `mcp.tool.execute` with trace name `McpRun`
  - `a2a.agent.execute` with trace name `AgentRun`
- Added consistent Langfuse tags and Registry metadata, including the application and operation type.
- Recorded discovery search parameters, results, and execution outcome.
- Centralized shared trace attributes and caller/client metadata handling.
- Improved MCP and A2A input/output serialization to preserve relevant protocol and business data.
- Made tracing fail-open so telemetry failures are logged without interrupting Registry operations.
- Propagated the current W3C `traceparent` header to downstream A2A agents, allowing instrumented agent spans to join the same distributed trace.
- Documented how `TRACELOOP_TRACE_CONTENT` controls prompt and completion capture for supported LLM instrumentations.
- Added unit tests for discovery tracing, trace metadata, input/output projection, error and cancellation handling, and A2A trace-context propagation.

## Validation

- Verified Registry discovery and execution spans are exported to Langfuse through the existing OTel Collector pipeline.
- All current CI checks pass, including Python 3.12 tests, Ruff lint and formatting, security scanning, and code analysis.