### PR TITLE
feat: add Langfuse tracing for workflow executions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,8 +74,12 @@ CREDS_KEY=your_secure_creds_key_for_encrypting_tokens
 # =============================================================================
 # LANGFUSE — LLM trace backend (cost tracking, token usage, session attribution)
 # =============================================================================
-# Fans out gen_ai.* spans through OTEL Collector into Langfuse Cloud
+# Fans out OpenTelemetry traces through OTEL Collector into Langfuse Cloud
 LANGFUSE_OTLP_AUTHORIZATION=
+# Controls Agno-generated child spans; Workflow root input/output is always recorded.
+# Set both to false to display Agno Workflow and Step input/output in Langfuse.
+OTEL_TRACE_HIDE_INPUTS=true
+OTEL_TRACE_HIDE_OUTPUTS=true
 
 # =============================================================================
 # AUTHENTICATION PROVIDER CONFIGURATION

--- a/registry-pkgs/src/registry_pkgs/telemetry/__init__.py
+++ b/registry-pkgs/src/registry_pkgs/telemetry/__init__.py
@@ -16,6 +16,7 @@ from .decorators import (
     create_timed_context,
     track_duration,
 )
+from .workflow_tracing import ensure_langfuse_trace_attribute_processor
 
 __all__ = [
     "setup_metrics",
@@ -240,6 +241,7 @@ def setup_tracing(
             if provider_is_new
             else current_provider
         )
+        ensure_langfuse_trace_attribute_processor(tracer_provider)
 
         instrumentor = instrumentor_type()
         if not instrumentor.is_instrumented_by_opentelemetry:

--- a/registry-pkgs/src/registry_pkgs/telemetry/span_attributes.py
+++ b/registry-pkgs/src/registry_pkgs/telemetry/span_attributes.py
@@ -1,0 +1,39 @@
+"""Shared helpers for building OpenTelemetry span attributes destined for Langfuse.
+
+Used by both ``registry_pkgs.telemetry.workflow_tracing`` and
+``registry.mcpgw.tracing`` so the attribute-cleaning rule lives in one place.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+
+from opentelemetry.trace import Span
+
+logger = logging.getLogger(__name__)
+
+type SpanAttributeValue = bool | int | float | str | list[str]
+
+TRACE_APP = "registry"
+
+
+def clean_span_attributes(attributes: Mapping[str, object]) -> dict[str, SpanAttributeValue]:
+    cleaned: dict[str, SpanAttributeValue] = {}
+    for key, value in attributes.items():
+        if (isinstance(value, (bool, int, float, str)) and value != "") or (
+            isinstance(value, list) and value and all(isinstance(item, str) and item != "" for item in value)
+        ):
+            cleaned[key] = value
+    return cleaned
+
+
+def set_span_attributes(span: Span, attributes: Mapping[str, object]) -> None:
+    """Best-effort attribute assignment without exposing values in logs."""
+    try:
+        if not span.is_recording():
+            return
+        for key, value in clean_span_attributes(attributes).items():
+            span.set_attribute(key, value)
+    except Exception as exc:
+        logger.warning("Failed to set trace attributes (%s)", type(exc).__name__)

--- a/registry-pkgs/src/registry_pkgs/telemetry/workflow_tracing.py
+++ b/registry-pkgs/src/registry_pkgs/telemetry/workflow_tracing.py
@@ -18,15 +18,14 @@ from opentelemetry.sdk.trace import Span as SDKSpan
 from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
 from opentelemetry.trace import Span, Status, StatusCode
 
+from .span_attributes import TRACE_APP, SpanAttributeValue, clean_span_attributes, set_span_attributes
+
 logger = logging.getLogger(__name__)
 
-type SpanAttributeValue = bool | int | float | str | list[str]
-
-_TRACE_APP = "registry"
 _WORKFLOW_SPAN_NAME = "workflow.execute"
 _WORKFLOW_CONTINUE_SPAN_NAME = "workflow.continue"
 _WORKFLOW_TRACE_NAME = "WorkflowRun"
-_WORKFLOW_TAGS = [_TRACE_APP, "workflow"]
+_WORKFLOW_TAGS = [TRACE_APP, "workflow"]
 _TRACER = trace.get_tracer("registry.workflows")
 _FAILED_STATUSES = frozenset({"cancelled", "failed"})
 _TRACE_ATTRIBUTE_KEYS = frozenset(
@@ -43,31 +42,10 @@ _registered_providers: WeakSet[TracerProvider] = WeakSet()
 _registration_lock = Lock()
 
 
-def _clean_span_attributes(attributes: Mapping[str, object]) -> dict[str, SpanAttributeValue]:
-    cleaned: dict[str, SpanAttributeValue] = {}
-    for key, value in attributes.items():
-        if (isinstance(value, (bool, int, float, str)) and value != "") or (
-            isinstance(value, list) and value and all(isinstance(item, str) and item != "" for item in value)
-        ):
-            cleaned[key] = value
-    return cleaned
-
-
-def _set_span_attributes(span: Span, attributes: Mapping[str, object]) -> None:
-    """Best-effort attribute assignment without exposing values in logs."""
-    try:
-        if not span.is_recording():
-            return
-        for key, value in _clean_span_attributes(attributes).items():
-            span.set_attribute(key, value)
-    except Exception as exc:
-        logger.warning("Failed to set trace attributes (%s)", type(exc).__name__)
-
-
 def _trace_attributes(attributes: Mapping[str, object]) -> dict[str, SpanAttributeValue]:
     return {
         key: value
-        for key, value in _clean_span_attributes(attributes).items()
+        for key, value in clean_span_attributes(attributes).items()
         if key in _TRACE_ATTRIBUTE_KEYS or key.startswith(_TRACE_METADATA_PREFIX)
     }
 
@@ -94,7 +72,7 @@ class LangfuseTraceAttributeSpanProcessor(SpanProcessor):
         context = parent_context or otel_context.get_current()
         attributes = otel_context.get_value(_TRACE_ATTRIBUTES_CONTEXT_KEY, context)
         if isinstance(attributes, dict):
-            _set_span_attributes(span, attributes)
+            set_span_attributes(span, attributes)
 
 
 def ensure_langfuse_trace_attribute_processor(tracer_provider: TracerProvider) -> None:
@@ -133,12 +111,12 @@ def _build_workflow_attributes(
             "workflowRunId": workflow_run_id,
         }
     )
-    return _clean_span_attributes(
+    return clean_span_attributes(
         {
             "langfuse.observation.type": "chain",
             "langfuse.trace.name": _WORKFLOW_TRACE_NAME,
             "langfuse.trace.tags": tags or _WORKFLOW_TAGS,
-            "langfuse.trace.metadata.app": _TRACE_APP,
+            "langfuse.trace.metadata.app": TRACE_APP,
             "langfuse.trace.metadata.operationType": operation_type,
             **{f"langfuse.trace.metadata.{key}": value for key, value in metadata.items()},
             "langfuse.user.id": user_id,
@@ -178,7 +156,7 @@ def _record_workflow_result(span: Span, result: object) -> bool:
         "node_run_count": len(node_runs) if isinstance(node_runs, list) else None,
     }
     _set_serialized_attribute(span, "langfuse.observation.output", output)
-    _set_span_attributes(
+    set_span_attributes(
         span,
         {
             "registry.operation.status": status,
@@ -215,7 +193,7 @@ async def _trace_workflow_call[ResultT](
                 success = _record_workflow_result(span, result)
                 return result
             finally:
-                _set_span_attributes(span, {"registry.operation.success": success})
+                set_span_attributes(span, {"registry.operation.success": success})
 
 
 def trace_workflow_run[ResultT](

--- a/registry-pkgs/src/registry_pkgs/telemetry/workflow_tracing.py
+++ b/registry-pkgs/src/registry_pkgs/telemetry/workflow_tracing.py
@@ -18,6 +18,8 @@ from opentelemetry.sdk.trace import Span as SDKSpan
 from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
 from opentelemetry.trace import Span, Status, StatusCode
 
+from registry_pkgs.types import UserContextDict
+
 from .span_attributes import TRACE_APP, SpanAttributeValue, clean_span_attributes, set_span_attributes
 
 logger = logging.getLogger(__name__)
@@ -84,7 +86,7 @@ def ensure_langfuse_trace_attribute_processor(tracer_provider: TracerProvider) -
         _registered_providers.add(tracer_provider)
 
 
-def _auth_metadata(auth_context: dict[str, Any] | None) -> tuple[object, dict[str, object]]:
+def _auth_metadata(auth_context: UserContextDict | None) -> tuple[object, dict[str, object]]:
     if auth_context is None:
         return None, {}
     return auth_context.get("user_id"), {
@@ -100,7 +102,7 @@ def _build_workflow_attributes(
     *,
     operation_type: str,
     workflow_run_id: str,
-    auth_context: dict[str, Any] | None,
+    auth_context: UserContextDict | None,
     workflow_definition_id: str | None = None,
     tags: list[str] | None = None,
 ) -> dict[str, object]:
@@ -207,7 +209,7 @@ def trace_workflow_run[ResultT](
         definition_id: str,
         user_text: str,
         *,
-        auth_context: dict[str, Any] | None,
+        auth_context: UserContextDict | None,
         existing_run_id: str,
         injected_outputs: dict[str, dict[str, Any]] | None = None,
         stop_after_node_id: str | None = None,
@@ -254,7 +256,7 @@ def trace_workflow_continuation[ResultT](
         runner: object,
         *,
         existing_run_id: str,
-        auth_context: dict[str, Any] | None,
+        auth_context: UserContextDict | None,
     ) -> ResultT:
         attributes = _build_workflow_attributes(
             operation_type="workflow_continue",

--- a/registry-pkgs/src/registry_pkgs/telemetry/workflow_tracing.py
+++ b/registry-pkgs/src/registry_pkgs/telemetry/workflow_tracing.py
@@ -1,0 +1,298 @@
+"""Langfuse root tracing for Registry workflow runs and continuations."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable, Iterator, Mapping
+from contextlib import contextmanager
+from functools import partial, wraps
+from threading import Lock
+from typing import Any
+from weakref import WeakSet
+
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import Span as SDKSpan
+from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
+from opentelemetry.trace import Span, Status, StatusCode
+
+logger = logging.getLogger(__name__)
+
+type SpanAttributeValue = bool | int | float | str | list[str]
+
+_TRACE_APP = "registry"
+_WORKFLOW_SPAN_NAME = "workflow.execute"
+_WORKFLOW_CONTINUE_SPAN_NAME = "workflow.continue"
+_WORKFLOW_TRACE_NAME = "WorkflowRun"
+_WORKFLOW_TAGS = [_TRACE_APP, "workflow"]
+_TRACER = trace.get_tracer("registry.workflows")
+_FAILED_STATUSES = frozenset({"cancelled", "failed"})
+_TRACE_ATTRIBUTE_KEYS = frozenset(
+    {
+        "langfuse.session.id",
+        "langfuse.trace.name",
+        "langfuse.trace.tags",
+        "langfuse.user.id",
+    }
+)
+_TRACE_METADATA_PREFIX = "langfuse.trace.metadata."
+_TRACE_ATTRIBUTES_CONTEXT_KEY = "registry.langfuse.trace_attributes"
+_registered_providers: WeakSet[TracerProvider] = WeakSet()
+_registration_lock = Lock()
+
+
+def _clean_span_attributes(attributes: Mapping[str, object]) -> dict[str, SpanAttributeValue]:
+    cleaned: dict[str, SpanAttributeValue] = {}
+    for key, value in attributes.items():
+        if (isinstance(value, (bool, int, float, str)) and value != "") or (
+            isinstance(value, list) and value and all(isinstance(item, str) and item != "" for item in value)
+        ):
+            cleaned[key] = value
+    return cleaned
+
+
+def _set_span_attributes(span: Span, attributes: Mapping[str, object]) -> None:
+    """Best-effort attribute assignment without exposing values in logs."""
+    try:
+        if not span.is_recording():
+            return
+        for key, value in _clean_span_attributes(attributes).items():
+            span.set_attribute(key, value)
+    except Exception as exc:
+        logger.warning("Failed to set trace attributes (%s)", type(exc).__name__)
+
+
+def _trace_attributes(attributes: Mapping[str, object]) -> dict[str, SpanAttributeValue]:
+    return {
+        key: value
+        for key, value in _clean_span_attributes(attributes).items()
+        if key in _TRACE_ATTRIBUTE_KEYS or key.startswith(_TRACE_METADATA_PREFIX)
+    }
+
+
+@contextmanager
+def _propagate_langfuse_trace_attributes(attributes: Mapping[str, object]) -> Iterator[None]:
+    """Apply trace-level attributes to every in-process span created in this context."""
+    current_context = otel_context.get_current()
+    current_attributes = otel_context.get_value(_TRACE_ATTRIBUTES_CONTEXT_KEY, current_context)
+    inherited_attributes = current_attributes if isinstance(current_attributes, dict) else {}
+    propagated = {**inherited_attributes, **_trace_attributes(attributes)}
+    context = otel_context.set_value(_TRACE_ATTRIBUTES_CONTEXT_KEY, propagated, current_context)
+    token = otel_context.attach(context)
+    try:
+        yield
+    finally:
+        otel_context.detach(token)
+
+
+class LangfuseTraceAttributeSpanProcessor(SpanProcessor):
+    """Copy active Workflow trace attributes onto newly-created child spans."""
+
+    def on_start(self, span: SDKSpan, parent_context: Context | None = None) -> None:
+        context = parent_context or otel_context.get_current()
+        attributes = otel_context.get_value(_TRACE_ATTRIBUTES_CONTEXT_KEY, context)
+        if isinstance(attributes, dict):
+            _set_span_attributes(span, attributes)
+
+
+def ensure_langfuse_trace_attribute_processor(tracer_provider: TracerProvider) -> None:
+    """Register the Workflow attribute propagation processor once per provider."""
+    with _registration_lock:
+        if tracer_provider in _registered_providers:
+            return
+        tracer_provider.add_span_processor(LangfuseTraceAttributeSpanProcessor())
+        _registered_providers.add(tracer_provider)
+
+
+def _auth_metadata(auth_context: dict[str, Any] | None) -> tuple[object, dict[str, object]]:
+    if auth_context is None:
+        return None, {}
+    return auth_context.get("user_id"), {
+        "username": auth_context.get("username"),
+        "oauthClientId": auth_context.get("client_id"),
+        "authMethod": auth_context.get("auth_method"),
+        "authProvider": auth_context.get("provider"),
+        "authSource": auth_context.get("auth_source"),
+    }
+
+
+def _build_workflow_attributes(
+    *,
+    operation_type: str,
+    workflow_run_id: str,
+    auth_context: dict[str, Any] | None,
+    workflow_definition_id: str | None = None,
+    tags: list[str] | None = None,
+) -> dict[str, object]:
+    user_id, metadata = _auth_metadata(auth_context)
+    metadata.update(
+        {
+            "workflowDefinitionId": workflow_definition_id,
+            "workflowRunId": workflow_run_id,
+        }
+    )
+    return _clean_span_attributes(
+        {
+            "langfuse.observation.type": "chain",
+            "langfuse.trace.name": _WORKFLOW_TRACE_NAME,
+            "langfuse.trace.tags": tags or _WORKFLOW_TAGS,
+            "langfuse.trace.metadata.app": _TRACE_APP,
+            "langfuse.trace.metadata.operationType": operation_type,
+            **{f"langfuse.trace.metadata.{key}": value for key, value in metadata.items()},
+            "langfuse.user.id": user_id,
+            "langfuse.session.id": workflow_run_id,
+            "registry.operation.type": operation_type,
+            "registry.caller.authenticated": bool(user_id),
+            "workflow.definition.id": workflow_definition_id,
+            "workflow.run.id": workflow_run_id,
+        }
+    )
+
+
+def _set_serialized_attribute(span: Span, key: str, value: object) -> None:
+    try:
+        if span.is_recording():
+            span.set_attribute(key, json.dumps(value, ensure_ascii=False, separators=(",", ":"), default=str))
+    except Exception as exc:
+        logger.warning("Failed to serialize or set workflow trace attribute %s (%s)", key, type(exc).__name__)
+
+
+def _status_value(run: object) -> str | None:
+    status = getattr(run, "status", None)
+    value = getattr(status, "value", status)
+    return str(value).lower() if value is not None else None
+
+
+def _record_workflow_result(span: Span, result: object) -> bool:
+    if not isinstance(result, tuple) or len(result) != 2:
+        return True
+
+    run, node_runs = result
+    status = _status_value(run)
+    output = {
+        "workflow_run_id": str(getattr(run, "id", "")),
+        "status": status,
+        "output": getattr(run, "final_output", None),
+        "node_run_count": len(node_runs) if isinstance(node_runs, list) else None,
+    }
+    _set_serialized_attribute(span, "langfuse.observation.output", output)
+    _set_span_attributes(
+        span,
+        {
+            "registry.operation.status": status,
+            "workflow.node_run.count": output["node_run_count"],
+        },
+    )
+    success = status not in _FAILED_STATUSES
+    if not success:
+        error_summary = getattr(run, "error_summary", None)
+        try:
+            span.set_status(Status(StatusCode.ERROR, str(error_summary or f"Workflow {status}")))
+        except Exception:
+            pass
+    return success
+
+
+async def _trace_workflow_call[ResultT](
+    *,
+    span_name: str,
+    attributes: dict[str, object],
+    trace_input: dict[str, object],
+    call: Callable[[], Awaitable[ResultT]],
+) -> ResultT:
+    with _propagate_langfuse_trace_attributes(attributes):
+        with _TRACER.start_as_current_span(span_name, attributes=attributes) as span:
+            _set_serialized_attribute(span, "langfuse.observation.input", trace_input)
+            success = False
+            try:
+                result = await call()
+                success = _record_workflow_result(span, result)
+                return result
+            finally:
+                _set_span_attributes(span, {"registry.operation.success": success})
+
+
+def trace_workflow_run[ResultT](
+    func: Callable[..., Awaitable[ResultT]],
+) -> Callable[..., Awaitable[ResultT]]:
+    """Trace an initial or retried ``WorkflowRunner.run`` operation."""
+
+    @wraps(func)
+    async def wrapper(
+        runner: object,
+        definition_id: str,
+        user_text: str,
+        *,
+        auth_context: dict[str, Any] | None,
+        existing_run_id: str,
+        injected_outputs: dict[str, dict[str, Any]] | None = None,
+        stop_after_node_id: str | None = None,
+        definition_snapshot: dict[str, Any] | None = None,
+    ) -> ResultT:
+        attributes = _build_workflow_attributes(
+            operation_type="workflow_execution",
+            workflow_definition_id=definition_id,
+            workflow_run_id=existing_run_id,
+            auth_context=auth_context,
+        )
+        trace_input = {
+            "workflow_definition_id": definition_id,
+            "workflow_run_id": existing_run_id,
+            "input": user_text,
+        }
+        return await _trace_workflow_call(
+            span_name=_WORKFLOW_SPAN_NAME,
+            attributes=attributes,
+            trace_input=trace_input,
+            call=partial(
+                func,
+                runner,
+                definition_id,
+                user_text,
+                auth_context=auth_context,
+                existing_run_id=existing_run_id,
+                injected_outputs=injected_outputs,
+                stop_after_node_id=stop_after_node_id,
+                definition_snapshot=definition_snapshot,
+            ),
+        )
+
+    return wrapper
+
+
+def trace_workflow_continuation[ResultT](
+    func: Callable[..., Awaitable[ResultT]],
+) -> Callable[..., Awaitable[ResultT]]:
+    """Trace one HITL continuation and group it with the original workflow run."""
+
+    @wraps(func)
+    async def wrapper(
+        runner: object,
+        *,
+        existing_run_id: str,
+        auth_context: dict[str, Any] | None,
+    ) -> ResultT:
+        attributes = _build_workflow_attributes(
+            operation_type="workflow_continue",
+            workflow_run_id=existing_run_id,
+            auth_context=auth_context,
+            tags=[*_WORKFLOW_TAGS, "continue"],
+        )
+        return await _trace_workflow_call(
+            span_name=_WORKFLOW_CONTINUE_SPAN_NAME,
+            attributes=attributes,
+            trace_input={
+                "workflow_run_id": existing_run_id,
+                "action": "continue",
+            },
+            call=partial(
+                func,
+                runner,
+                existing_run_id=existing_run_id,
+                auth_context=auth_context,
+            ),
+        )
+
+    return wrapper

--- a/registry-pkgs/src/registry_pkgs/telemetry/workflow_tracing.py
+++ b/registry-pkgs/src/registry_pkgs/telemetry/workflow_tracing.py
@@ -190,8 +190,12 @@ def _record_workflow_result(span: Span, result: object) -> bool:
         error_summary = getattr(run, "error_summary", None)
         try:
             span.set_status(Status(StatusCode.ERROR, str(error_summary or f"Workflow {status}")))
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(
+                "Failed to set workflow span status (%s) for status=%s",
+                type(exc).__name__,
+                status,
+            )
     return success
 
 

--- a/registry-pkgs/src/registry_pkgs/types.py
+++ b/registry-pkgs/src/registry_pkgs/types.py
@@ -1,0 +1,41 @@
+"""Shared, framework-agnostic types used across ``registry``, ``auth-server``, and ``registry_pkgs``."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class UserContextDict(TypedDict):
+    """
+    UserContextDict is the type of the dictionary set as the Request.state.user attribute for each incoming request
+    **to a non-public route** by the UnifiedAuthMiddlware.
+    If a FastAPI path operation function needs to access this UserContextDict information, it can retrieve this dictionary
+    by asking for the `user_context: CurrentUser` dependency injection (``registry.auth.dependencies.CurrentUser``).
+    If an MCP tool/resource/prompt handler function needs it, it can retrieve this dictionary by asking for the
+    `ctx: Context` dependency injection (`mcp.server.fastmcp.Context`) and then accessing
+    `ctx.request_context.request.state.user`.
+    """
+
+    # From the "user_id" field of the JWT claim.
+    user_id: str | None
+
+    # From the "client_id" claim of the JWT.
+    client_id: str
+
+    # From the "sub" field of the JWT claim.
+    username: str | None
+
+    # From the "groups" field of the JWT claim.
+    groups: list[str]
+
+    # Converted from the "scope" field of the JWT claim, or mapped from the "groups" field if "scope" doesn't exist.
+    scopes: list[str]
+
+    # "jwt" if the JWT token comes from the Authorization header. "traditional" if from browser cookie.
+    auth_method: str
+
+    # "jwt" if the JWT token comes from the Authorization header. "local" if from browser cookie.
+    provider: str
+
+    # "jwt_auth" if the JWT token comes from the Authorization header. "jwt_session_auth" if from browser cookie.
+    auth_source: str

--- a/registry-pkgs/src/registry_pkgs/workflows/executor_resolver.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/executor_resolver.py
@@ -26,6 +26,7 @@ from registry_pkgs.models.a2a_agent import A2AAgent
 from registry_pkgs.models.extended_mcp_server import ExtendedMCPServer
 from registry_pkgs.models.workflow import WorkflowNode
 from registry_pkgs.telemetry.workflow_metrics import record_agent_invocation
+from registry_pkgs.types import UserContextDict
 from registry_pkgs.workflows.a2a_client import HeadersProvider
 from registry_pkgs.workflows.a2a_executor import make_a2a_executor, make_a2a_pool_executor
 from registry_pkgs.workflows.mcp_executor import McpHeadersProvider, make_mcp_executor
@@ -127,7 +128,7 @@ async def build_executor_registry(
     executor_keys: list[str],
     *,
     llm: Model,
-    auth_context: dict[str, Any] | None,
+    auth_context: UserContextDict | None,
     jwt_config: JwtSigningConfig,
     pool_nodes: list[WorkflowNode] | None = None,
     selector_llm: Model | None = None,
@@ -196,7 +197,7 @@ async def _resolve_executor(
     key: str,
     *,
     llm: Model,
-    auth_context: dict[str, Any] | None,
+    auth_context: UserContextDict | None,
     jwt_config: JwtSigningConfig,
     a2a_httpx_client: httpx.AsyncClient | None = None,
     headers_provider: HeadersProvider | None = None,

--- a/registry-pkgs/src/registry_pkgs/workflows/mcp_executor.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/mcp_executor.py
@@ -16,12 +16,13 @@ from registry_pkgs.core.config import JwtSigningConfig
 from registry_pkgs.models.enums import AgentCoreRuntimeAccessMode
 from registry_pkgs.models.extended_mcp_server import ExtendedMCPServer
 from registry_pkgs.telemetry.workflow_metrics import record_tool_calls
+from registry_pkgs.types import UserContextDict
 from registry_pkgs.workflows.helpers import build_prompt
 from registry_pkgs.workflows.types import WorkflowConfigError
 
 logger = logging.getLogger(__name__)
 
-McpHeadersProvider = Callable[[ExtendedMCPServer, dict[str, Any] | None], Awaitable[dict[str, str]]]
+McpHeadersProvider = Callable[[ExtendedMCPServer, UserContextDict | None], Awaitable[dict[str, str]]]
 
 
 def _get_target_url(server: ExtendedMCPServer) -> str:
@@ -81,7 +82,7 @@ def make_mcp_executor(
     mcp_server: ExtendedMCPServer,
     *,
     llm: Model,
-    auth_context: dict[str, Any] | None,
+    auth_context: UserContextDict | None,
     jwt_config: JwtSigningConfig,
     redis_client: Any | None,
     redis_key_prefix: str,

--- a/registry-pkgs/src/registry_pkgs/workflows/runner.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/runner.py
@@ -65,6 +65,7 @@ from registry_pkgs.models.workflow import (
     WorkflowRun,
 )
 from registry_pkgs.telemetry.workflow_metrics import record_workflow_run
+from registry_pkgs.telemetry.workflow_tracing import trace_workflow_continuation, trace_workflow_run
 from registry_pkgs.workflows.a2a_client import HeadersProvider
 from registry_pkgs.workflows.compiler import StepExecutor, compile_workflow, flatten_workflow_nodes
 from registry_pkgs.workflows.control import DirectiveQueue, WorkflowCancelledError
@@ -159,6 +160,7 @@ class WorkflowRunner:
         self._redis_key_prefix = redis_key_prefix
         self._mcp_headers_provider = mcp_headers_provider
 
+    @trace_workflow_run
     async def run(
         self,
         definition_id: str,
@@ -315,6 +317,7 @@ class WorkflowRunner:
             mcp_headers_provider=self._mcp_headers_provider,
         )
 
+    @trace_workflow_continuation
     async def continue_run(
         self,
         *,

--- a/registry-pkgs/src/registry_pkgs/workflows/runner.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/runner.py
@@ -66,6 +66,7 @@ from registry_pkgs.models.workflow import (
 )
 from registry_pkgs.telemetry.workflow_metrics import record_workflow_run
 from registry_pkgs.telemetry.workflow_tracing import trace_workflow_continuation, trace_workflow_run
+from registry_pkgs.types import UserContextDict
 from registry_pkgs.workflows.a2a_client import HeadersProvider
 from registry_pkgs.workflows.compiler import StepExecutor, compile_workflow, flatten_workflow_nodes
 from registry_pkgs.workflows.control import DirectiveQueue, WorkflowCancelledError
@@ -166,7 +167,7 @@ class WorkflowRunner:
         definition_id: str,
         user_text: str,
         *,
-        auth_context: dict[str, Any] | None,
+        auth_context: UserContextDict | None,
         existing_run_id: str,
         injected_outputs: dict[str, dict[str, Any]] | None = None,
         stop_after_node_id: str | None = None,
@@ -280,7 +281,7 @@ class WorkflowRunner:
     async def _build_registry(
         self,
         definition: WorkflowDefinition,
-        auth_context: dict[str, Any] | None,
+        auth_context: UserContextDict | None,
     ) -> dict[str, StepExecutor]:
         """Extract executor keys + pool nodes from the definition and resolve them.
 
@@ -322,7 +323,7 @@ class WorkflowRunner:
         self,
         *,
         existing_run_id: str,
-        auth_context: dict[str, Any] | None,
+        auth_context: UserContextDict | None,
     ) -> tuple[WorkflowRun, list[NodeRun]]:
         """Resume a run that is holding at one or more pending requirements.
 

--- a/registry-pkgs/tests/unit/telemetry/test_telemetry_setup.py
+++ b/registry-pkgs/tests/unit/telemetry/test_telemetry_setup.py
@@ -307,6 +307,7 @@ class TestSetupTracing:
         with (
             patch("opentelemetry.trace.get_tracer_provider", return_value=MagicMock()),
             patch("opentelemetry.trace.set_tracer_provider") as mock_set,
+            patch("registry_pkgs.telemetry.ensure_langfuse_trace_attribute_processor") as mock_ensure_processor,
             patch(
                 "registry_pkgs.telemetry._load_agno_instrumentation",
                 return_value=(mock_instrumentor_type, mock_trace_config_type),
@@ -319,6 +320,7 @@ class TestSetupTracing:
             mock_set.assert_called_once()
             tp_arg = mock_set.call_args[0][0]
             assert isinstance(tp_arg, TracerProvider)
+            mock_ensure_processor.assert_called_once_with(tp_arg)
             mock_instrumentor_type.return_value.instrument.assert_called_once()
             _, instrument_kwargs = mock_instrumentor_type.return_value.instrument.call_args
             assert instrument_kwargs["tracer_provider"] is tp_arg

--- a/registry-pkgs/tests/unit/telemetry/test_workflow_tracing.py
+++ b/registry-pkgs/tests/unit/telemetry/test_workflow_tracing.py
@@ -165,7 +165,7 @@ async def test_workflow_run_trace_matches_execution_format_and_propagates_to_chi
 @pytest.mark.unit
 @pytest.mark.telemetry
 @pytest.mark.asyncio
-async def test_workflow_run_trace_status_failure_does_not_change_result() -> None:
+async def test_workflow_run_trace_status_failure_does_not_change_result(caplog: pytest.LogCaptureFixture) -> None:
     result = (
         SimpleNamespace(id="run-1", status=WorkflowRunStatus.FAILED, error_summary="model failed"),
         [],
@@ -186,6 +186,7 @@ async def test_workflow_run_trace_status_failure_does_not_change_result() -> Non
     assert returned is result
     span.set_attribute.assert_any_call("registry.operation.success", False)
     span.set_status.assert_called_once()
+    assert "Failed to set workflow span status (RuntimeError) for status=failed" in caplog.text
 
 
 @pytest.mark.unit

--- a/registry-pkgs/tests/unit/telemetry/test_workflow_tracing.py
+++ b/registry-pkgs/tests/unit/telemetry/test_workflow_tracing.py
@@ -1,0 +1,343 @@
+"""Unit tests for Workflow tracing and process-local attribute propagation."""
+
+import json
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from agno.workflow import Step, StepInput, StepOutput, Workflow
+from openinference.instrumentation import TraceConfig
+from openinference.instrumentation.agno import AgnoInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from registry_pkgs.models.enums import WorkflowRunStatus
+from registry_pkgs.telemetry.workflow_tracing import (
+    LangfuseTraceAttributeSpanProcessor,
+    _propagate_langfuse_trace_attributes,
+    ensure_langfuse_trace_attribute_processor,
+    trace_workflow_continuation,
+    trace_workflow_run,
+)
+
+
+def _auth_context() -> dict[str, object]:
+    return {
+        "user_id": "user-1",
+        "username": "kelvin",
+        "client_id": "workflow-client",
+        "auth_method": "jwt",
+        "provider": "keycloak",
+        "auth_source": "jwt_auth",
+    }
+
+
+def _attribute_json(span: MagicMock, key: str) -> dict[str, object]:
+    call = next(call for call in span.set_attribute.call_args_list if call.args[0] == key)
+    return json.loads(call.args[1])
+
+
+@pytest.mark.unit
+@pytest.mark.telemetry
+def test_processor_propagates_only_trace_level_attributes_within_context() -> None:
+    processor = LangfuseTraceAttributeSpanProcessor()
+    child_span = MagicMock()
+    child_span.is_recording.return_value = True
+    attributes = {
+        "langfuse.observation.type": "chain",
+        "langfuse.trace.name": "WorkflowRun",
+        "langfuse.trace.tags": ["registry", "workflow"],
+        "langfuse.trace.metadata.workflowRunId": "run-1",
+        "langfuse.user.id": "user-1",
+        "registry.operation.type": "workflow_execution",
+    }
+
+    with _propagate_langfuse_trace_attributes(attributes):
+        processor.on_start(child_span)
+
+    child_span.set_attribute.assert_any_call("langfuse.trace.name", "WorkflowRun")
+    child_span.set_attribute.assert_any_call("langfuse.trace.tags", ["registry", "workflow"])
+    child_span.set_attribute.assert_any_call("langfuse.trace.metadata.workflowRunId", "run-1")
+    child_span.set_attribute.assert_any_call("langfuse.user.id", "user-1")
+    propagated_keys = {call.args[0] for call in child_span.set_attribute.call_args_list}
+    assert "langfuse.observation.type" not in propagated_keys
+    assert "registry.operation.type" not in propagated_keys
+
+    span_after_context = MagicMock()
+    span_after_context.is_recording.return_value = True
+    processor.on_start(span_after_context)
+    span_after_context.set_attribute.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.telemetry
+def test_processor_registration_is_idempotent_per_provider() -> None:
+    provider = MagicMock()
+
+    ensure_langfuse_trace_attribute_processor(provider)
+    ensure_langfuse_trace_attribute_processor(provider)
+
+    provider.add_span_processor.assert_called_once()
+    processor = provider.add_span_processor.call_args.args[0]
+    assert isinstance(processor, LangfuseTraceAttributeSpanProcessor)
+
+
+@pytest.mark.unit
+@pytest.mark.telemetry
+@pytest.mark.asyncio
+async def test_workflow_run_trace_matches_execution_format_and_propagates_to_children() -> None:
+    child_span = MagicMock()
+    child_span.is_recording.return_value = True
+
+    @trace_workflow_run
+    async def run(
+        runner,
+        definition_id,
+        user_text,
+        *,
+        auth_context,
+        existing_run_id,
+        injected_outputs=None,
+        stop_after_node_id=None,
+        definition_snapshot=None,
+    ):
+        del runner, definition_id, user_text, auth_context, injected_outputs, stop_after_node_id, definition_snapshot
+        LangfuseTraceAttributeSpanProcessor().on_start(child_span)
+        return (
+            SimpleNamespace(
+                id=existing_run_id,
+                status=WorkflowRunStatus.COMPLETED,
+                final_output={"content": "report ready"},
+                error_summary=None,
+            ),
+            [SimpleNamespace(), SimpleNamespace()],
+        )
+
+    span = MagicMock()
+    span.is_recording.return_value = True
+    with patch("registry_pkgs.telemetry.workflow_tracing._TRACER") as tracer:
+        tracer.start_as_current_span.return_value = nullcontext(span)
+        result = await run(
+            object(),
+            "definition-1",
+            "prepare a report",
+            auth_context=_auth_context(),
+            existing_run_id="run-1",
+        )
+
+    assert result[0].status == WorkflowRunStatus.COMPLETED
+    (span_name,) = tracer.start_as_current_span.call_args.args
+    attributes = tracer.start_as_current_span.call_args.kwargs["attributes"]
+    assert span_name == "workflow.execute"
+    assert attributes["langfuse.observation.type"] == "chain"
+    assert attributes["langfuse.trace.name"] == "WorkflowRun"
+    assert attributes["langfuse.trace.tags"] == ["registry", "workflow"]
+    assert attributes["langfuse.trace.metadata.app"] == "registry"
+    assert attributes["langfuse.trace.metadata.operationType"] == "workflow_execution"
+    assert attributes["langfuse.trace.metadata.workflowDefinitionId"] == "definition-1"
+    assert attributes["langfuse.trace.metadata.workflowRunId"] == "run-1"
+    assert attributes["langfuse.trace.metadata.username"] == "kelvin"
+    assert attributes["langfuse.trace.metadata.oauthClientId"] == "workflow-client"
+    assert attributes["langfuse.user.id"] == "user-1"
+    assert attributes["langfuse.session.id"] == "run-1"
+    assert attributes["registry.operation.type"] == "workflow_execution"
+    assert attributes["registry.caller.authenticated"] is True
+    assert _attribute_json(span, "langfuse.observation.input") == {
+        "workflow_definition_id": "definition-1",
+        "workflow_run_id": "run-1",
+        "input": "prepare a report",
+    }
+    assert _attribute_json(span, "langfuse.observation.output") == {
+        "workflow_run_id": "run-1",
+        "status": "completed",
+        "output": {"content": "report ready"},
+        "node_run_count": 2,
+    }
+    span.set_attribute.assert_any_call("registry.operation.success", True)
+    child_span.set_attribute.assert_any_call("langfuse.trace.name", "WorkflowRun")
+    child_span.set_attribute.assert_any_call("langfuse.trace.tags", ["registry", "workflow"])
+    child_span.set_attribute.assert_any_call("langfuse.trace.metadata.workflowRunId", "run-1")
+    child_span.set_attribute.assert_any_call("langfuse.user.id", "user-1")
+
+
+@pytest.mark.unit
+@pytest.mark.telemetry
+@pytest.mark.asyncio
+async def test_workflow_run_trace_status_failure_does_not_change_result() -> None:
+    result = (
+        SimpleNamespace(id="run-1", status=WorkflowRunStatus.FAILED, error_summary="model failed"),
+        [],
+    )
+
+    @trace_workflow_run
+    async def run(runner, definition_id, user_text, **kwargs):
+        del runner, definition_id, user_text, kwargs
+        return result
+
+    span = MagicMock()
+    span.is_recording.return_value = True
+    span.set_status.side_effect = RuntimeError("status rejected")
+    with patch("registry_pkgs.telemetry.workflow_tracing._TRACER") as tracer:
+        tracer.start_as_current_span.return_value = nullcontext(span)
+        returned = await run(object(), "definition-1", "hello", auth_context=None, existing_run_id="run-1")
+
+    assert returned is result
+    span.set_attribute.assert_any_call("registry.operation.success", False)
+    span.set_status.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.telemetry
+@pytest.mark.asyncio
+async def test_workflow_run_trace_preserves_execution_error() -> None:
+    error = RuntimeError("workflow unavailable")
+
+    @trace_workflow_run
+    async def run(runner, definition_id, user_text, **kwargs):
+        del runner, definition_id, user_text, kwargs
+        raise error
+
+    span = MagicMock()
+    span.is_recording.return_value = True
+    with patch("registry_pkgs.telemetry.workflow_tracing._TRACER") as tracer:
+        tracer.start_as_current_span.return_value = nullcontext(span)
+        with pytest.raises(RuntimeError) as exc_info:
+            await run(object(), "definition-1", "hello", auth_context=None, existing_run_id="run-1")
+
+    assert exc_info.value is error
+    span.set_attribute.assert_any_call("registry.operation.success", False)
+
+    span_after_error = MagicMock()
+    span_after_error.is_recording.return_value = True
+    LangfuseTraceAttributeSpanProcessor().on_start(span_after_error)
+    span_after_error.set_attribute.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.telemetry
+@pytest.mark.asyncio
+async def test_workflow_trace_attribute_failure_does_not_change_result() -> None:
+    result = (
+        SimpleNamespace(id="run-1", status=WorkflowRunStatus.COMPLETED, error_summary=None),
+        [],
+    )
+
+    @trace_workflow_run
+    async def run(runner, definition_id, user_text, **kwargs):
+        del runner, definition_id, user_text, kwargs
+        return result
+
+    span = MagicMock()
+    span.is_recording.return_value = True
+    span.set_attribute.side_effect = RuntimeError("attribute rejected")
+    with patch("registry_pkgs.telemetry.workflow_tracing._TRACER") as tracer:
+        tracer.start_as_current_span.return_value = nullcontext(span)
+        returned = await run(object(), "definition-1", "hello", auth_context=None, existing_run_id="run-1")
+
+    assert returned is result
+
+
+@pytest.mark.unit
+@pytest.mark.telemetry
+@pytest.mark.asyncio
+async def test_workflow_continuation_trace_uses_same_session_with_continue_tag() -> None:
+    @trace_workflow_continuation
+    async def continue_run(runner, *, existing_run_id, auth_context):
+        del runner, auth_context
+        return (
+            SimpleNamespace(
+                id=existing_run_id,
+                status=WorkflowRunStatus.COMPLETED,
+                final_output={"content": "continued"},
+                error_summary=None,
+            ),
+            [],
+        )
+
+    span = MagicMock()
+    span.is_recording.return_value = True
+    with patch("registry_pkgs.telemetry.workflow_tracing._TRACER") as tracer:
+        tracer.start_as_current_span.return_value = nullcontext(span)
+        await continue_run(object(), existing_run_id="run-1", auth_context=_auth_context())
+
+    attributes = tracer.start_as_current_span.call_args.kwargs["attributes"]
+    assert attributes["langfuse.trace.name"] == "WorkflowRun"
+    assert attributes["langfuse.trace.tags"] == ["registry", "workflow", "continue"]
+    assert attributes["langfuse.session.id"] == "run-1"
+    assert attributes["langfuse.trace.metadata.operationType"] == "workflow_continue"
+    assert _attribute_json(span, "langfuse.observation.input") == {
+        "workflow_run_id": "run-1",
+        "action": "continue",
+    }
+    assert _attribute_json(span, "langfuse.observation.output") == {
+        "workflow_run_id": "run-1",
+        "status": "completed",
+        "output": {"content": "continued"},
+        "node_run_count": 0,
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.telemetry
+@pytest.mark.asyncio
+async def test_real_agno_workflow_spans_are_nested_and_receive_langfuse_attributes() -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    ensure_langfuse_trace_attribute_processor(provider)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    instrumentor = AgnoInstrumentor()
+    if instrumentor.is_instrumented_by_opentelemetry:
+        instrumentor.uninstrument()
+    instrumentor.instrument(
+        tracer_provider=provider,
+        config=TraceConfig(
+            hide_inputs=False,
+            hide_outputs=False,
+            hide_llm_tools=True,
+            hide_llm_invocation_parameters=True,
+        ),
+    )
+
+    async def executor(step_input: StepInput, session_state: dict | None = None) -> StepOutput:
+        del step_input, session_state
+        return StepOutput(content="done", success=True)
+
+    @trace_workflow_run
+    async def run(runner, definition_id, user_text, **kwargs):
+        del runner, definition_id, user_text, kwargs
+        workflow = Workflow(name="trace-test-workflow", steps=[Step(name="trace-step", executor=executor)])
+        await workflow.arun(input="hidden input", session_id="run-1")
+        return (
+            SimpleNamespace(id="run-1", status=WorkflowRunStatus.COMPLETED, error_summary=None),
+            [SimpleNamespace()],
+        )
+
+    try:
+        with patch("registry_pkgs.telemetry.workflow_tracing._TRACER", provider.get_tracer("registry.workflows")):
+            await run(object(), "definition-1", "hidden input", auth_context=_auth_context(), existing_run_id="run-1")
+        provider.force_flush()
+        spans = exporter.get_finished_spans()
+
+        root_span = next(span for span in spans if span.name == "workflow.execute")
+        agno_workflow_span = next(span for span in spans if span.name == "trace_test_workflow.arun")
+        assert agno_workflow_span.parent is not None
+        assert agno_workflow_span.parent.span_id == root_span.context.span_id
+        step_span = next(span for span in spans if span.name.startswith("trace_step"))
+        assert "input.value" in agno_workflow_span.attributes
+        assert "output.value" in agno_workflow_span.attributes
+        assert "input.value" in step_span.attributes
+        assert "output.value" in step_span.attributes
+        assert "hidden input" in str(agno_workflow_span.attributes["input.value"])
+        assert "done" in str(agno_workflow_span.attributes["output.value"])
+        assert "hidden input" in str(step_span.attributes["input.value"])
+        assert "done" in str(step_span.attributes["output.value"])
+        for span in spans:
+            assert span.attributes["langfuse.trace.name"] == "WorkflowRun"
+            assert span.attributes["langfuse.trace.tags"] == ("registry", "workflow")
+            assert span.attributes["langfuse.trace.metadata.workflowRunId"] == "run-1"
+            assert span.attributes["langfuse.user.id"] == "user-1"
+    finally:
+        instrumentor.uninstrument()
+        provider.shutdown()

--- a/registry/src/registry/auth/dependencies.py
+++ b/registry/src/registry/auth/dependencies.py
@@ -1,48 +1,18 @@
 import logging
-from typing import Annotated, TypedDict
+from typing import Annotated
 
 from fastapi import Depends, HTTPException, Request, status
 from itsdangerous import URLSafeTimedSerializer
+
+from registry_pkgs.types import UserContextDict
 
 from ..core.config import settings
 
 logger = logging.getLogger(__name__)
 
-
-class UserContextDict(TypedDict):
-    """
-    UserContextDict is the type of the dictionary set as the Request.state.user attribute for each incoming request
-    **to a non-public route** by the UnifiedAuthMiddlware.
-    If a FastAPI path operation function needs to access this UserContextDict information, it can retrieve this dictionary
-    by asking for the `user_context: CurrentUser` dependency injection.
-    If an MCP tool/resource/prompt handler function needs it, it can retrieve this dictionary by asking for the
-    `ctx: Context` dependency injection (`mcp.server.fastmcp.Context`) and then accessing
-    `ctx.request_context.request.state.user`.
-    """
-
-    # From the "user_id" field of the JWT claim.
-    user_id: str | None
-
-    # From the "client_id" claim of the JWT.
-    client_id: str
-
-    # From the "sub" field of the JWT claim.
-    username: str | None
-
-    # From the "groups" field of the JWT claim.
-    groups: list[str]
-
-    # Converted from the "scope" field of the JWT claim, or mapped from the "groups" field if "scope" doesn't exist.
-    scopes: list[str]
-
-    # "jwt" if the JWT token comes from the Authorization header. "traditional" if from browser cookie.
-    auth_method: str
-
-    # "jwt" if the JWT token comes from the Authorization header. "local" if from browser cookie.
-    provider: str
-
-    # "jwt_auth" if the JWT token comes from the Authorization header. "jwt_session_auth" if from browser cookie.
-    auth_source: str
+# UserContextDict is re-exported here (defined in registry_pkgs.types) so existing
+# `from registry.auth.dependencies import UserContextDict` call sites keep working, and so
+# registry_pkgs code — which cannot import from registry — can use the same type.
 
 
 def get_current_user(request: Request) -> UserContextDict:

--- a/registry/src/registry/mcpgw/tracing.py
+++ b/registry/src/registry/mcpgw/tracing.py
@@ -27,6 +27,8 @@ from opentelemetry import trace
 from opentelemetry.trace import Span, Status, StatusCode
 from pydantic import AnyUrl, BaseModel
 
+from registry_pkgs.telemetry.span_attributes import TRACE_APP, clean_span_attributes, set_span_attributes
+
 from .core.types import McpAppContext
 
 logger = logging.getLogger(__name__)
@@ -41,7 +43,6 @@ _DISCOVERY_OPERATIONS = {
     "mcp": ("mcp.discovery", "McpDiscovery", "discover_servers", "mcp"),
     "a2a": ("a2a.discovery", "AgentDiscovery", "discover_agents", "agent"),
 }
-_TRACE_APP = "registry"
 _TRACER = trace.get_tracer("registry.mcpgw")
 _RAW_PYTHON_BYTES_OMITTED = "[RAW PYTHON BYTES OMITTED]"
 _TRACE_MODEL_FIELDS: dict[type[BaseModel], tuple[str, ...]] = {
@@ -128,26 +129,6 @@ def _serialize_trace_value(value: Any) -> str:
     return json.dumps(serialized, ensure_ascii=False, separators=(",", ":"))
 
 
-def _clean_attributes(attributes: dict[str, Any]) -> dict[str, bool | int | float | str | list[str]]:
-    cleaned: dict[str, bool | int | float | str | list[str]] = {}
-    for key, value in attributes.items():
-        if (isinstance(value, (bool, int, float, str)) and value != "") or (
-            isinstance(value, list) and value and all(isinstance(item, str) and item != "" for item in value)
-        ):
-            cleaned[key] = value
-    return cleaned
-
-
-def _set_span_attributes(span: Span, attributes: dict[str, Any]) -> None:
-    try:
-        if not span.is_recording():
-            return
-        for key, value in _clean_attributes(attributes).items():
-            span.set_attribute(key, value)
-    except Exception as exc:
-        logger.warning("Failed to set trace attributes (%s)", type(exc).__name__)
-
-
 def _extract_caller_identity(ctx: Context[ServerSession, McpAppContext]) -> dict[str, Any]:
     try:
         request_context = getattr(ctx, "request_context", None)
@@ -177,7 +158,7 @@ def _extract_caller_identity(ctx: Context[ServerSession, McpAppContext]) -> dict
             identity["mcp_client_name"] = getattr(client_info, "name", None)
             identity["mcp_client_version"] = getattr(client_info, "version", None)
 
-        return _clean_attributes(identity)
+        return clean_span_attributes(identity)
     except Exception:
         logger.warning("Failed to extract caller identity for tracing", exc_info=True)
         return {}
@@ -185,7 +166,7 @@ def _extract_caller_identity(ctx: Context[ServerSession, McpAppContext]) -> dict
 
 def _caller_attributes(ctx: Context[ServerSession, McpAppContext]) -> dict[str, Any]:
     identity = _extract_caller_identity(ctx)
-    return _clean_attributes(
+    return clean_span_attributes(
         {
             "langfuse.user.id": identity.get("user_id"),
             "langfuse.trace.metadata.username": identity.get("username"),
@@ -214,14 +195,14 @@ def _build_trace_attributes(
         "langfuse.observation.type": observation_type,
         "langfuse.trace.name": trace_name,
         "langfuse.trace.tags": tags,
-        "langfuse.trace.metadata.app": _TRACE_APP,
+        "langfuse.trace.metadata.app": TRACE_APP,
         "langfuse.trace.metadata.operationType": operation_type,
         "registry.operation.type": operation_type,
     }
 
 
 def _trace_tags(operation: str) -> list[str]:
-    return [_TRACE_APP, operation]
+    return [TRACE_APP, operation]
 
 
 def _set_serialized_attribute(
@@ -258,7 +239,7 @@ def _record_result(span: Span, result: CallToolResult) -> bool:
     try:
         span.set_status(Status(StatusCode.ERROR, "MCP operation returned an error result"))
     except Exception:
-        pass
+        logger.error("failed to set OTEL span status to ERROR when MCP operation returned an error result")
     return False
 
 
@@ -300,7 +281,7 @@ def trace_discovery(
             "top_n": top_n,
             "type_list": type_list,
         }
-        with _TRACER.start_as_current_span(span_name, attributes=_clean_attributes(attributes)) as span:
+        with _TRACER.start_as_current_span(span_name, attributes=clean_span_attributes(attributes)) as span:
             _set_serialized_attribute(span, "langfuse.observation.input", trace_input)
             success = False
             try:
@@ -309,7 +290,7 @@ def trace_discovery(
                 success = True
                 return results
             finally:
-                _set_span_attributes(span, {"registry.operation.success": success})
+                set_span_attributes(span, {"registry.operation.success": success})
 
     return wrapper
 
@@ -343,7 +324,7 @@ def trace_tool_execution(
             "mcp.tool.name": tool_name,
             "mcp.server.id": server_id,
         }
-        with _TRACER.start_as_current_span(_TOOL_SPAN_NAME, attributes=_clean_attributes(attributes)) as span:
+        with _TRACER.start_as_current_span(_TOOL_SPAN_NAME, attributes=clean_span_attributes(attributes)) as span:
             _set_serialized_attribute(
                 span,
                 "langfuse.observation.input",
@@ -355,7 +336,7 @@ def trace_tool_execution(
                 success = _record_result(span, result)
                 return result
             finally:
-                _set_span_attributes(span, {"registry.operation.success": success})
+                set_span_attributes(span, {"registry.operation.success": success})
 
     return wrapper
 
@@ -387,7 +368,7 @@ def trace_agent_execution[AgentMessageT](
             ),
             "a2a.agent.id": agent_id,
         }
-        with _TRACER.start_as_current_span(_AGENT_SPAN_NAME, attributes=_clean_attributes(attributes)) as span:
+        with _TRACER.start_as_current_span(_AGENT_SPAN_NAME, attributes=clean_span_attributes(attributes)) as span:
             _set_serialized_attribute(
                 span,
                 "langfuse.observation.input",
@@ -399,6 +380,6 @@ def trace_agent_execution[AgentMessageT](
                 success = _record_result(span, result)
                 return result
             finally:
-                _set_span_attributes(span, {"registry.operation.success": success})
+                set_span_attributes(span, {"registry.operation.success": success})
 
     return wrapper

--- a/registry/src/registry/services/workflow_executor.py
+++ b/registry/src/registry/services/workflow_executor.py
@@ -5,7 +5,6 @@ This module provides functions to execute workflows asynchronously using Backgro
 """
 
 import logging
-from typing import Any
 
 from beanie import PydanticObjectId
 
@@ -14,13 +13,15 @@ from registry_pkgs.models.workflow import NodeRun, WorkflowRun
 from registry_pkgs.workflows.helpers import extract_user_text
 from registry_pkgs.workflows.runner import WorkflowRunner
 
+from ..auth.dependencies import UserContextDict
+
 logger = logging.getLogger(__name__)
 
 
 async def execute_workflow_run_background(
     run_id: str | PydanticObjectId,
     workflow_runner: WorkflowRunner,
-    auth_context: dict[str, Any] | None = None,
+    auth_context: UserContextDict | None = None,
 ) -> None:
     """
     Execute a workflow run in the background.

--- a/registry/tests/unit/mcpgw/test_tracing.py
+++ b/registry/tests/unit/mcpgw/test_tracing.py
@@ -32,7 +32,7 @@ from registry.mcpgw.tracing import (
     _build_tool_trace_input,
     _extract_caller_identity,
     _serialize_trace_value,
-    _set_span_attributes,
+    set_span_attributes,
     trace_agent_execution,
     trace_discovery,
     trace_tool_execution,
@@ -433,7 +433,7 @@ def test_span_attribute_failure_is_logged_without_attribute_data(caplog: pytest.
     span.set_attribute.side_effect = RuntimeError("attribute rejected")
 
     with caplog.at_level("WARNING", logger="registry.mcpgw.tracing"):
-        _set_span_attributes(span, {"sensitive-key": "DO_NOT_LOG_ATTRIBUTE_VALUE"})
+        set_span_attributes(span, {"sensitive-key": "DO_NOT_LOG_ATTRIBUTE_VALUE"})
 
     assert "Failed to set trace attributes (RuntimeError)" in caplog.text
     assert "sensitive-key" not in caplog.text


### PR DESCRIPTION
## Summary

This PR adds Langfuse tracing for Registry Workflow executions and continuations, building on the Agno instrumentation introduced in PR #518.

## What changed

- Added `workflow.execute` and `workflow.continue` root spans with the trace name `WorkflowRun`.
- Recorded Workflow input/output, execution status, and user/session metadata.
- Propagated Langfuse trace metadata to existing Agno Workflow and Step spans.
- Added configuration documentation and focused tests for Workflow tracing and failure isolation.

## Validation

- Verified Workflow root spans and Agno child spans are grouped correctly in Langfuse.
- All workspace tests and Ruff checks pass.