### PR TITLE
Fix: Raise workflow prompt truncation budget, unskip test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -605,6 +605,13 @@ AWS_BEDROCK_REQUIRE_AIP=false
 # Must be set to an actual available AIP ARN when AWS_BEDROCK_REQUIRE_AIP=true
 # AWS_BEDROCK_SONNET_AIP_ARN=
 
+# Max characters a compiled workflow step prompt (goal + dependencies + trigger params, as a whole)
+# may reach before being truncated. Sized for the workflow LLM's context window above
+# (currently Claude Sonnet 5, 1M tokens) — ~900,000 tokens of budget at a ~4 chars/token estimate,
+# leaving headroom for the rest of the request and the model's response.
+# Default: 3600000
+# WORKFLOW_PROMPT_MAX_CHARS=3600000
+
 # =============================================================================
 # OPENAI EMBEDDINGS CONFIGURATION
 # =============================================================================

--- a/registry-pkgs/src/registry_pkgs/core/config.py
+++ b/registry-pkgs/src/registry_pkgs/core/config.py
@@ -118,6 +118,30 @@ class TelemetryConfig(BaseModel):
     )
 
 
+_CHARS_PER_TOKEN_ESTIMATE = 4  # rough English-text heuristic; Claude's tokenizer has no fixed char:token ratio
+_WORKFLOW_LLM_CONTEXT_BUDGET_TOKENS = 900_000  # leaves ~100K tokens of headroom under Sonnet 5's 1M-token window
+
+
+class WorkflowPromptSettings(BaseSettings):
+    """Tuning knob for how large a compiled workflow step prompt may grow before truncation.
+
+    Standalone `BaseSettings` rather than a `BaseModel` threaded from `JarvisBaseSettings` (unlike
+    `JwtSigningConfig` and friends below): it has no required fields, so `registry_pkgs.workflows.helpers`
+    can read it directly without the owning app (registry/auth-server) having to construct and pass it down.
+
+    Default sizes to the workflow LLM's context window (currently Claude Sonnet 5 on AWS Bedrock via an
+    Application Inference Profile — see `Settings.workflow_llm_model_id` in the registry app's config),
+    leaving headroom for the rest of the request and the model's own response.
+    """
+
+    model_config = SettingsConfigDict(case_sensitive=False, extra="ignore")
+
+    workflow_prompt_max_chars: int = Field(
+        default=_WORKFLOW_LLM_CONTEXT_BUDGET_TOKENS * _CHARS_PER_TOKEN_ESTIMATE,
+        description="Max characters a compiled workflow step prompt may reach before being truncated",
+    )
+
+
 class JarvisBaseSettings(BaseSettings):
     """Shared base settings for all Jarvis services.
 

--- a/registry-pkgs/src/registry_pkgs/workflows/helpers.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/helpers.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from agno.workflow import StepInput, StepOutput
 
+from registry_pkgs.core.config import WorkflowPromptSettings
 from registry_pkgs.workflows.prompt import (
     ADDITIONAL_DATA_DEPENDENCY_NODE_NAMES,
     ADDITIONAL_DATA_DEPENDENCY_OBJECTIVES,
@@ -16,24 +17,23 @@ from registry_pkgs.workflows.prompt import (
 )
 from registry_pkgs.workflows.serialization import content_to_str
 
-_MAX_DEPENDENCY_CONTENT_CHARS = 8000
+_MAX_PROMPT_CHARS = WorkflowPromptSettings().workflow_prompt_max_chars
 
-_MediaSummaryFields = tuple[tuple[str, int | None], ...]
-_IMAGE_SUMMARY_FIELDS: _MediaSummaryFields = (("mime_type", None), ("format", None), ("alt_text", 500))
-_VIDEO_SUMMARY_FIELDS: _MediaSummaryFields = (("mime_type", None), ("format", None), ("duration", None))
-_AUDIO_SUMMARY_FIELDS: _MediaSummaryFields = (
-    ("mime_type", None),
-    ("format", None),
-    ("duration", None),
-    ("transcript", 500),
-)
+_MediaSummaryFields = tuple[str, ...]
+_IMAGE_SUMMARY_FIELDS: _MediaSummaryFields = ("mime_type", "format", "alt_text")
+_VIDEO_SUMMARY_FIELDS: _MediaSummaryFields = ("mime_type", "format", "duration")
+_AUDIO_SUMMARY_FIELDS: _MediaSummaryFields = ("mime_type", "format", "duration", "transcript")
 
 
-def _truncate(value: str, *, limit: int = _MAX_DEPENDENCY_CONTENT_CHARS) -> str:
-    """Cap prompt-bound text at *limit* chars, appending a note about what was cut."""
-    if len(value) <= limit:
+def _truncate(value: str) -> str:
+    """Cap the fully-assembled prompt at _MAX_PROMPT_CHARS, appending a note about what was cut.
+
+    Applied once to the whole rendered prompt in build_prompt() — not per dependency or per field —
+    so the cap reflects what actually matters: the total size of what's sent to the workflow LLM.
+    """
+    if len(value) <= _MAX_PROMPT_CHARS:
         return value
-    return f"{value[:limit]}\n[truncated: {len(value) - limit} chars omitted]"
+    return f"{value[:_MAX_PROMPT_CHARS]}\n[truncated: {len(value) - _MAX_PROMPT_CHARS} chars omitted]"
 
 
 def _safe_file_preview(file_content: Any, mime_type: str | None) -> str | None:
@@ -57,11 +57,11 @@ def _media_summary_lines(items: list[Any], fallback_label: str, fields: _MediaSu
     lines = []
     for item in items:
         details = [item.id or item.mime_type or fallback_label]
-        for attr, limit in fields:
+        for attr in fields:
             value = getattr(item, attr, None)
             if value is None or value == "":
                 continue
-            details.append(f"{attr}={_truncate(str(value), limit=limit) if limit else value}")
+            details.append(f"{attr}={value}")
         lines.append(f"- {', '.join(details)}")
     return "\n".join(lines)
 
@@ -70,7 +70,7 @@ def step_output_to_prompt_text(output: StepOutput) -> str:
     """Render a StepOutput into a compact, prompt-safe text summary (metadata only, never bytes)."""
     sections: list[str] = []
     if output.content is not None:
-        sections.append(f"Text output:\n{_truncate(content_to_str(output.content))}")
+        sections.append(f"Text output:\n{content_to_str(output.content)}")
 
     if output.images:
         sections.append("Images:\n" + _media_summary_lines(output.images, "image", _IMAGE_SUMMARY_FIELDS))
@@ -95,7 +95,7 @@ def step_output_to_prompt_text(output: StepOutput) -> str:
             lines.append(f"- {', '.join(details)}")
             preview = _safe_file_preview(file.content, file.mime_type)
             if preview:
-                lines.append(f"  Preview:\n{_truncate(preview)}")
+                lines.append(f"  Preview:\n{preview}")
         sections.append("Files:\n" + "\n".join(lines))
 
     if not output.success:
@@ -123,19 +123,22 @@ def build_prompt(step_input: StepInput) -> str:
     ``compiler._with_intention_data``, then delegates to ``render_step_prompt``.
     Falls back to raw trigger text when ``additional_data`` has no step_objective
     (e.g. demo executors or direct unit-test calls that bypass the compiler).
+
+    The fully-assembled prompt is truncated as a whole (see ``_truncate``) — individual
+    dependency outputs, media fields, and trigger parameters are never capped in isolation.
     """
     additional = step_input.additional_data or {}
     step_objective: str = additional.get(ADDITIONAL_DATA_STEP_OBJECTIVE) or ""
 
     # Graceful degradation for demo executors / direct test calls
     if not step_objective:
-        return step_input.get_input_as_string() or "(no input)"
+        return _truncate(step_input.get_input_as_string() or "(no input)")
 
     workflow_description: str | None = additional.get(ADDITIONAL_DATA_WORKFLOW_DESCRIPTION)
     dependency_node_names: list[str] = additional.get(ADDITIONAL_DATA_DEPENDENCY_NODE_NAMES) or []
     dependency_objectives: dict[str, str] = additional.get(ADDITIONAL_DATA_DEPENDENCY_OBJECTIVES) or {}
     trigger_input: dict[str, Any] | None = additional.get(ADDITIONAL_DATA_INITIAL_INPUT)
-    trigger_parameters = _truncate(content_to_str(trigger_input)) if trigger_input else None
+    trigger_parameters = content_to_str(trigger_input) if trigger_input else None
 
     previous = step_input.previous_step_outputs or {}
 
@@ -162,10 +165,11 @@ def build_prompt(step_input: StepInput) -> str:
     is_entry = not previous
     initial_input = step_input.get_input_as_string() if is_entry and not dependencies else None
 
-    return render_step_prompt(
+    prompt = render_step_prompt(
         step_objective=step_objective,
         workflow_description=workflow_description,
         dependencies=dependencies,
         initial_input=initial_input,
         trigger_parameters=trigger_parameters,
     )
+    return _truncate(prompt)

--- a/registry-pkgs/tests/unit/workflow/test_compiler.py
+++ b/registry-pkgs/tests/unit/workflow/test_compiler.py
@@ -16,10 +16,9 @@ from registry_pkgs.models.workflow import (
     WorkflowNode,
     WorkflowRun,
 )
-from registry_pkgs.workflows import compiler
+from registry_pkgs.workflows import compiler, helpers
 from registry_pkgs.workflows.compiler import step_kwargs
 from registry_pkgs.workflows.helpers import build_prompt, step_output_to_prompt_text
-from registry_pkgs.workflows.serialization import content_to_str
 
 
 async def _executor(*args, **kwargs):
@@ -1281,9 +1280,9 @@ class TestIntentionData:
         assert 'Dependencies:\n- "Ghost Node": produce ghost output.' in prompt
         assert "Current Step Inputs:" not in prompt
 
-    @pytest.mark.skip(reason="truncation temporarily disabled")
     @pytest.mark.asyncio
-    async def test_long_output_is_truncated_in_dependency_prompt(self):
+    async def test_long_output_is_truncated_in_dependency_prompt(self, monkeypatch):
+        """Truncation applies to the whole assembled prompt once it exceeds the aggregate budget."""
         upstream = _step_node("Big Node", "tool", "produce long output")
         node = self._step_node_with_refs("echo", ["Big Node"], "consume long output")
         definition = _workflow_definition([upstream, node])
@@ -1297,12 +1296,20 @@ class TestIntentionData:
             definition, _workflow_run(), executor_registry={"tool": capturing_executor}
         )
         long_content = "x" * 10_000
-        previous = self._make_previous_outputs(**{"Big Node": long_content})
-        await workflow.steps[1].executor(StepInput(input="task", previous_step_outputs=previous), {})
+        step_input = StepInput(
+            input="task", previous_step_outputs=self._make_previous_outputs(**{"Big Node": long_content})
+        )
 
-        prompt = received_prompts[0]
-        assert "x" * 8000 in prompt
-        assert "[truncated: 2000 chars omitted]" in prompt
+        await workflow.steps[1].executor(step_input, {})
+        full_prompt = received_prompts[0]
+        assert len(full_prompt) > 10_000  # sanity check before mocking a cap below that size
+
+        monkeypatch.setattr(helpers, "_MAX_PROMPT_CHARS", 8000)
+        await workflow.steps[1].executor(step_input, {})
+        truncated_prompt = received_prompts[1]
+
+        omitted = len(full_prompt) - 8000
+        assert truncated_prompt == f"{full_prompt[:8000]}\n[truncated: {omitted} chars omitted]"
 
     @pytest.mark.asyncio
     async def test_no_dependencies_entry_node_renders_initial_input(self):
@@ -1495,8 +1502,8 @@ class TestIntentionData:
         assert "Workflow Trigger Parameters" not in prompts[0]
 
     @pytest.mark.asyncio
-    async def test_oversized_initial_input_is_truncated_in_trigger_parameters(self):
-        """trigger_parameters gets the same 8000-char cap as dependency content (helpers._truncate)."""
+    async def test_oversized_initial_input_is_truncated_in_trigger_parameters(self, monkeypatch):
+        """An oversized trigger_parameters block also counts toward the aggregate prompt budget."""
         node = _step_node("echo", "tool", "do the thing")
         definition = _workflow_definition([node])
         oversized_input = {"blob": "x" * 10_000}
@@ -1513,16 +1520,18 @@ class TestIntentionData:
             return SimpleNamespace(content="ok")
 
         workflow = compiler.compile_workflow(definition, run, executor_registry={"tool": capturing_executor})
-        await workflow.steps[0].executor(StepInput(input="task"), {})
+        step_input = StepInput(input="task")
 
-        prompt = prompts[0]
-        full_json = content_to_str(oversized_input)
-        omitted = len(full_json) - 8000
-        # `_indented_block` reflows the truncated text's line-leading whitespace, so assert on
-        # the un-reflowable pieces: the full oversized run must not survive intact, and the
-        # truncation note must carry the exact omitted-char count.
-        assert "x" * 10_000 not in prompt
-        assert f"[truncated: {omitted} chars omitted]" in prompt
+        await workflow.steps[0].executor(step_input, {})
+        full_prompt = prompts[0]
+        assert len(full_prompt) > 10_000  # sanity check before mocking a cap below that size
+
+        monkeypatch.setattr(helpers, "_MAX_PROMPT_CHARS", 8000)
+        await workflow.steps[0].executor(step_input, {})
+        truncated_prompt = prompts[1]
+
+        omitted = len(full_prompt) - 8000
+        assert truncated_prompt == f"{full_prompt[:8000]}\n[truncated: {omitted} chars omitted]"
 
     def test_build_prompt_falls_back_without_additional_data(self):
         assert build_prompt(StepInput(input="hello")) == "hello"
@@ -1744,6 +1753,40 @@ class TestIntentionData:
         assert "image-bytes" not in prompt
         assert "video-bytes" not in prompt
         assert "audio-bytes" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_long_media_metadata_is_not_independently_truncated(self):
+        """Per-field caps on alt_text/transcript were removed — only the aggregate prompt budget applies now."""
+        from agno.media import Audio, Image
+
+        upstream = _step_node("Media Node", "tool", "produce media")
+        node = self._step_node_with_refs("echo", ["Media Node"], "consume media")
+        definition = _workflow_definition([upstream, node])
+        received_prompts: list[str] = []
+
+        async def capturing_executor(step_input, session_state=None):
+            received_prompts.append(build_prompt(step_input))
+            return SimpleNamespace(content="ok")
+
+        workflow = compiler.compile_workflow(
+            definition, _workflow_run(), executor_registry={"tool": capturing_executor}
+        )
+        long_alt_text = "a" * 600
+        long_transcript = "b" * 600
+        previous = {
+            "Media Node": StepOutput(
+                step_name="Media Node",
+                images=[Image(content=b"image-bytes", mime_type="image/png", id="image-1", alt_text=long_alt_text)],
+                audio=[Audio(content=b"audio-bytes", mime_type="audio/mpeg", id="audio-1", transcript=long_transcript)],
+                success=True,
+            )
+        }
+        await workflow.steps[1].executor(StepInput(input="analyse", previous_step_outputs=previous), {})
+
+        prompt = received_prompts[0]
+        assert f"alt_text={long_alt_text}" in prompt
+        assert f"transcript={long_transcript}" in prompt
+        assert "[truncated:" not in prompt
 
 
 @pytest.mark.unit

--- a/registry-pkgs/tests/unit/workflow/test_helpers.py
+++ b/registry-pkgs/tests/unit/workflow/test_helpers.py
@@ -4,7 +4,24 @@ from __future__ import annotations
 
 import json
 
+from registry_pkgs.core.config import WorkflowPromptSettings
+from registry_pkgs.workflows import helpers
 from registry_pkgs.workflows.helpers import extract_user_text
+
+
+def test_workflow_prompt_settings_default_matches_900k_token_budget():
+    """Default sizes to ~900K tokens (Sonnet 5's 1M-token window minus headroom) at ~4 chars/token."""
+    assert WorkflowPromptSettings().workflow_prompt_max_chars == 3_600_000
+
+
+def test_truncate_returns_value_unchanged_when_within_limit(monkeypatch):
+    monkeypatch.setattr(helpers, "_MAX_PROMPT_CHARS", 100)
+    assert helpers._truncate("short") == "short"
+
+
+def test_truncate_caps_and_annotates_oversized_value(monkeypatch):
+    monkeypatch.setattr(helpers, "_MAX_PROMPT_CHARS", 10)
+    assert helpers._truncate("x" * 15) == f"{'x' * 10}\n[truncated: 5 chars omitted]"
 
 
 def test_extract_user_text_prefers_user_text_key():


### PR DESCRIPTION
Truncation was previously applied per-piece (8,000 chars per dependency, 500 chars for `alt_text`/`transcript`,
separately for trigger params), a leftover from early development on a small-context-window model. The workflow
LLM is now Sonnet-class (1M-token window), and per-piece caps don't actually bound total prompt size — a node
with several dependencies could still overflow the context window even with each piece "truncated."

- Replaced all per-piece truncation with a single aggregate cap applied once to the fully-assembled prompt
(`build_prompt()` in `helpers.py`).
- New `WorkflowPromptSettings` (`registry_pkgs/core/config.py`), env var `WORKFLOW_PROMPT_MAX_CHARS`, default
`3,600,000` chars (~900K tokens at ~4 chars/token, leaving headroom under Sonnet 5's 1M-token window).
- Unskipped `test_long_output_is_truncated_in_dependency_prompt` (previously marked "truncation temporarily
disabled" since the day truncation was introduced — stale from the start) and rewrote it, plus
`test_oversized_initial_input_is_truncated_in_trigger_parameters`, against the new aggregate behavior.
- Added `test_long_media_metadata_is_not_independently_truncated` and settings/`_truncate` unit tests.

**Not in scope:** the workflow LLM model isn't strictly hardcoded — it resolves via `aws_bedrock_sonnet_aip_arn`
with a fallback to `aws_workflow_llm_model` (default `amazon.nova-2-lite-v1:0`) when no AIP is configured. The
900K-token budget assumes the Sonnet path; a model-selection factory pattern is planned separately to make this
properly aware of the active model's context window.
