### PR TITLE
Fix: workflow node dependency

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -1,0 +1,36 @@
+name: Frontend Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: "Vitest"
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: npm
+        cache-dependency-path: frontend/package-lock.json
+
+    - name: Install dependencies
+      working-directory: frontend
+      run: npm ci
+
+    - name: Run unit tests
+      working-directory: frontend
+      run: npm run test

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,7 +41,8 @@
         "eslint-plugin-react-refresh": "^0.4.9",
         "globals": "^15.9.0",
         "typescript-eslint": "^8.0.1",
-        "vite": "^7.2.2"
+        "vite": "^7.2.2",
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4858,6 +4859,13 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -5199,6 +5207,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -5271,6 +5290,13 @@
       "version": "0.7.54",
       "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.54.tgz",
       "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5885,6 +5911,149 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -6565,6 +6734,16 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -7349,6 +7528,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -9680,6 +9869,16 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -13834,6 +14033,20 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -14138,6 +14351,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -17705,6 +17925,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -17872,6 +18099,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -17895,6 +18129,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -18649,6 +18890,23 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -18692,6 +18950,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -19405,6 +19673,119 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -19944,6 +20325,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "start": "vite",
     "build": "vite build",
     "serve": "vite preview",
+    "test": "vitest run",
     "format": "biome check --write",
     "rebuild:package-lock": "rm -rf node_modules package-lock.json && npm install"
   },
@@ -56,7 +57,8 @@
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
     "typescript-eslint": "^8.0.1",
-    "vite": "^7.2.2"
+    "vite": "^7.2.2",
+    "vitest": "^4.1.11"
   },
   "overrides": {
     "nth-check": "^2.1.1",

--- a/frontend/src/components/WorkflowCanvas/utils/dag.test.ts
+++ b/frontend/src/components/WorkflowCanvas/utils/dag.test.ts
@@ -1,0 +1,135 @@
+import type { Edge, Node } from '@xyflow/react';
+import { describe, expect, it } from 'vitest';
+import type { NodeData } from '../types';
+import { getAncestors, getEffectiveExecutingParents, getReferenceCandidates, pruneInvalidRefs } from './dag';
+
+const makeNode = (id: string, type: string, refs?: string[]): Node<NodeData> => ({
+  id,
+  type,
+  position: { x: 0, y: 0 },
+  data: refs ? { label: id, refs } : { label: id },
+});
+
+const makeEdge = (source: string, target: string): Edge => ({ id: `${source}->${target}`, source, target });
+
+describe('getEffectiveExecutingParents', () => {
+  it('treats a direct execution-to-execution edge as an implicit parent', () => {
+    const nodes = [makeNode('A', 'agent'), makeNode('B', 'agent')];
+    const edges = [makeEdge('A', 'B')];
+
+    expect(getEffectiveExecutingParents('B', edges, nodes)).toEqual(new Set(['A']));
+  });
+
+  it('returns nothing for a node with no parents', () => {
+    const nodes = [makeNode('A', 'agent')];
+
+    expect(getEffectiveExecutingParents('A', [], nodes)).toEqual(new Set());
+  });
+
+  it('does not tunnel through a Condition node to reach an implicit parent (regression)', () => {
+    // A -> B -> Condition -> C, where C is the first node inside the Condition's branch.
+    const nodes = [
+      makeNode('A', 'agent'),
+      makeNode('B', 'agent'),
+      makeNode('Condition', 'cond'),
+      makeNode('C', 'agent'),
+    ];
+    const edges = [makeEdge('A', 'B'), makeEdge('B', 'Condition'), makeEdge('Condition', 'C')];
+
+    expect(getEffectiveExecutingParents('C', edges, nodes)).toEqual(new Set());
+  });
+
+  it.each(['router', 'loop', 'parallel'])('does not tunnel through a %s node either', structuralType => {
+    const nodes = [makeNode('B', 'agent'), makeNode('S', structuralType), makeNode('C', 'agent')];
+    const edges = [makeEdge('B', 'S'), makeEdge('S', 'C')];
+
+    expect(getEffectiveExecutingParents('C', edges, nodes)).toEqual(new Set());
+  });
+
+  it('treats the node directly after a branch entry as having that entry as its implicit parent', () => {
+    // Condition -> C -> D, both C and D inside the same branch.
+    const nodes = [makeNode('Condition', 'cond'), makeNode('C', 'agent'), makeNode('D', 'agent')];
+    const edges = [makeEdge('Condition', 'C'), makeEdge('C', 'D')];
+
+    expect(getEffectiveExecutingParents('D', edges, nodes)).toEqual(new Set(['C']));
+  });
+});
+
+describe('getAncestors', () => {
+  it('returns every upstream node reachable through reverse edges, regardless of node type', () => {
+    const edges = [makeEdge('A', 'B'), makeEdge('B', 'Condition'), makeEdge('Condition', 'C')];
+
+    expect(getAncestors('C', edges)).toEqual(new Set(['Condition', 'B', 'A']));
+  });
+});
+
+describe('getReferenceCandidates', () => {
+  it('offers every non-implicit execution ancestor for the first node inside a branch (IT Helpdesk workflow regression)', () => {
+    // A -> B -> Condition -> C -> D
+    const nodes = [
+      makeNode('A', 'agent'),
+      makeNode('B', 'agent'),
+      makeNode('Condition', 'cond'),
+      makeNode('C', 'agent'),
+      makeNode('D', 'agent'),
+    ];
+    const edges = [makeEdge('A', 'B'), makeEdge('B', 'Condition'), makeEdge('Condition', 'C'), makeEdge('C', 'D')];
+
+    expect(getReferenceCandidates('C', nodes, edges).map(n => n.id)).toEqual(['A', 'B']);
+  });
+
+  it('excludes a direct execution parent as implicit, but still offers earlier nodes', () => {
+    // Same graph as above: D's direct parent C is implicit and excluded, A and B remain.
+    const nodes = [
+      makeNode('A', 'agent'),
+      makeNode('B', 'agent'),
+      makeNode('Condition', 'cond'),
+      makeNode('C', 'agent'),
+      makeNode('D', 'agent'),
+    ];
+    const edges = [makeEdge('A', 'B'), makeEdge('B', 'Condition'), makeEdge('Condition', 'C'), makeEdge('C', 'D')];
+
+    expect(getReferenceCandidates('D', nodes, edges).map(n => n.id)).toEqual(['A', 'B']);
+  });
+
+  it('excludes structural nodes and the node itself from candidates', () => {
+    const nodes = [makeNode('A', 'agent'), makeNode('Condition', 'cond'), makeNode('C', 'agent')];
+    const edges = [makeEdge('A', 'Condition'), makeEdge('Condition', 'C')];
+
+    expect(getReferenceCandidates('C', nodes, edges).map(n => n.id)).toEqual(['A']);
+  });
+});
+
+describe('pruneInvalidRefs', () => {
+  it('strips a ref pointing at a node that is now an implicit (direct execution) parent', () => {
+    const nodes = [makeNode('A', 'agent'), makeNode('B', 'agent', ['A'])];
+    const edges = [makeEdge('A', 'B')];
+
+    const [, b] = pruneInvalidRefs(nodes, edges);
+
+    expect(b.data.refs).toEqual([]);
+  });
+
+  it('strips a ref that is no longer reachable after its edge is removed', () => {
+    const nodes = [makeNode('A', 'agent'), makeNode('B', 'agent'), makeNode('C', 'agent', ['A'])];
+    const edges = [makeEdge('B', 'C')];
+
+    const pruned = pruneInvalidRefs(nodes, edges);
+
+    expect(pruned.find(n => n.id === 'C')?.data.refs).toEqual([]);
+  });
+
+  it('keeps a valid explicit ref across a branch boundary', () => {
+    const nodes = [
+      makeNode('A', 'agent'),
+      makeNode('B', 'agent'),
+      makeNode('Condition', 'cond'),
+      makeNode('C', 'agent', ['B']),
+    ];
+    const edges = [makeEdge('A', 'B'), makeEdge('B', 'Condition'), makeEdge('Condition', 'C')];
+
+    const pruned = pruneInvalidRefs(nodes, edges);
+
+    expect(pruned.find(n => n.id === 'C')?.data.refs).toEqual(['B']);
+  });
+});

--- a/frontend/src/components/WorkflowCanvas/utils/dag.ts
+++ b/frontend/src/components/WorkflowCanvas/utils/dag.ts
@@ -11,26 +11,22 @@ export const getDirectParents = (nodeId: string, edges: Edge[]): Set<string> =>
   new Set(edges.filter(edge => edge.target === nodeId).map(edge => edge.source));
 
 /**
- * Returns the closest execution nodes on every upstream path.
- * Structural nodes are traversed; traversal stops when an Agent, MCP, or Pool is reached.
+ * Returns the node's direct parents that are themselves execution nodes.
+ *
+ * Their output is already injected as implicit input at runtime (see
+ * compiler._build_implicit_previous_step_names), but only across a direct
+ * edge — a structural node (Condition/Router/Loop/Parallel) between two
+ * execution nodes breaks that implicit chain, so it must not be tunneled
+ * through here either. A node whose direct parent is structural has no
+ * effective executing parent at all.
  */
 export const getEffectiveExecutingParents = (nodeId: string, edges: Edge[], nodes: Node<NodeData>[]): Set<string> => {
   const effectiveParents = new Set<string>();
-  const visited = new Set<string>();
-  const queue = [nodeId];
   const nodeMap = new Map(nodes.map(node => [node.id, node]));
 
-  for (let index = 0; index < queue.length; index += 1) {
-    const current = queue[index];
-    if (current === undefined || visited.has(current)) continue;
-    visited.add(current);
-
-    for (const upstreamId of getDirectParents(current, edges)) {
-      const upstreamNode = nodeMap.get(upstreamId);
-      if (!upstreamNode) continue;
-      if (isExecutionNode(upstreamNode)) effectiveParents.add(upstreamId);
-      else queue.push(upstreamId);
-    }
+  for (const parentId of getDirectParents(nodeId, edges)) {
+    const parentNode = nodeMap.get(parentId);
+    if (parentNode && isExecutionNode(parentNode)) effectiveParents.add(parentId);
   }
 
   return effectiveParents;

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    // 'agent': silent for passing tests/files, full detail (diff, stack, code frame)
+    // preserved for failures. Keeps a green run to a few summary lines.
+    reporters: ['agent'],
   },
 });


### PR DESCRIPTION
The first node inside a Condition/Router/Loop/Parallel branch couldn't reference any upstream node beyond its
branch's entry point, and silently received none of that missing node's output at runtime. Confirmed against the
"IT Helpdesk Ticket Triage & Knowledge Answer Automation" workflow, where "Generate & Send Response" never saw "Search Confluence Knowledge"'s output.

**Root cause:** `getEffectiveExecutingParents` (frontend) tunneled through structural nodes to find the nearest
execution node and treated it as an implicit dependency, hiding it from "Reference upstream outputs". The
backend's implicit-dependency chain intentionally breaks at every container boundary, so that node was never
actually implicit — it was just unreachable, both implicitly and explicitly.

**Fix:** restrict the implicit-parent check to a single hop, matching the backend's real semantics.

## Changes

- `fix(frontend)`: `getEffectiveExecutingParents` no longer tunnels through Condition/Router/Loop/Parallel
nodes.
- `test(frontend)`: add Vitest (node environment, no jsdom/UI testing) + regression tests for `dag.ts`'s DAG
helpers.
- `ci`: add a GitHub Actions workflow running the frontend unit test suite on any `frontend/**` change.

## Test plan

- [x] `npm run test` — 14/14 passing; confirmed 7 of them fail against the pre-fix code (verified via `git
stash`), so they actually cover the regression.
- [x] `npm ci` and Biome check both clean.