### PR TITLE
Hotfix: all tag-related operations ignore tags with `cli-v` prefix

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -37,12 +37,14 @@ jobs:
             PREV_TAG="$PREV_TAG_INPUT"
           else
             # Find the tag of the most recent published (non-draft) GitHub release,
-            # skipping NEW_TAG itself if a release was already created for it.
+            # skipping NEW_TAG itself if a release was already created for it, and
+            # restricted to asc* tags so a cli-v* CLI mirror release (see
+            # cli-jarvis-registry's release.yaml) can't be picked as the diff base.
             PREV_TAG=$(gh release list \
               --exclude-drafts \
               --limit 20 \
               --json tagName,isDraft \
-              --jq "[.[] | select(.tagName != \"${NEW_TAG}\")][0].tagName" \
+              --jq "[.[] | select((.tagName | startswith(\"asc\")) and .tagName != \"${NEW_TAG}\")][0].tagName" \
               2>/dev/null || echo "")
           fi
           if [ -z "$PREV_TAG" ]; then
@@ -73,5 +75,8 @@ jobs:
             --title "Jarvis Registry $NEW_TAG" \
             --notes "$RELEASE_NOTES" \
             --latest
-        # Publishing this release automatically fires release-changelog.yml
-        # (on: release: types: [published]) → generates the MkDocs docs page.
+        # Changelog generation is a separate manual step: run the "Release
+        # Changelog" workflow (release_changelog.yaml, workflow_dispatch) against
+        # this tag. If auto-triggering on `release: published` is ever restored,
+        # gate it on startsWith(github.event.release.tag_name, 'asc') so it
+        # doesn't fire on cli-v* CLI mirror releases.

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       new_tag:
-        description: 'Tag to create the release for (e.g. asc1.2.3)'
+        description: "Tag to create the release for (e.g. asc1.2.3)"
         required: true
         type: string
       prev_tag:
-        description: 'Previous tag for release notes base (leave blank to auto-detect)'
+        description: "Previous tag for release notes base (leave blank to auto-detect)"
         required: false
         type: string
 
@@ -39,7 +39,7 @@ jobs:
             # Find the tag of the most recent published (non-draft) GitHub release,
             # skipping NEW_TAG itself if a release was already created for it, and
             # restricted to asc* tags so a cli-v* CLI mirror release (see
-            # cli-jarvis-registry's release.yaml) can't be picked as the diff base.
+            # jarvis-registry-cli's release.yaml) can't be picked as the diff base.
             PREV_TAG=$(gh release list \
               --exclude-drafts \
               --limit 20 \
@@ -68,7 +68,7 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEW_TAG:  ${{ inputs.new_tag }}
+          NEW_TAG: ${{ inputs.new_tag }}
           RELEASE_NOTES: ${{ steps.notes.outputs['release-notes'] }}
         run: |
           gh release create "$NEW_TAG" \

--- a/.github/workflows/release_changelog.yaml
+++ b/.github/workflows/release_changelog.yaml
@@ -42,11 +42,14 @@ jobs:
           if [ -n "$INPUT_TAG" ]; then
             TAG="$INPUT_TAG"
           else
+            # --limit 20 + a startswith("asc") filter, not --limit 1, so a more
+            # recent cli-v* CLI mirror release (see create_release.yaml) can't
+            # shadow the actual latest Jarvis Registry release.
             TAG=$(gh release list \
               --exclude-drafts \
-              --limit 1 \
+              --limit 20 \
               --json tagName \
-              --jq '.[0].tagName' \
+              --jq '[.[] | select(.tagName | startswith("asc"))][0].tagName' \
               2>/dev/null || echo "")
           fi
           if [ -z "$TAG" ]; then

--- a/.github/workflows/tag_build_images.yaml
+++ b/.github/workflows/tag_build_images.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Get current version from latest tag
         id: get_version
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "asc0.0.0")
+          LATEST_TAG=$(git describe --tags --match 'asc*' --abbrev=0 2>/dev/null || echo "asc0.0.0")
           CURRENT_VERSION=${LATEST_TAG#asc}
           echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
I just published the first Jarvis Registry CLI release, tagged `cli-v0.1.0` from the `jarvis-registry-cli` repo. Because of this new format of tags, we should update some workflows in this repo so that they correctly ignores `cli-v*` tags and only look at `asc*` tags.