### PR TITLE
fix: propagate Langfuse trace attributes to A2A agents

### DIFF
--- a/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
+++ b/registry-pkgs/src/registry_pkgs/workflows/a2a_client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from time import monotonic
 from typing import Any
@@ -25,7 +26,7 @@ from a2a.types import (
 )
 from a2a.utils.artifact import get_artifact_text
 from a2a.utils.message import get_message_text
-from opentelemetry import baggage
+from opentelemetry import baggage, trace
 from opentelemetry.baggage.propagation import W3CBaggagePropagator
 from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
@@ -57,6 +58,8 @@ _TRACE_CONTEXT_PROPAGATOR = CompositePropagator(
 )
 _TRACE_CONTEXT_HEADERS = frozenset({"baggage", "traceparent", "tracestate"})
 _LANGFUSE_ENVIRONMENT_BAGGAGE_KEY = "langfuse.environment"
+_LANGFUSE_TRACE_NAME_BAGGAGE_KEY = "langfuse.trace.name"
+_LANGFUSE_TRACE_TAGS_BAGGAGE_KEY = "langfuse.trace.tags"
 
 HeadersProvider = Callable[[A2AAgent], Awaitable[dict[str, str]]]
 ClientProvider = Callable[[A2AAgent], Awaitable[httpx.AsyncClient]]
@@ -205,7 +208,7 @@ def _extra_call_headers(agent: A2AAgent) -> dict[str, str]:
 
 
 def _inject_traceparent(headers: dict[str, str]) -> dict[str, str]:
-    """Return copied headers with the current trace and controlled environment baggage."""
+    """Return copied headers with the current trace and controlled Langfuse baggage."""
     outbound_headers = {key: value for key, value in headers.items() if key.lower() not in _TRACE_CONTEXT_HEADERS}
     try:
         outbound_context = baggage.clear()
@@ -216,6 +219,22 @@ def _inject_traceparent(headers: dict[str, str]) -> dict[str, str]:
                 environment,
                 context=outbound_context,
             )
+        span_attributes = getattr(trace.get_current_span(), "attributes", None)
+        if isinstance(span_attributes, Mapping):
+            trace_name = span_attributes.get(_LANGFUSE_TRACE_NAME_BAGGAGE_KEY)
+            if isinstance(trace_name, str) and trace_name:
+                outbound_context = baggage.set_baggage(
+                    _LANGFUSE_TRACE_NAME_BAGGAGE_KEY,
+                    trace_name,
+                    context=outbound_context,
+                )
+            trace_tags = span_attributes.get(_LANGFUSE_TRACE_TAGS_BAGGAGE_KEY)
+            if isinstance(trace_tags, (list, tuple)) and trace_tags:
+                outbound_context = baggage.set_baggage(
+                    _LANGFUSE_TRACE_TAGS_BAGGAGE_KEY,
+                    json.dumps(trace_tags, separators=(",", ":")),
+                    context=outbound_context,
+                )
         _TRACE_CONTEXT_PROPAGATOR.inject(
             outbound_headers,
             context=outbound_context,

--- a/registry-pkgs/tests/unit/workflow/test_a2a_client.py
+++ b/registry-pkgs/tests/unit/workflow/test_a2a_client.py
@@ -22,6 +22,7 @@ from a2a.types import (
     TransportProtocol,
 )
 from beanie import PydanticObjectId
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState, use_span
 
 from registry_pkgs.core.config import JwtSigningConfig
@@ -848,6 +849,32 @@ async def test_call_a2a_injects_current_trace_context_into_request_headers():
         "Traceparent": "00-00000000000000000000000000000002-0000000000000002-01",
         "Tracestate": "old=value",
     }
+
+
+@pytest.mark.asyncio
+async def test_call_a2a_injects_current_langfuse_trace_attributes():
+    agent = _make_agent()
+    mock_factory, mock_client = _mock_client([_msg("ok")])
+    tracer = TracerProvider().get_tracer(__name__)
+
+    with (
+        patch("registry_pkgs.workflows.a2a_client.ClientFactory", return_value=mock_factory),
+        patch("registry_pkgs.workflows.a2a_client.get_trace_environment", return_value="demo"),
+    ):
+        with tracer.start_as_current_span(
+            "a2a.agent.execute",
+            attributes={
+                "langfuse.trace.name": "AgentRun",
+                "langfuse.trace.tags": ["registry", "agent"],
+            },
+        ):
+            result = await call_a2a(agent, "test")
+
+    assert result.success is True
+    send_context = mock_client.send_message.call_args.kwargs["context"]
+    assert send_context.state["http_kwargs"]["headers"]["baggage"] == (
+        "langfuse.environment=demo,langfuse.trace.name=AgentRun,langfuse.trace.tags=%5B%22registry%22%2C%22agent%22%5D"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Propagate the current Langfuse trace name and tags to downstream A2A agents alongside the deployment environment.

## Changes

- Add `langfuse.trace.name` and `langfuse.trace.tags` to A2A baggage.
- Preserve `AgentRun` and `["registry", "agent"]` for direct Registry agent calls.
- Add coverage for the propagated baggage values.

## Testing

- `uv run poe test-all`
- `uv run poe check`

## Impact

- Enables downstream Agent and LLM spans to use the same Langfuse trace name and tags.
- No changes to A2A request schemas or workflow execution.
- No impact on metrics or collector configuration.