### PR TITLE
Feature/as 1826

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,7 +87,7 @@ OTEL_TRACE_HIDE_OUTPUTS=true
 # =============================================================================
 # AUTHENTICATION PROVIDER CONFIGURATION
 # =============================================================================
-# Choose authentication provider: 'cognito', 'keycloak', , 'google' or 'entra'
+# Choose authentication provider: 'cognito', 'keycloak', 'google' or 'entra'
 AUTH_PROVIDER=entra
 
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -87,7 +87,7 @@ OTEL_TRACE_HIDE_OUTPUTS=true
 # =============================================================================
 # AUTHENTICATION PROVIDER CONFIGURATION
 # =============================================================================
-# Choose authentication provider: 'cognito', 'keycloak', or 'entra'
+# Choose authentication provider: 'cognito', 'keycloak', , 'google' or 'entra'
 AUTH_PROVIDER=entra
 
 # =============================================================================
@@ -130,8 +130,8 @@ AUTH_PROVIDER=entra
 # KEYCLOAK_M2M_CLIENT_ID=mcp-gateway-m2m
 # KEYCLOAK_M2M_CLIENT_SECRET=your-keycloak-m2m-secret-here
 
-# Enable Keycloak in OAuth2 providers
-# KEYCLOAK_ENABLED=true
+# Show the Keycloak button on the login page (default: false)
+# KEYCLOAK_ENABLED=false
 
 # Initial admin and test user passwords for Keycloak setup
 # INITIAL_ADMIN_PASSWORD=your-secure-keycloak-admin-password
@@ -155,6 +155,9 @@ AUTH_PROVIDER=entra
 # Cognito App Client Secret
 # Get this from Amazon Cognito console > User Pools > App Integration > App clients
 # COGNITO_CLIENT_SECRET=your_cognito_client_secret_here
+
+# Show the Cognito button on the login page (default: false)
+# COGNITO_ENABLED=false
 
 
 # =============================================================================
@@ -217,6 +220,32 @@ ENTRA_NAME_CLAIM=name
 # id token: OIDC get user info, JWT
 # access token: OAuth 2.0,  Graph API
 ENTRA_ROLE_TOKEN_KIND=id
+
+# Show the Entra button on the login page (default: true)
+# ENTRA_ENABLED=true
+
+# =============================================================================
+# GOOGLE WORKSPACE OAUTH2 CONFIGURATION (if AUTH_PROVIDER=google or GOOGLE_ENABLED=true)
+# =============================================================================
+
+# Google OAuth 2.0 client credentials
+# Get these from Google Cloud Console > APIs & Services > Credentials > OAuth 2.0 Client IDs
+# GOOGLE_CLIENT_ID=xxxxxxxx.apps.googleusercontent.com
+# GOOGLE_CLIENT_SECRET=your_google_client_secret_here
+
+# Optional Workspace domain restriction. When set, only accounts whose verified `hd` claim
+# matches are allowed to log in (and the account picker is narrowed to this domain).
+# Leave empty to allow any verified Google account.
+# GOOGLE_ALLOWED_HD=yourcompany.com
+
+# Service account key JSON for resolving Google group memberships via the Cloud Identity API.
+# Google does not put groups in the id_token, so this is required for group->scope mapping.
+# Paste the raw JSON key content (single line). Without it, Google login still works but
+# resolves zero groups (minimal scopes).
+# GOOGLE_SERVICE_ACCOUNT_KEY_JSON={"type":"service_account",...}
+
+# Show the Google button on the login page (default: false)
+# GOOGLE_ENABLED=false
 
 # =============================================================================
 # APPLICATION SECURITY

--- a/auth-server/src/auth_server/container.py
+++ b/auth-server/src/auth_server/container.py
@@ -5,6 +5,7 @@ from redis import Redis
 
 from registry_pkgs.core.consent_store import ConsentStore, PendingConsentStore
 from registry_pkgs.core.oauth_state_store import OAuthStateStore
+from registry_pkgs.google.cloud_identity_client import CloudIdentityGroupsClient
 
 from .core.config import AuthSettings
 from .core.types import AllowedProvider
@@ -74,6 +75,10 @@ class AuthContainer:
     def token_grant_service(self) -> TokenGrantService:
         return TokenGrantService(self.user_service, self.oauth_state_store, self.consent_store)
 
+    @cached_property
+    def cloud_identity_client(self) -> CloudIdentityGroupsClient:
+        return CloudIdentityGroupsClient(self._settings.google_service_account_key_json)
+
     @cache
     def get_provider_config(self, provider: AllowedProvider) -> AuthProviderConfig | EntraConfig:
         return self._config_loader.get_provider_config(provider)
@@ -84,4 +89,5 @@ class AuthContainer:
             provider,
             self._settings,
             self._oauth2_config,
+            self.cloud_identity_client,
         )

--- a/auth-server/src/auth_server/core/config.py
+++ b/auth-server/src/auth_server/core/config.py
@@ -37,6 +37,7 @@ class AuthSettings(JarvisBaseSettings):
     keycloak_client_secret: str | None = None
     keycloak_m2m_client_id: str | None = None
     keycloak_m2m_client_secret: str | None = None
+    keycloak_enabled: str = "false"
 
     # ==================== Cognito Settings ====================
     cognito_user_pool_id: str | None = None
@@ -44,10 +45,23 @@ class AuthSettings(JarvisBaseSettings):
     cognito_client_secret: str | None = None
     cognito_domain: str | None = None
     aws_region: str = "us-east-1"
+    cognito_enabled: str = "false"
 
     # ==================== Entra ID Settings ====================
     # entra_tenant_id / entra_client_id / entra_client_secret are inherited from JarvisBaseSettings.
     entra_token_kind: str = "id"  # "id" or "access"
+    entra_enabled: str = "true"
+
+    # ==================== Google Settings ====================
+    google_client_id: str | None = None
+    google_client_secret: str | None = None
+    google_allowed_hd: str = ""
+    google_enabled: str = "false"
+
+    # Provider toggles (*_enabled) feed the ${..._ENABLED} substitution in oauth2_providers.yml.
+    # Kept as strings so a blank env value (e.g. `ENTRA_ENABLED=`) is valid and falls back to the
+    # YAML default; config_loader coerces the substituted value to a real bool. Only entra is on
+    # by default — every other provider is opt-in.
 
     # ==================== Metrics Settings ====================
     metrics_service_url: str = "http://localhost:8890"

--- a/auth-server/src/auth_server/core/types.py
+++ b/auth-server/src/auth_server/core/types.py
@@ -1,6 +1,6 @@
 from typing import Literal, TypedDict
 
-AllowedProvider = Literal["keycloak", "cognito", "entra"]
+AllowedProvider = Literal["keycloak", "cognito", "entra", "google"]
 
 
 class AuthProviderConfig(TypedDict):
@@ -29,6 +29,11 @@ class EntraConfig(AuthProviderConfig):
     m2m_scope: str
 
 
+class GoogleConfig(AuthProviderConfig):
+    jwks_url: str
+    allowed_hd: str
+
+
 class SessionCookieConfig(TypedDict):
     max_age_seconds: int
     secure: bool  # Set to false for development
@@ -41,6 +46,7 @@ class OAuth2Providers(TypedDict):
     keycloak: AuthProviderConfig
     cognito: AuthProviderConfig
     entra: EntraConfig
+    google: GoogleConfig
 
 
 class OAuth2Config(TypedDict):

--- a/auth-server/src/auth_server/oauth2_providers.yml
+++ b/auth-server/src/auth_server/oauth2_providers.yml
@@ -15,7 +15,7 @@ providers:
     groups_claim: "groups"
     email_claim: "email"
     name_claim: "name"
-    enabled: true
+    enabled: "${KEYCLOAK_ENABLED:-false}"
 
   cognito:
     display_name: "AWS Cognito"
@@ -34,7 +34,7 @@ providers:
     groups_claim: "cognito:groups"
     email_claim: "email"
     name_claim: "name"
-    enabled: false
+    enabled: "${COGNITO_ENABLED:-false}"
 
   # github:
   #   display_name: "GitHub"
@@ -53,22 +53,26 @@ providers:
   #   name_claim: "name"
   #   enabled: false  # Enable web-based OAuth2 flow for GitHub
 
-  # google:
-  #   display_name: "Google"
-  #   client_id: "${GOOGLE_CLIENT_ID}"
-  #   client_secret: "${GOOGLE_CLIENT_SECRET}"
-  #   auth_url: "https://accounts.google.com/o/oauth2/auth"
-  #   token_url: "https://oauth2.googleapis.com/token"
-  #   user_info_url: "https://www.googleapis.com/oauth2/v2/userinfo"
-  #   scopes: ["openid", "email", "profile"]
-  #   response_type: "code"
-  #   grant_type: "authorization_code"
-  #   # Google specific claim mapping
-  #   username_claim: "email"
-  #   groups_claim: null  # Google doesn't provide groups in basic scope
-  #   email_claim: "email"
-  #   name_claim: "name"
-  #   enabled: false  # Disabled by default
+  google:
+    display_name: "Google"
+    client_id: "${GOOGLE_CLIENT_ID}"
+    client_secret: "${GOOGLE_CLIENT_SECRET}"
+    # Endpoints are identical for every Google Workspace org (not tenant-specific).
+    auth_url: "https://accounts.google.com/o/oauth2/v2/auth"
+    token_url: "https://oauth2.googleapis.com/token"
+    jwks_url: "https://www.googleapis.com/oauth2/v3/certs"
+    user_info_url: "https://openidconnect.googleapis.com/v1/userinfo"
+    scopes: ["openid", "email", "profile"]
+    response_type: "code"
+    grant_type: "authorization_code"
+    # Google specific claim mapping
+    username_claim: "${GOOGLE_USERNAME_CLAIM:-email}"
+    groups_claim: null  # Groups come from Cloud Identity API, not the token
+    email_claim: "${GOOGLE_EMAIL_CLAIM:-email}"
+    name_claim: "${GOOGLE_NAME_CLAIM:-name}"
+    # Optional Workspace domain restriction (empty = any verified Google account)
+    allowed_hd: "${GOOGLE_ALLOWED_HD:-}"
+    enabled: "${GOOGLE_ENABLED:-false}"
 
   entra:
     display_name: "Microsoft Entra ID"
@@ -93,4 +97,4 @@ providers:
     graph_url: "${ENTRA_GRAPH_URL:-https://graph.microsoft.com}"
     # M2M (Machine-to-Machine) default scope
     m2m_scope: "${ENTRA_M2M_SCOPE:-https://graph.microsoft.com/.default}"
-    enabled: true
+    enabled: "${ENTRA_ENABLED:-true}"

--- a/auth-server/src/auth_server/providers/factory.py
+++ b/auth-server/src/auth_server/providers/factory.py
@@ -3,12 +3,15 @@
 # Builtin
 import logging
 
+from registry_pkgs.google.cloud_identity_client import CloudIdentityGroupsClient
+
 from ..core.config import AuthSettings
-from ..core.types import AllowedProvider
+from ..core.types import AllowedProvider, GoogleConfig
 from ..utils.config_loader import EntraConfig, OAuth2Config
 from .base import AuthProvider
 from .cognito import CognitoProvider
 from .entra import EntraIdProvider
+from .google import GoogleProvider
 from .keycloak import KeycloakProvider
 
 # Get logger - logging is configured centrally in server.py via settings.configure_logging()
@@ -19,14 +22,16 @@ def get_auth_provider(
     provider_type: AllowedProvider,
     settings: AuthSettings,
     oauth2_config: OAuth2Config,
+    cloud_identity_client: CloudIdentityGroupsClient,
 ) -> AuthProvider:
     """Factory function to get the appropriate auth provider.
 
     Args:
-        settings_override:
-        oauth2_config:
         provider_type: Type of provider to create ('cognito', 'keycloak', or 'entra').
                       If None, uses auth-server settings.
+        settings:
+        oauth2_config:
+        cloud_identity_client:
 
     Returns:
         AuthProvider instance configured for the specified provider
@@ -42,6 +47,8 @@ def get_auth_provider(
         return _create_cognito_provider(settings)
     elif provider_type == "entra":
         return _create_entra_provider(oauth2_config["providers"]["entra"])
+    elif provider_type == "google":
+        return _create_google_provider(oauth2_config["providers"]["google"], cloud_identity_client)
     else:
         raise ValueError(f"Unknown auth provider: {provider_type}")
 
@@ -196,4 +203,35 @@ def _create_entra_provider(entra_config: EntraConfig) -> EntraIdProvider:
         groups_claim=groups_claim,
         email_claim=email_claim,
         name_claim=name_claim,
+    )
+
+
+def _create_google_provider(
+    google_config: GoogleConfig,
+    cloud_identity_client: CloudIdentityGroupsClient,
+) -> GoogleProvider:
+    """Create and configure the Google Workspace provider."""
+    client_id = google_config.get("client_id")
+    client_secret = google_config.get("client_secret")
+
+    missing_vars = []
+    if not client_id:
+        missing_vars.append("GOOGLE_CLIENT_ID")
+    if not client_secret:
+        missing_vars.append("GOOGLE_CLIENT_SECRET")
+
+    if missing_vars:
+        raise ValueError(
+            f"Missing required Google configuration: {', '.join(missing_vars)}. Please set these environment variables."
+        )
+
+    logger.info("Initializing Google provider")
+
+    return GoogleProvider(
+        client_id=client_id,
+        client_secret=client_secret,
+        cloud_identity_client=cloud_identity_client,
+        allowed_hd=google_config.get("allowed_hd", ""),
+        scopes=google_config.get("scopes"),
+        grant_type=google_config.get("grant_type", "authorization_code"),
     )

--- a/auth-server/src/auth_server/providers/factory.py
+++ b/auth-server/src/auth_server/providers/factory.py
@@ -213,12 +213,21 @@ def _create_google_provider(
     """Create and configure the Google Workspace provider."""
     client_id = google_config.get("client_id")
     client_secret = google_config.get("client_secret")
+    auth_url = google_config.get("auth_url")
+    token_url = google_config.get("token_url")
+    jwks_url = google_config.get("jwks_url")
 
     missing_vars = []
     if not client_id:
         missing_vars.append("GOOGLE_CLIENT_ID")
     if not client_secret:
         missing_vars.append("GOOGLE_CLIENT_SECRET")
+    if not auth_url:
+        missing_vars.append("auth_url in oauth2_providers.yml")
+    if not token_url:
+        missing_vars.append("token_url in oauth2_providers.yml")
+    if not jwks_url:
+        missing_vars.append("jwks_url in oauth2_providers.yml")
 
     if missing_vars:
         raise ValueError(
@@ -231,6 +240,9 @@ def _create_google_provider(
         client_id=client_id,
         client_secret=client_secret,
         cloud_identity_client=cloud_identity_client,
+        auth_url=auth_url,
+        token_url=token_url,
+        jwks_url=jwks_url,
         allowed_hd=google_config.get("allowed_hd", ""),
         scopes=google_config.get("scopes"),
         grant_type=google_config.get("grant_type", "authorization_code"),

--- a/auth-server/src/auth_server/providers/google.py
+++ b/auth-server/src/auth_server/providers/google.py
@@ -1,0 +1,213 @@
+import logging
+import time
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+from authlib.integrations.requests_client import OAuth2Session
+
+from registry_pkgs.core.jwt_utils import (
+    ExpiredSignatureError,
+    InvalidTokenError,
+    decode_jwt_with_jwk,
+    find_matching_jwk,
+    get_token_kid,
+)
+from registry_pkgs.google.cloud_identity_client import CloudIdentityGroupsClient
+
+from .base import AuthProvider
+
+logger = logging.getLogger(__name__)
+
+_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+_TOKEN_URL = "https://oauth2.googleapis.com/token"
+_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs"
+_VALID_ISSUERS = ("https://accounts.google.com", "accounts.google.com")
+_JWKS_CACHE_TTL_SECONDS = 3600
+
+
+class GoogleEmailNotVerifiedError(ValueError):
+    """Raised when a Google id_token's email is not verified."""
+
+
+class GoogleDomainNotAllowedError(ValueError):
+    """Raised when a Google id_token's `hd` claim is outside the allowed domain."""
+
+
+class GoogleProvider(AuthProvider):
+    """Google Workspace OIDC provider (human SSO only — no M2M)."""
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        cloud_identity_client: CloudIdentityGroupsClient,
+        allowed_hd: str = "",
+        scopes: list[str] | None = None,
+        grant_type: str = "authorization_code",
+    ) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self._cloud_identity_client = cloud_identity_client
+        self.allowed_hd = allowed_hd
+        self.scopes = scopes or ["openid", "email", "profile"]
+        self.grant_type = grant_type
+
+        self.auth_url = _AUTH_URL
+        self.token_url = _TOKEN_URL
+        self.jwks_url = _JWKS_URL
+        self.valid_issuers = _VALID_ISSUERS
+
+        self._jwks_cache: dict[str, Any] | None = None
+        self._jwks_cache_time: float = 0
+        self._jwks_cache_ttl: int = _JWKS_CACHE_TTL_SECONDS
+
+        logger.debug(f"Initialized Google provider with scopes={self.scopes}, allowed_hd={allowed_hd or '(any)'}")
+
+    async def get_jwks(self) -> dict[str, Any]:
+        """Fetch Google's JWKS with a 1-hour TTL cache (mirrors EntraIdProvider)."""
+        current_time = time.time()
+        if self._jwks_cache and (current_time - self._jwks_cache_time) < self._jwks_cache_ttl:
+            logger.debug("Using cached JWKS")
+            return self._jwks_cache
+
+        try:
+            logger.debug(f"Fetching JWKS from {self.jwks_url}")
+            async with httpx.AsyncClient() as client:
+                response = await client.get(self.jwks_url, timeout=10)
+                response.raise_for_status()
+                self._jwks_cache = response.json()
+                self._jwks_cache_time = current_time
+            return self._jwks_cache
+        except Exception as e:
+            logger.error(f"Failed to retrieve JWKS from Google: {e}")
+            raise ValueError(f"Cannot retrieve JWKS: {e}")
+
+    async def _verify_id_token(self, id_token: str) -> dict[str, Any]:
+        """Cryptographically verify a Google id_token and return its claims."""
+        jwks = await self.get_jwks()
+        matching_key = find_matching_jwk(jwks, get_token_kid(id_token))
+        return decode_jwt_with_jwk(
+            id_token,
+            matching_key,
+            algorithms=["RS256"],
+            issuer=list(self.valid_issuers),
+            audience=self.client_id,
+        )
+
+    async def validate_token(self, token: str, **kwargs: Any) -> dict[str, Any]:
+        """Validate a Google id_token and return a standard validation dict."""
+        try:
+            claims = await self._verify_id_token(token)
+            email = claims.get("email")
+            return {
+                "valid": True,
+                "username": email,
+                "email": email,
+                "groups": [],
+                "scopes": [],
+                "client_id": claims.get("aud", self.client_id),
+                "method": "google",
+                "data": claims,
+            }
+        except ExpiredSignatureError:
+            logger.warning("Google token validation failed: token expired")
+            raise ValueError("Token has expired")
+        except InvalidTokenError as e:
+            logger.warning(f"Google token validation failed: {e}")
+            raise ValueError(f"Invalid token: {e}")
+
+    async def get_user_info(self, access_token: str, id_token: str | None = None) -> dict[str, Any]:
+        """Verify the id_token, enforce the login gate, then resolve groups.
+
+        Returns the same shape as ``EntraIdProvider.get_user_info``:
+        ``{"username", "email", "name", "id", "groups"}`` — with ``groups`` set to the
+        list of Cloud Identity group **email addresses**.
+        """
+        if not id_token:
+            raise ValueError("Google login requires an id_token")
+
+        claims = await self._verify_id_token(id_token)
+        email = claims.get("email")
+
+        # Login gate — enforced before any group lookup.
+        if claims.get("email_verified") is not True:
+            raise GoogleEmailNotVerifiedError(f"Email not verified for {email}")
+
+        if self.allowed_hd and claims.get("hd") != self.allowed_hd:
+            raise GoogleDomainNotAllowedError(
+                f"Domain '{claims.get('hd')}' is not the allowed domain '{self.allowed_hd}'"
+            )
+
+        groups = await self._cloud_identity_client.list_transitive_groups_for_member(email)
+
+        return {
+            "username": email,
+            "email": email,
+            "name": claims.get("name"),
+            "id": claims.get("sub"),
+            "groups": [g.email for g in groups],
+        }
+
+    def get_auth_url(self, redirect_uri: str, state: str, scope: str | None = None) -> str:
+        """Build Google's authorization URL, narrowing the account picker via `hd`."""
+        params = {
+            "client_id": self.client_id,
+            "response_type": "code",
+            "scope": scope or " ".join(self.scopes),
+            "redirect_uri": redirect_uri,
+            "state": state,
+        }
+        if self.allowed_hd:
+            # UX nicety only — never a substitute for the server-side hd-claim check.
+            params["hd"] = self.allowed_hd
+        return f"{self.auth_url}?{urlencode(params)}"
+
+    def get_logout_url(self, redirect_uri: str) -> str:
+        """Google has no RP-initiated logout endpoint — return the redirect unchanged."""
+        return redirect_uri
+
+    def exchange_code_for_token(self, code: str, redirect_uri: str) -> dict[str, Any]:
+        """Exchange an authorization code for tokens via Authlib."""
+        try:
+            client = OAuth2Session(
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                token_endpoint=self.token_url,
+                scope=" ".join(self.scopes),
+            )
+            return client.fetch_token(
+                self.token_url,
+                code=code,
+                redirect_uri=redirect_uri,
+                grant_type=self.grant_type,
+            )
+        except Exception as e:
+            logger.error(f"Failed to exchange code for token: {e}")
+            raise ValueError(f"Token exchange failed: {e}")
+
+    async def refresh_token(self, refresh_token: str) -> dict[str, Any]:
+        """Refresh an access token using a refresh token."""
+        try:
+            data = {
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+            }
+            headers = {"Content-Type": "application/x-www-form-urlencoded"}
+            async with httpx.AsyncClient() as client:
+                response = await client.post(self.token_url, data=data, headers=headers, timeout=10)
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPError as e:
+            logger.error(f"Failed to refresh token: {e}")
+            raise ValueError(f"Token refresh failed: {e}")
+
+    async def get_m2m_token(
+        self, client_id: str | None = None, client_secret: str | None = None, scope: str | None = None
+    ) -> dict[str, Any]:
+        raise NotImplementedError("Google does not support machine-to-machine authentication")
+
+    async def validate_m2m_token(self, token: str) -> dict[str, Any]:
+        raise NotImplementedError("Google does not support machine-to-machine authentication")

--- a/auth-server/src/auth_server/providers/google.py
+++ b/auth-server/src/auth_server/providers/google.py
@@ -19,9 +19,6 @@ from .base import AuthProvider
 
 logger = logging.getLogger(__name__)
 
-_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
-_TOKEN_URL = "https://oauth2.googleapis.com/token"
-_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs"
 _VALID_ISSUERS = ("https://accounts.google.com", "accounts.google.com")
 _JWKS_CACHE_TTL_SECONDS = 3600
 
@@ -42,6 +39,9 @@ class GoogleProvider(AuthProvider):
         client_id: str,
         client_secret: str,
         cloud_identity_client: CloudIdentityGroupsClient,
+        auth_url: str,
+        token_url: str,
+        jwks_url: str,
         allowed_hd: str = "",
         scopes: list[str] | None = None,
         grant_type: str = "authorization_code",
@@ -53,9 +53,9 @@ class GoogleProvider(AuthProvider):
         self.scopes = scopes or ["openid", "email", "profile"]
         self.grant_type = grant_type
 
-        self.auth_url = _AUTH_URL
-        self.token_url = _TOKEN_URL
-        self.jwks_url = _JWKS_URL
+        self.auth_url = auth_url
+        self.token_url = token_url
+        self.jwks_url = jwks_url
         self.valid_issuers = _VALID_ISSUERS
 
         self._jwks_cache: dict[str, Any] | None = None

--- a/auth-server/src/auth_server/providers/google.py
+++ b/auth-server/src/auth_server/providers/google.py
@@ -23,6 +23,15 @@ _VALID_ISSUERS = ("https://accounts.google.com", "accounts.google.com")
 _JWKS_CACHE_TTL_SECONDS = 3600
 
 
+def _group_local_part(group_email: str) -> str:
+    """Cloud Identity groups are always email-addressed (``groupKey.id``), but scopes.yml's
+    group_mappings keys are bare, provider-agnostic role names. Take the local part before
+    "@" so a Workspace group like "jarvis-registry-admin@example.com" matches the role name
+    "jarvis-registry-admin" regardless of which Workspace domain it was created in.
+    """
+    return group_email.split("@", 1)[0]
+
+
 class GoogleEmailNotVerifiedError(ValueError):
     """Raised when a Google id_token's email is not verified."""
 
@@ -146,7 +155,7 @@ class GoogleProvider(AuthProvider):
             "email": email,
             "name": claims.get("name"),
             "id": claims.get("sub"),
-            "groups": [g.email for g in groups],
+            "groups": [_group_local_part(g.email) for g in groups],
         }
 
     def get_auth_url(self, redirect_uri: str, state: str, scope: str | None = None) -> str:

--- a/auth-server/src/auth_server/routes/oauth_flow.py
+++ b/auth-server/src/auth_server/routes/oauth_flow.py
@@ -60,6 +60,7 @@ from ..deps import (
 from ..models.client_registration import ClientRegistrationRequest, ClientRegistrationResponse
 from ..models.device_flow import DeviceCodeResponse, DeviceTokenResponse
 from ..providers.base import AuthProvider
+from ..providers.google import GoogleDomainNotAllowedError, GoogleEmailNotVerifiedError
 from ..services.client_registration_service import ClientRegistrationError, ClientRegistrationService
 from ..services.oauth_client_policy import (
     is_registry_client as _is_registry_client,
@@ -286,6 +287,10 @@ def _redirect_to_provider(
         "state": session_data["state"],
         "redirect_uri": callback_uri,
     }
+    # Google's `hd` narrows the account picker to the allowed Workspace domain (UX only —
+    # the authoritative check is the server-side hd-claim validation in GoogleProvider).
+    if provider == "google" and provider_config.get("allowed_hd"):
+        auth_params["hd"] = provider_config["allowed_hd"]
     auth_url = f"{provider_config['auth_url']}?{urlencode(auth_params)}"
 
     response = RedirectResponse(url=auth_url, status_code=302)
@@ -741,8 +746,8 @@ async def get_oauth2_providers(oauth2_config: OAuth2Config = Depends(get_oauth2_
     try:
         enabled = []
         for provider_name, config in cast(dict[str, AuthProviderConfig], oauth2_config["providers"]).items():
-            # Always return one provider that is both enabled and matches that AUTH_PROVIDER env var.
-            if config.get("enabled", False) and provider_name == settings.auth_provider:
+            # Return every enabled provider so the login page can render one button per IdP.
+            if config.get("enabled", False):
                 enabled.append(
                     {"name": provider_name, "display_name": config.get("display_name", provider_name.title())}
                 )
@@ -1140,7 +1145,7 @@ async def oauth2_callback(
                     }
                 else:
                     raise ValueError("No ID token and access token claims unavailable")
-            elif provider == "entra":
+            elif provider in ("entra", "google"):
                 user_info = await auth_provider.get_user_info(
                     access_token=token_data["access_token"], id_token=token_data.get("id_token")
                 )
@@ -1153,7 +1158,15 @@ async def oauth2_callback(
                 }
             else:
                 raise ValueError(f"Unsupported provider {provider}")
-        except (InvalidSignatureError, InvalidTokenError, InvalidIssuerError, InvalidAudienceError):
+        except (
+            InvalidSignatureError,
+            InvalidTokenError,
+            InvalidIssuerError,
+            InvalidAudienceError,
+            GoogleEmailNotVerifiedError,
+            GoogleDomainNotAllowedError,
+        ):
+            # Login-gate rejections must not fall through to the generic userInfo path.
             raise
         except Exception:
             logger.exception("Falling back to userInfo on token parsing error")
@@ -1272,6 +1285,12 @@ async def oauth2_callback(
 
         return _finish_oauth2_callback(token_data, mapped_user, session_data, resolved_scopes, store)
 
+    except GoogleEmailNotVerifiedError:
+        logger.warning(f"Google login rejected: email not verified (provider={provider})")
+        return RedirectResponse(url=f"{error_url}?error=google_email_unverified", status_code=302)
+    except GoogleDomainNotAllowedError:
+        logger.warning(f"Google login rejected: domain not allowed (provider={provider})")
+        return RedirectResponse(url=f"{error_url}?error=google_domain_not_allowed", status_code=302)
     except Exception:
         logger.exception(f"Error in OAuth2 callback for {provider}")
 

--- a/auth-server/src/auth_server/routes/oauth_flow.py
+++ b/auth-server/src/auth_server/routes/oauth_flow.py
@@ -863,7 +863,7 @@ async def consent_page(
             pending.get("resolved_scopes") or [],
             settings.jwt_token_config,
         )
-        scopes = [(name, get_scope_description(name, settings.scopes_file_config)) for name in granted_scopes]
+        scopes = [(name, get_scope_description(name)) for name in granted_scopes]
 
         return HTMLResponse(
             render_consent_page(
@@ -1191,11 +1191,7 @@ async def oauth2_callback(
 
         # Resolve scope: intersection of requested scope and user's default scope
         user_groups = mapped_user.get("groups", [])
-        default_user_scopes = (
-            map_groups_to_scopes(user_groups, settings.scopes_file_config)
-            if user_groups
-            else mapped_user.get("scopes", [])
-        )
+        default_user_scopes = map_groups_to_scopes(user_groups) if user_groups else mapped_user.get("scopes", [])
 
         requested_scope_str = device_data.get("scope") if device_data else session_data.get("requested_scope")
         if requested_scope_str:

--- a/auth-server/src/auth_server/server.py
+++ b/auth-server/src/auth_server/server.py
@@ -108,6 +108,7 @@ async def lifespan(app: FastAPI):
         logger.info("🔄 Shutting down Auth Server...")
         try:
             if hasattr(app.state, "container"):
+                await app.state.container.cloud_identity_client.aclose()
                 del app.state.container
             logger.info("Closing Redis connection...")
             close_redis_client(redis_client)

--- a/auth-server/src/auth_server/services/token_grant_service.py
+++ b/auth-server/src/auth_server/services/token_grant_service.py
@@ -155,7 +155,7 @@ class TokenGrantService:
             "user_id": user_id,
             "groups": user_info.get("groups", []),
             "token_use": ACCESS_USE,
-            "auth_provider": settings.auth_provider,
+            "auth_provider": user_info.get("provider", settings.auth_provider),
         }
         if include_identity_claims:
             extra_claims.update({"name": user_info.get("name"), "idp_id": user_info.get("idp_id")})

--- a/auth-server/src/auth_server/services/token_grant_service.py
+++ b/auth-server/src/auth_server/services/token_grant_service.py
@@ -223,11 +223,7 @@ class TokenGrantService:
         if resolved_scopes is None:
             logger.info("No resolved_scope in auth code, computing from groups (backward compatibility)")
             user_groups = user_info.get("groups", [])
-            resolved_scopes = (
-                map_groups_to_scopes(user_groups, settings.scopes_file_config)
-                if user_groups
-                else user_info.get("scopes", [])
-            )
+            resolved_scopes = map_groups_to_scopes(user_groups) if user_groups else user_info.get("scopes", [])
 
         refresh_token = secrets.token_urlsafe(32)
         response = self._mint_response(

--- a/auth-server/src/auth_server/utils/config_loader.py
+++ b/auth-server/src/auth_server/utils/config_loader.py
@@ -36,6 +36,11 @@ class OAuth2ConfigLoader:
             # Substitute environment variables in configuration
             processed_config = self._substitute_env_vars(config)
 
+            # Coerce every provider's `enabled` to a real bool: substitution turns bool
+            # settings into the string "true"/"false", and the string "false" is truthy.
+            for provider_cfg in processed_config.get("providers", {}).values():
+                provider_cfg["enabled"] = str(provider_cfg.get("enabled", False)).strip().lower() == "true"
+
             # Log loaded providers
             providers = list(processed_config.get("providers", {}).keys())
             logger.info(f"Successfully loaded OAuth2 configuration with providers: {providers}")

--- a/auth-server/tests/integration/test_dual_provider_login.py
+++ b/auth-server/tests/integration/test_dual_provider_login.py
@@ -1,0 +1,93 @@
+"""Dual-provider (Entra + Google) login wiring against the real oauth2_providers.yml.
+
+Guards the demo scenario where both Entra and Google are enabled simultaneously: the
+providers listing, per-provider construction, and the authorization redirect each build
+correctly and independently. No HTTP server or real IdP credentials required.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from itsdangerous import URLSafeTimedSerializer
+
+from auth_server.container import AuthContainer
+from auth_server.core.config import AuthSettings
+from auth_server.providers.entra import EntraIdProvider
+from auth_server.providers.google import GoogleProvider
+from auth_server.routes.oauth_flow import _redirect_to_provider
+
+
+def _demo_settings(**overrides) -> AuthSettings:
+    # Explicit toggles keep the test independent of any local .env; this mirrors a demo env
+    # that sets GOOGLE_ENABLED=true (entra on by default, keycloak/cognito off by default).
+    base = {
+        "keycloak_enabled": "false",
+        "cognito_enabled": "false",
+        "entra_enabled": "true",
+        "google_enabled": "true",
+        "entra_tenant_id": "tenant-abc",
+        "entra_client_id": "entra-client",
+        "entra_client_secret": "entra-secret",
+        "google_client_id": "google-client.apps.googleusercontent.com",
+        "google_client_secret": "google-secret",
+        "google_allowed_hd": "ascending.com",
+        "google_service_account_key_json": "",
+        "secret_key": "demo-secret",
+    }
+    base.update(overrides)
+    return AuthSettings(**base)
+
+
+def _container(**overrides) -> AuthContainer:
+    return AuthContainer(_demo_settings(**overrides), redis_client=Mock())
+
+
+@pytest.mark.integration
+@pytest.mark.auth
+class TestDualProviderLogin:
+    def test_providers_listing_shows_exactly_entra_and_google(self):
+        providers = _container().oauth2_config["providers"]
+        listed = {name for name, cfg in providers.items() if cfg["enabled"]}
+        assert listed == {"entra", "google"}
+
+    def test_keycloak_stays_off_even_if_env_sets_it_true(self):
+        # Toggling KEYCLOAK_ENABLED brings it back — proves the toggle is env-driven, not hardcoded.
+        providers = _container(keycloak_enabled="true").oauth2_config["providers"]
+        listed = {name for name, cfg in providers.items() if cfg["enabled"]}
+        assert listed == {"keycloak", "entra", "google"}
+
+    def test_container_builds_each_provider_independently_and_caches(self):
+        container = _container()
+        entra = container.get_auth_provider("entra")
+        google = container.get_auth_provider("google")
+
+        assert isinstance(entra, EntraIdProvider)
+        assert isinstance(google, GoogleProvider)
+        # Cached per provider so each instance's JWKS cache persists across requests.
+        assert container.get_auth_provider("google") is google
+        assert container.get_auth_provider("entra") is entra
+
+    def test_login_redirect_targets_correct_idp_per_provider(self):
+        providers = _container().oauth2_config["providers"]
+        signer = URLSafeTimedSerializer("demo-secret")
+        session = {"state": "s-1"}
+
+        entra_url = _redirect_to_provider("entra", providers["entra"], session, False, signer).headers["location"]
+        google_url = _redirect_to_provider("google", providers["google"], session, False, signer).headers["location"]
+
+        assert entra_url.startswith("https://login.microsoftonline.com/")
+        assert google_url.startswith("https://accounts.google.com/o/oauth2/v2/auth")
+
+    def test_google_redirect_narrows_account_picker_with_hd(self):
+        providers = _container().oauth2_config["providers"]
+        signer = URLSafeTimedSerializer("demo-secret")
+
+        google_url = _redirect_to_provider("google", providers["google"], {"state": "s-1"}, False, signer).headers[
+            "location"
+        ]
+        entra_url = _redirect_to_provider("entra", providers["entra"], {"state": "s-1"}, False, signer).headers[
+            "location"
+        ]
+
+        assert "hd=ascending.com" in google_url
+        assert "hd=" not in entra_url

--- a/auth-server/tests/integration/test_oauth_callback_token_flow.py
+++ b/auth-server/tests/integration/test_oauth_callback_token_flow.py
@@ -22,6 +22,7 @@ from auth_server.deps import (
     get_token_grant_service,
     get_user_service,
 )
+from auth_server.providers.google import GoogleDomainNotAllowedError, GoogleEmailNotVerifiedError
 from auth_server.server import app
 from auth_server.services.token_grant_service import TokenGrantService
 from registry_pkgs.core.jwt_tokens import MintedManagedAgentToken
@@ -519,6 +520,88 @@ class TestOAuth2CallbackStandardFlow:
         assert response.status_code == 302
         assert "oauth2_callback_failed" in response.headers["location"]
         mock_get_user_info.assert_not_called()
+
+    def _run_google_gate_callback(
+        self,
+        error: Exception,
+        mock_user_service,
+    ):
+        """Drive a Google callback whose get_user_info raises a login-gate error and
+        return the 302 response. The login-gate rejection must surface a specific error
+        code and never fall back to the generic userInfo path."""
+        oauth2_config = {
+            "providers": {
+                "google": {
+                    "enabled": True,
+                    "client_id": "test-client",
+                    "client_secret": "test-secret",
+                    "token_url": "http://google/token",
+                    "user_info_url": "http://google/userinfo",
+                    "username_claim": "email",
+                    "email_claim": "email",
+                    "name_claim": "name",
+                    "groups_claim": None,
+                }
+            }
+        }
+
+        mock_google_provider = MagicMock()
+        mock_google_provider.get_user_info = AsyncMock(side_effect=error)
+
+        with (
+            patch("auth_server.routes.oauth_flow.exchange_code_for_token") as mock_exchange_token,
+            patch("auth_server.routes.oauth_flow.get_user_info") as mock_get_user_info,
+            patch("auth_server.routes.oauth_flow.settings") as mock_settings,
+        ):
+            mock_exchange_token.return_value = {"access_token": "google_access", "id_token": "google_id_token"}
+            mock_settings.registry_url = "http://localhost:3000"
+            mock_settings.registry_error_redirect = "http://localhost:3000/error"
+            mock_settings.auth_server_external_url = "http://localhost:8888"
+            mock_settings.auth_server_url = "http://localhost:8888"
+            mock_settings.auth_server_api_prefix = ""
+            mock_settings.oauth_session_ttl_seconds = 600
+            mock_settings.secret_key = "test-secret-key"
+            mock_settings.oauth2_temp_session_cookie_name = settings.oauth2_temp_session_cookie_name
+            mock_settings.oauth2_consent_nonce_cookie_name = settings.oauth2_consent_nonce_cookie_name
+
+            test_signer = URLSafeTimedSerializer("test-secret-key")
+            app.dependency_overrides = {}
+            app.dependency_overrides[get_oauth_state_store] = lambda: test_oauth_state_store
+            app.dependency_overrides[get_oauth2_config] = lambda: oauth2_config
+            app.dependency_overrides[get_user_service] = lambda: mock_user_service
+            app.dependency_overrides[get_signer] = lambda: test_signer
+            app.dependency_overrides[get_auth_provider] = lambda: mock_google_provider
+
+            test_client = TestClient(app)
+            session_data = {
+                "state": "test-state-google-gate",
+                "client_state": None,
+                "provider": "google",
+                "redirect_uri": "http://localhost:3000/redirect",
+                "client_id": "mock-client-id",
+                "code_challenge": "123",
+                "code_challenge_method": "S256",
+                "client_redirect_uri": "http://localhost:3000/redirect",
+            }
+            test_client.cookies.set(settings.oauth2_temp_session_cookie_name, test_signer.dumps(session_data))
+            response = test_client.get(
+                f"{API_PREFIX}/oauth2/callback/google",
+                params={"code": "google_code", "state": "test-state-google-gate"},
+                follow_redirects=False,
+            )
+
+        mock_get_user_info.assert_not_called()
+        return response
+
+    def test_oauth_callback_google_unverified_email_redirects(self, clear_device_storage, mock_user_service):
+        response = self._run_google_gate_callback(GoogleEmailNotVerifiedError("email not verified"), mock_user_service)
+        assert response.status_code == 302
+        assert "error=google_email_unverified" in response.headers["location"]
+
+    def test_oauth_callback_google_domain_not_allowed_redirects(self, clear_device_storage, mock_user_service):
+        response = self._run_google_gate_callback(GoogleDomainNotAllowedError("domain not allowed"), mock_user_service)
+        assert response.status_code == 302
+        assert "error=google_domain_not_allowed" in response.headers["location"]
 
     @patch("auth_server.routes.oauth_flow.exchange_code_for_token")
     @patch("auth_server.routes.oauth_flow.get_token_kid")

--- a/auth-server/tests/integration/test_oauth_flow_routes.py
+++ b/auth-server/tests/integration/test_oauth_flow_routes.py
@@ -1326,6 +1326,38 @@ class TestDeviceFlowCallbackAndConsent:
         assert "servers-read" not in response.text
 
 
+class TestOAuth2ProvidersListing:
+    def test_returns_every_enabled_provider(self, test_client: TestClient):
+        config = {
+            "providers": {
+                "entra": {"enabled": True, "display_name": "Microsoft Entra ID"},
+                "google": {"enabled": True, "display_name": "Google"},
+                "cognito": {"enabled": False, "display_name": "AWS Cognito"},
+            }
+        }
+        test_client.app.dependency_overrides[get_oauth2_config] = lambda: config
+
+        response = test_client.get(f"{API_PREFIX}/oauth2/providers")
+
+        assert response.status_code == 200
+        names = {p["name"] for p in response.json()["providers"]}
+        assert names == {"entra", "google"}
+
+    def test_omits_disabled_google(self, test_client: TestClient):
+        config = {
+            "providers": {
+                "entra": {"enabled": True, "display_name": "Microsoft Entra ID"},
+                "google": {"enabled": False, "display_name": "Google"},
+            }
+        }
+        test_client.app.dependency_overrides[get_oauth2_config] = lambda: config
+
+        response = test_client.get(f"{API_PREFIX}/oauth2/providers")
+
+        names = {p["name"] for p in response.json()["providers"]}
+        assert names == {"entra"}
+
+
 def _extract_state_from_temp_session(session_cookie: str) -> str:
     signer = URLSafeTimedSerializer("test-secret-key-for-testing")
     session_data = signer.loads(session_cookie)

--- a/auth-server/tests/unit/services/test_token_grant_service.py
+++ b/auth-server/tests/unit/services/test_token_grant_service.py
@@ -265,3 +265,33 @@ async def test_authorization_code_exchange_logs_user_before_redirect_uri_mismatc
     assert response.status_code == 400
     assert b"redirect_uri mismatch" in response.body
     assert "user_id: user-123" in caplog.text
+
+
+def _mint_kwargs(service: TokenGrantService, user_info: dict) -> dict:
+    with patch(
+        "auth_server.services.token_grant_service.mint_managed_agent_token_with_scope",
+        return_value=MintedManagedAgentToken("token", "scope"),
+    ) as mint:
+        service._mint_response(
+            client_id="mcp-client",
+            user_info=user_info,
+            user_id="user-1",
+            requested_scopes="scope",
+            issued_at=int(time.time()),
+            refresh_token="refresh",
+            include_identity_claims=False,
+        )
+    _, kwargs = mint.call_args
+    return kwargs["extra_claims"]
+
+
+def test_mint_response_uses_per_login_provider(service: TokenGrantService) -> None:
+    claims = _mint_kwargs(service, {"username": "u", "groups": [], "provider": "google"})
+    assert claims["auth_provider"] == "google"
+
+
+def test_mint_response_falls_back_to_settings_provider(service: TokenGrantService) -> None:
+    from auth_server.services.token_grant_service import settings
+
+    claims = _mint_kwargs(service, {"username": "u", "groups": []})
+    assert claims["auth_provider"] == settings.auth_provider

--- a/auth-server/tests/unit/test_config_loader.py
+++ b/auth-server/tests/unit/test_config_loader.py
@@ -1,0 +1,50 @@
+import pytest
+
+from auth_server.core.config import AuthSettings
+from auth_server.utils.config_loader import OAuth2ConfigLoader
+
+
+@pytest.mark.unit
+@pytest.mark.auth
+class TestEnabledCoercion:
+    def test_all_providers_enabled_is_real_bool(self):
+        # Substitution yields strings for the toggles; every provider's `enabled` must still
+        # reach downstream consumers as a real bool.
+        providers = OAuth2ConfigLoader(AuthSettings(google_enabled="true", entra_enabled="false")).get_config()[
+            "providers"
+        ]
+
+        for name in ("keycloak", "cognito", "entra", "google"):
+            assert isinstance(providers[name]["enabled"], bool), name
+
+    def test_every_provider_toggle_is_env_driven(self):
+        providers = OAuth2ConfigLoader(
+            AuthSettings(
+                keycloak_enabled="true",
+                cognito_enabled="true",
+                entra_enabled="true",
+                google_enabled="true",
+            )
+        ).get_config()["providers"]
+
+        listed = {name for name, cfg in providers.items() if cfg["enabled"]}
+        assert listed == {"keycloak", "cognito", "entra", "google"}
+
+    def test_demo_case_only_google_and_entra(self):
+        # Demo env: GOOGLE_ENABLED=true; entra on by default; keycloak/cognito off by default.
+        providers = OAuth2ConfigLoader(AuthSettings(google_enabled="true")).get_config()["providers"]
+
+        listed = {name for name, cfg in providers.items() if cfg["enabled"]}
+        assert listed == {"entra", "google"}
+
+    def test_blank_toggle_falls_back_to_default(self):
+        # A blank env value (e.g. `ENTRA_ENABLED=`) is a valid string and must not crash startup;
+        # `${VAR:-default}` then applies the default.
+        providers = OAuth2ConfigLoader(
+            AuthSettings(keycloak_enabled="", cognito_enabled="", entra_enabled="", google_enabled="")
+        ).get_config()["providers"]
+
+        assert providers["entra"]["enabled"] is True  # only entra defaults on
+        assert providers["google"]["enabled"] is False
+        assert providers["keycloak"]["enabled"] is False
+        assert providers["cognito"]["enabled"] is False

--- a/auth-server/tests/unit/test_factory.py
+++ b/auth-server/tests/unit/test_factory.py
@@ -1,0 +1,57 @@
+from unittest.mock import Mock
+
+import pytest
+
+from auth_server.providers.factory import _create_google_provider, get_auth_provider
+from auth_server.providers.google import GoogleProvider
+
+
+def _google_config(**overrides) -> dict:
+    config = {
+        "client_id": "google-client",
+        "client_secret": "google-secret",
+        "scopes": ["openid", "email", "profile"],
+        "grant_type": "authorization_code",
+        "allowed_hd": "corp.example",
+    }
+    config.update(overrides)
+    return config
+
+
+@pytest.mark.unit
+@pytest.mark.auth
+class TestCreateGoogleProvider:
+    def test_constructs_provider_from_config(self):
+        cic = Mock()
+        provider = _create_google_provider(_google_config(), cic)
+
+        assert isinstance(provider, GoogleProvider)
+        assert provider.client_id == "google-client"
+        assert provider.client_secret == "google-secret"
+        assert provider.allowed_hd == "corp.example"
+        assert provider._cloud_identity_client is cic
+
+    def test_defaults_allowed_hd_to_empty(self):
+        provider = _create_google_provider(_google_config(allowed_hd=None) | {"allowed_hd": ""}, Mock())
+        assert provider.allowed_hd == ""
+
+    @pytest.mark.parametrize("missing", ["client_id", "client_secret"])
+    def test_missing_required_config_raises(self, missing):
+        config = _google_config()
+        config[missing] = ""
+
+        with pytest.raises(ValueError, match="Missing required Google configuration"):
+            _create_google_provider(config, Mock())
+
+
+@pytest.mark.unit
+@pytest.mark.auth
+class TestGetAuthProviderDispatch:
+    def test_google_branch_routes_to_google_provider(self):
+        oauth2_config = {"providers": {"google": _google_config()}}
+        provider = get_auth_provider("google", Mock(), oauth2_config, Mock())
+        assert isinstance(provider, GoogleProvider)
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(ValueError, match="Unknown auth provider"):
+            get_auth_provider("nope", Mock(), {"providers": {}}, Mock())

--- a/auth-server/tests/unit/test_factory.py
+++ b/auth-server/tests/unit/test_factory.py
@@ -10,6 +10,9 @@ def _google_config(**overrides) -> dict:
     config = {
         "client_id": "google-client",
         "client_secret": "google-secret",
+        "auth_url": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_url": "https://oauth2.googleapis.com/token",
+        "jwks_url": "https://www.googleapis.com/oauth2/v3/certs",
         "scopes": ["openid", "email", "profile"],
         "grant_type": "authorization_code",
         "allowed_hd": "corp.example",
@@ -30,12 +33,15 @@ class TestCreateGoogleProvider:
         assert provider.client_secret == "google-secret"
         assert provider.allowed_hd == "corp.example"
         assert provider._cloud_identity_client is cic
+        assert provider.auth_url == "https://accounts.google.com/o/oauth2/v2/auth"
+        assert provider.token_url == "https://oauth2.googleapis.com/token"
+        assert provider.jwks_url == "https://www.googleapis.com/oauth2/v3/certs"
 
     def test_defaults_allowed_hd_to_empty(self):
         provider = _create_google_provider(_google_config(allowed_hd=None) | {"allowed_hd": ""}, Mock())
         assert provider.allowed_hd == ""
 
-    @pytest.mark.parametrize("missing", ["client_id", "client_secret"])
+    @pytest.mark.parametrize("missing", ["client_id", "client_secret", "auth_url", "token_url", "jwks_url"])
     def test_missing_required_config_raises(self, missing):
         config = _google_config()
         config[missing] = ""

--- a/auth-server/tests/unit/test_google_provider.py
+++ b/auth-server/tests/unit/test_google_provider.py
@@ -1,0 +1,177 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from auth_server.providers.google import (
+    GoogleDomainNotAllowedError,
+    GoogleEmailNotVerifiedError,
+    GoogleProvider,
+)
+from registry_pkgs.core.jwt_utils import InvalidSignatureError
+from registry_pkgs.google.cloud_identity_client import GoogleWorkspaceGroupInfo
+
+
+def _provider(allowed_hd: str = "") -> GoogleProvider:
+    return GoogleProvider(
+        client_id="client-id",
+        client_secret="client-secret",
+        cloud_identity_client=AsyncMock(),
+        allowed_hd=allowed_hd,
+    )
+
+
+def _claims(**overrides) -> dict:
+    claims = {
+        "email": "user@example.com",
+        "email_verified": True,
+        "name": "Test User",
+        "sub": "google-sub-123",
+        "hd": "example.com",
+        "aud": "client-id",
+    }
+    claims.update(overrides)
+    return claims
+
+
+@pytest.mark.unit
+@pytest.mark.auth
+class TestGoogleGetUserInfo:
+    @pytest.mark.asyncio
+    async def test_returns_group_emails_from_cloud_identity(self):
+        provider = _provider()
+        provider._verify_id_token = AsyncMock(return_value=_claims())
+        provider._cloud_identity_client.list_transitive_groups_for_member = AsyncMock(
+            return_value=[
+                GoogleWorkspaceGroupInfo(email="eng@example.com", display_name="Eng", resource_name="groups/1"),
+                GoogleWorkspaceGroupInfo(email="all@example.com", display_name="All", resource_name="groups/2"),
+            ]
+        )
+
+        info = await provider.get_user_info("access-token", id_token="id-token")
+
+        assert info == {
+            "username": "user@example.com",
+            "email": "user@example.com",
+            "name": "Test User",
+            "id": "google-sub-123",
+            "groups": ["eng@example.com", "all@example.com"],
+        }
+
+    @pytest.mark.asyncio
+    async def test_rejects_unverified_email_before_group_lookup(self):
+        provider = _provider()
+        provider._verify_id_token = AsyncMock(return_value=_claims(email_verified=False))
+
+        with pytest.raises(GoogleEmailNotVerifiedError):
+            await provider.get_user_info("access-token", id_token="id-token")
+
+        provider._cloud_identity_client.list_transitive_groups_for_member.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_mismatched_hd_when_configured(self):
+        provider = _provider(allowed_hd="corp.example")
+        provider._verify_id_token = AsyncMock(return_value=_claims(hd="attacker.com"))
+
+        with pytest.raises(GoogleDomainNotAllowedError):
+            await provider.get_user_info("access-token", id_token="id-token")
+
+        provider._cloud_identity_client.list_transitive_groups_for_member.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_accepts_any_hd_when_unset(self):
+        provider = _provider(allowed_hd="")
+        provider._verify_id_token = AsyncMock(return_value=_claims(hd="anything.com"))
+        provider._cloud_identity_client.list_transitive_groups_for_member = AsyncMock(return_value=[])
+
+        info = await provider.get_user_info("access-token", id_token="id-token")
+
+        assert info["email"] == "user@example.com"
+        assert info["groups"] == []
+
+    @pytest.mark.asyncio
+    async def test_requires_id_token(self):
+        provider = _provider()
+
+        with pytest.raises(ValueError, match="id_token"):
+            await provider.get_user_info("access-token", id_token=None)
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_signature(self):
+        provider = _provider()
+        provider.get_jwks = AsyncMock(return_value={"keys": [{"kid": "kid-1"}]})
+
+        with (
+            patch("auth_server.providers.google.get_token_kid", return_value="kid-1"),
+            patch(
+                "auth_server.providers.google.decode_jwt_with_jwk",
+                side_effect=InvalidSignatureError("bad signature"),
+            ),
+        ):
+            with pytest.raises(InvalidSignatureError):
+                await provider.get_user_info("access-token", id_token="id-token")
+
+
+@pytest.mark.unit
+@pytest.mark.auth
+class TestGoogleVerifyIdToken:
+    @pytest.mark.asyncio
+    async def test_verifies_against_accepted_issuers_and_audience(self):
+        provider = _provider()
+        provider.get_jwks = AsyncMock(return_value={"keys": [{"kid": "kid-1"}]})
+
+        with (
+            patch("auth_server.providers.google.get_token_kid", return_value="kid-1"),
+            patch("auth_server.providers.google.decode_jwt_with_jwk", return_value=_claims()) as mock_decode,
+        ):
+            claims = await provider._verify_id_token("id-token")
+
+        assert claims["email"] == "user@example.com"
+        _, kwargs = mock_decode.call_args
+        assert kwargs["issuer"] == ["https://accounts.google.com", "accounts.google.com"]
+        assert kwargs["audience"] == "client-id"
+
+
+@pytest.mark.unit
+@pytest.mark.auth
+class TestGoogleJwksCaching:
+    @pytest.mark.asyncio
+    async def test_caches_jwks_within_ttl(self):
+        provider = _provider()
+        jwks = {"keys": [{"kid": "kid-1"}]}
+
+        with patch("auth_server.providers.google.httpx.AsyncClient") as mock_client_cls:
+            mock_client = mock_client_cls.return_value.__aenter__.return_value
+            mock_response = AsyncMock()
+            mock_response.json = lambda: jwks
+            mock_response.raise_for_status = lambda: None
+            mock_client.get = AsyncMock(return_value=mock_response)
+
+            first = await provider.get_jwks()
+            second = await provider.get_jwks()
+
+        assert first == jwks
+        assert second == jwks
+        mock_client.get.assert_awaited_once()  # second call served from cache
+
+
+@pytest.mark.unit
+@pytest.mark.auth
+class TestGoogleMisc:
+    def test_auth_url_includes_hd_when_configured(self):
+        url = _provider(allowed_hd="corp.example").get_auth_url("https://cb", "state-1")
+        assert "hd=corp.example" in url
+
+    def test_auth_url_omits_hd_when_unset(self):
+        url = _provider().get_auth_url("https://cb", "state-1")
+        assert "hd=" not in url
+
+    def test_logout_url_returns_redirect_unchanged(self):
+        assert _provider().get_logout_url("https://back") == "https://back"
+
+    @pytest.mark.asyncio
+    async def test_m2m_not_supported(self):
+        provider = _provider()
+        with pytest.raises(NotImplementedError):
+            await provider.get_m2m_token()
+        with pytest.raises(NotImplementedError):
+            await provider.validate_m2m_token("token")

--- a/auth-server/tests/unit/test_google_provider.py
+++ b/auth-server/tests/unit/test_google_provider.py
@@ -6,6 +6,7 @@ from auth_server.providers.google import (
     GoogleDomainNotAllowedError,
     GoogleEmailNotVerifiedError,
     GoogleProvider,
+    _group_local_part,
 )
 from registry_pkgs.core.jwt_utils import InvalidSignatureError
 from registry_pkgs.google.cloud_identity_client import GoogleWorkspaceGroupInfo
@@ -40,7 +41,9 @@ def _claims(**overrides) -> dict:
 @pytest.mark.auth
 class TestGoogleGetUserInfo:
     @pytest.mark.asyncio
-    async def test_returns_group_emails_from_cloud_identity(self):
+    async def test_returns_group_local_parts_from_cloud_identity(self):
+        """Cloud Identity groups are email-addressed, but scopes.yml's group_mappings keys
+        are bare role names — get_user_info must strip the domain before returning groups."""
         provider = _provider()
         provider._verify_id_token = AsyncMock(return_value=_claims())
         provider._cloud_identity_client.list_transitive_groups_for_member = AsyncMock(
@@ -57,7 +60,7 @@ class TestGoogleGetUserInfo:
             "email": "user@example.com",
             "name": "Test User",
             "id": "google-sub-123",
-            "groups": ["eng@example.com", "all@example.com"],
+            "groups": ["eng", "all"],
         }
 
     @pytest.mark.asyncio
@@ -178,3 +181,16 @@ class TestGoogleMisc:
             await provider.get_m2m_token()
         with pytest.raises(NotImplementedError):
             await provider.validate_m2m_token("token")
+
+
+@pytest.mark.unit
+@pytest.mark.auth
+class TestGroupLocalPart:
+    def test_strips_domain(self):
+        assert _group_local_part("jarvis-registry-admin@example.com") == "jarvis-registry-admin"
+
+    def test_strips_only_first_at(self):
+        assert _group_local_part("a@b@example.com") == "a"
+
+    def test_leaves_bare_string_unchanged(self):
+        assert _group_local_part("jarvis-registry-admin") == "jarvis-registry-admin"

--- a/auth-server/tests/unit/test_google_provider.py
+++ b/auth-server/tests/unit/test_google_provider.py
@@ -16,6 +16,9 @@ def _provider(allowed_hd: str = "") -> GoogleProvider:
         client_id="client-id",
         client_secret="client-secret",
         cloud_identity_client=AsyncMock(),
+        auth_url="https://accounts.google.com/o/oauth2/v2/auth",
+        token_url="https://oauth2.googleapis.com/token",
+        jwks_url="https://www.googleapis.com/oauth2/v3/certs",
         allowed_hd=allowed_hd,
     )
 

--- a/auth-server/tests/unit/test_oauth_flow_helpers.py
+++ b/auth-server/tests/unit/test_oauth_flow_helpers.py
@@ -3,9 +3,12 @@
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
+from itsdangerous import URLSafeTimedSerializer
+
 from auth_server.routes.oauth_flow import (
     _is_registered_redirect_uri,
     _redirect_error_to_client,
+    _redirect_to_provider,
     _trusted_error_redirect_uris,
     _validate_known_client_for_redirect,
 )
@@ -91,6 +94,47 @@ def test_trusted_error_redirect_uris_adds_exact_deployment_callback() -> None:
     assert is_safe_unverified_redirect_target(callback, trusted_uris) is True
     assert is_safe_unverified_redirect_target(f"{callback}/", trusted_uris) is False
     assert is_safe_unverified_redirect_target(f"{callback}/extra", trusted_uris) is False
+
+
+def _redirect_to_provider_query(provider: str, provider_config: dict) -> dict:
+    signer = URLSafeTimedSerializer("test-secret")
+    session_data = {"state": "state-1"}
+    with patch("auth_server.routes.oauth_flow.settings") as mock_settings:
+        mock_settings.auth_server_external_url = "http://localhost:8888"
+        mock_settings.auth_server_api_prefix = ""
+        mock_settings.oauth2_temp_session_cookie_name = "oauth2_temp_session"
+        mock_settings.oauth_session_ttl_seconds = 600
+        mock_settings.session_cookie_secure = False
+        response = _redirect_to_provider(provider, provider_config, session_data, is_https=False, signer=signer)
+    return parse_qs(urlparse(response.headers["location"]).query)
+
+
+def _google_config(**overrides) -> dict:
+    config = {
+        "client_id": "google-client",
+        "response_type": "code",
+        "scopes": ["openid", "email", "profile"],
+        "auth_url": "https://accounts.google.com/o/oauth2/v2/auth",
+        "allowed_hd": "corp.example",
+    }
+    config.update(overrides)
+    return config
+
+
+def test_redirect_to_provider_adds_hd_for_google_when_configured() -> None:
+    query = _redirect_to_provider_query("google", _google_config())
+    assert query["hd"] == ["corp.example"]
+
+
+def test_redirect_to_provider_omits_hd_for_google_when_unset() -> None:
+    query = _redirect_to_provider_query("google", _google_config(allowed_hd=""))
+    assert "hd" not in query
+
+
+def test_redirect_to_provider_never_adds_hd_for_non_google() -> None:
+    # allowed_hd on a non-google config must not leak an hd param.
+    query = _redirect_to_provider_query("entra", _google_config())
+    assert "hd" not in query
 
 
 def test_redirect_error_to_client_builds_302_with_oauth_error() -> None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,14 +204,12 @@ services:
       - ENTRA_ROLE_TOKEN_KIND=${ENTRA_ROLE_TOKEN_KIND:-id}
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
       - OTEL_SERVICE_NAME=auth-server
-      - SCOPES_CONFIG_PATH=/app/scopes.yml
       # MongoDB configuration
       - MONGO_URI=mongodb://registry-mongodb:27017/jarvis
     ports:
       - "8888:8888"
     volumes:
       - ./auth-server/logs:/app/logs
-      - ./registry-pkgs/src/registry_pkgs/scopes.yml:/app/scopes.yml
     restart: unless-stopped
     env_file:
       - .env

--- a/docker/Dockerfile.auth
+++ b/docker/Dockerfile.auth
@@ -27,7 +27,6 @@ COPY ./config/metrics/auth_server.yml /app/config/metrics/auth_server.yml
 
 # Point to shared config files
 ENV OTEL_METRICS_CONFIG_PATH=/app/config/metrics/auth_server.yml
-ENV SCOPES_CONFIG_PATH=/app/config/scopes.yml
 
 # Create logs directory
 RUN mkdir -p /app/logs

--- a/docker/Dockerfile.registry
+++ b/docker/Dockerfile.registry
@@ -33,7 +33,6 @@ COPY ./config/metrics/registry.yml /app/config/metrics/registry.yml
 
 # Point to shared config files
 ENV OTEL_METRICS_CONFIG_PATH=/app/config/metrics/registry.yml
-ENV SCOPES_CONFIG_PATH=/app/config/scopes.yml
 
 # Create logs directory
 RUN mkdir -p /app/logs

--- a/registry-pkgs/src/registry_pkgs/access_control.py
+++ b/registry-pkgs/src/registry_pkgs/access_control.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from beanie import PydanticObjectId
 
-from registry_pkgs.models import Group, PrincipalType, User
+from registry_pkgs.models import ExtendedGroup, PrincipalType, User
 
 
 def build_acl_principal_or_clause(
@@ -30,5 +30,5 @@ async def resolve_group_ids_for_user(
     user = await User.get(user_id, session=session)
     if user is None or not user.idOnTheSource:
         return []
-    groups = await Group.find({"memberIds": user.idOnTheSource}, session=session).to_list()
+    groups = await ExtendedGroup.find({"memberIds": user.idOnTheSource}, session=session).to_list()
     return [group.id for group in groups]

--- a/registry-pkgs/src/registry_pkgs/core/config.py
+++ b/registry-pkgs/src/registry_pkgs/core/config.py
@@ -255,6 +255,10 @@ class JarvisBaseSettings(BaseSettings):
     entra_client_id: str | None = None
     entra_client_secret: str | None = None
 
+    # ==================== Google Cloud Identity Groups (service account) ====================
+    # Raw JSON key content for the Workspace Groups Reader service account
+    google_service_account_key_json: str = ""
+
     # ==================== Scopes ====================
     scopes_config_path: str = ""
 

--- a/registry-pkgs/src/registry_pkgs/core/config.py
+++ b/registry-pkgs/src/registry_pkgs/core/config.py
@@ -245,7 +245,7 @@ class JarvisBaseSettings(BaseSettings):
     @field_validator("auth_provider")
     @classmethod
     def validate_auth_provider(cls, v: str) -> str:
-        allowed = ["cognito", "keycloak", "entra"]
+        allowed = ["cognito", "keycloak", "entra", "google"]
         if v.lower() not in allowed:
             raise ValueError(f"auth_provider must be one of {allowed}, got '{v}'")
         return v.lower()

--- a/registry-pkgs/src/registry_pkgs/core/config.py
+++ b/registry-pkgs/src/registry_pkgs/core/config.py
@@ -9,7 +9,7 @@ from cryptography.hazmat.primitives.serialization import load_pem_private_key, l
 from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from .scopes import ScopesConfig, load_scopes_config
+from .scopes import load_scopes_config
 
 INTERACTIVE_TOKEN_CLIENT_ID = "user-generated"
 
@@ -259,9 +259,6 @@ class JarvisBaseSettings(BaseSettings):
     # Raw JSON key content for the Workspace Groups Reader service account
     google_service_account_key_json: str = ""
 
-    # ==================== Scopes ====================
-    scopes_config_path: str = ""
-
     # ==================== Model Validation ====================
     # Skip model validation if set to "disabled". Disabling should only happen for import checks in CI.
     x_jarvis_registry_import_checks: str = "enabled"
@@ -427,12 +424,8 @@ class JarvisBaseSettings(BaseSettings):
         )
 
     @cached_property
-    def scopes_file_config(self) -> ScopesConfig:
-        return ScopesConfig(scopes_config_path=self.scopes_config_path)
-
-    @cached_property
     def scopes_config(self) -> dict[str, Any]:
-        return load_scopes_config(self.scopes_file_config)
+        return load_scopes_config()
 
     @cached_property
     def scopes_list(self) -> list[str]:

--- a/registry-pkgs/src/registry_pkgs/core/scopes.py
+++ b/registry-pkgs/src/registry_pkgs/core/scopes.py
@@ -1,14 +1,14 @@
 """Centralized scopes configuration loader for MCP Gateway services.
 
-This module loads ``scopes.yml`` from an explicit ``ScopesConfig`` object rather than
-reading environment variables directly. Callers provide the config, and the loader
-resolves the file using this priority:
+Loads the package-bundled ``scopes.yml`` — the single source of truth for group-to-scope
+mappings across every deployment. Per-client values never belong in this OSS repo, so this
+module always resolves the file bundled with ``registry-pkgs``; there is no per-deployment
+override path. ``group_mappings`` keys are provider-agnostic role names — each auth
+provider is responsible for converting its own IdP-native group identifiers into these
+names before a group list reaches this module (e.g. Google Workspace groups are
+email-addressed, so ``GoogleProvider`` strips the domain before returning its group list).
 
-1. ``ScopesConfig.scopes_config_path`` when it points to an existing file
-2. The package-bundled ``scopes.yml`` included with ``registry-pkgs``
-
-Configuration is loaded lazily on first use and cached by resolved file path for the
-lifetime of the process. Changes to a loaded ``scopes.yml`` still require a restart.
+Configuration is loaded lazily on first use and cached for the lifetime of the process.
 """
 
 import logging
@@ -16,49 +16,28 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
-_SCOPES_CONFIG_CACHE: dict[str, dict[str, Any]] = {}
+_SCOPES_CONFIG_CACHE: dict[str, Any] | None = None
 
 
-class ScopesConfig(BaseModel):
-    scopes_config_path: str = Field(
-        default="",
-        description="Path to scopes.yml; package-bundled file is used when empty",
-    )
-
-
-def get_scopes_file_path(config: ScopesConfig) -> Path:
-    """Resolve the scopes.yml path from explicit config or the packaged fallback."""
-    if config.scopes_config_path:
-        scopes_path = Path(config.scopes_config_path)
-        if scopes_path.exists():
-            logger.info(f"Using scopes config from SCOPES_CONFIG_PATH: {scopes_path}")
-            return scopes_path
-        logger.warning(f"SCOPES_CONFIG_PATH set to {config.scopes_config_path} but file not found")
-
+def get_scopes_file_path() -> Path:
+    """Resolve the package-bundled scopes.yml path."""
     package_path = Path(__file__).parent.parent / "scopes.yml"
     if package_path.exists():
-        logger.info(f"Using package-bundled scopes config: {package_path}")
         return package_path
 
-    raise FileNotFoundError(
-        "scopes.yml not found. Provide scopes_config_path or ensure scopes.yml is packaged with registry-pkgs."
-    )
+    raise FileNotFoundError("scopes.yml not found; ensure scopes.yml is packaged with registry-pkgs.")
 
 
-def load_scopes_config(config: ScopesConfig) -> dict[str, Any]:
-    """Load scopes configuration from YAML with path-based lazy caching."""
-    if config.scopes_config_path and config.scopes_config_path in _SCOPES_CONFIG_CACHE:
-        return _SCOPES_CONFIG_CACHE[config.scopes_config_path]
+def load_scopes_config() -> dict[str, Any]:
+    """Load scopes configuration from the package-bundled YAML, cached after first load."""
+    global _SCOPES_CONFIG_CACHE
+    if _SCOPES_CONFIG_CACHE is not None:
+        return _SCOPES_CONFIG_CACHE
 
-    scopes_file = get_scopes_file_path(config)
-    cache_key = str(scopes_file.resolve())
-
-    if cache_key in _SCOPES_CONFIG_CACHE:
-        return _SCOPES_CONFIG_CACHE[cache_key]
+    scopes_file = get_scopes_file_path()
 
     try:
         with open(scopes_file) as f:
@@ -70,9 +49,7 @@ def load_scopes_config(config: ScopesConfig) -> dict[str, Any]:
             raise RuntimeError("scopes.yml missing required 'group_mappings' section")
 
         logger.info(f"Loaded scopes config with {len(loaded.get('group_mappings', {}))} group mappings")
-        _SCOPES_CONFIG_CACHE[cache_key] = loaded
-        if config.scopes_config_path:
-            _SCOPES_CONFIG_CACHE[config.scopes_config_path] = loaded
+        _SCOPES_CONFIG_CACHE = loaded
         return loaded
 
     except yaml.YAMLError as e:
@@ -83,9 +60,9 @@ def load_scopes_config(config: ScopesConfig) -> dict[str, Any]:
         raise
 
 
-def map_groups_to_scopes(groups: list[str], config: ScopesConfig) -> list[str]:
-    """Map user groups to OAuth2 scopes using the configured scopes file."""
-    group_mappings = load_scopes_config(config).get("group_mappings", {})
+def map_groups_to_scopes(groups: list[str]) -> list[str]:
+    """Map user groups to OAuth2 scopes using the bundled scopes.yml."""
+    group_mappings = load_scopes_config().get("group_mappings", {})
     scopes: list[str] = []
 
     for group in groups:
@@ -107,7 +84,7 @@ def map_groups_to_scopes(groups: list[str], config: ScopesConfig) -> list[str]:
     return unique_scopes
 
 
-def filter_known_groups(groups: list[str], config: ScopesConfig) -> list[str]:
+def filter_known_groups(groups: list[str]) -> list[str]:
     """Filter a user's raw IdP groups down to those with a scope mapping in scopes.yml.
 
     Groups outside `group_mappings` carry no authorization meaning to this application —
@@ -115,11 +92,11 @@ def filter_known_groups(groups: list[str], config: ScopesConfig) -> list[str]:
     before a group list is minted into a JWT keeps that dead weight out of every session
     cookie instead of transmitting and then ignoring it.
     """
-    group_mappings = load_scopes_config(config).get("group_mappings", {})
+    group_mappings = load_scopes_config().get("group_mappings", {})
     return [group for group in groups if group in group_mappings]
 
 
-def get_scope_description(scope_name: str, config: ScopesConfig) -> str | None:
+def get_scope_description(scope_name: str) -> str | None:
     """Return the lay-person description for a scope, or None if the scope or field is absent."""
-    scope_entry = load_scopes_config(config).get(scope_name)
+    scope_entry = load_scopes_config().get(scope_name)
     return scope_entry.get("description") if isinstance(scope_entry, dict) else None

--- a/registry-pkgs/src/registry_pkgs/database/mongodb.py
+++ b/registry-pkgs/src/registry_pkgs/database/mongodb.py
@@ -13,12 +13,12 @@ from pymongo import AsyncMongoClient
 from ..core.config import MongoConfig
 from ..models import (
     A2AAgent,
+    ExtendedGroup,
     ExtendedMCPServer,
     ExtendedSkill,
     ExtendedSkillFile,
     Federation,
     FederationSyncJob,
-    Group,
     Key,
     NodeRun,
     RegistryAccessRole,
@@ -102,7 +102,7 @@ class MongoDB:
             rebuild_namespace = {
                 "User": User,
                 "RegistryAccessRole": RegistryAccessRole,
-                "Group": Group,
+                "ExtendedGroup": ExtendedGroup,
                 "RegistryAclEntry": RegistryAclEntry,
                 "ExtendedMCPServer": ExtendedMCPServer,
                 "Token": Token,
@@ -117,7 +117,7 @@ class MongoDB:
             }
             User.model_rebuild(_types_namespace=rebuild_namespace)
             RegistryAccessRole.model_rebuild(_types_namespace=rebuild_namespace)
-            Group.model_rebuild(_types_namespace=rebuild_namespace)
+            ExtendedGroup.model_rebuild(_types_namespace=rebuild_namespace)
             RegistryAclEntry.model_rebuild(_types_namespace=rebuild_namespace)
             ExtendedMCPServer.model_rebuild(_types_namespace=rebuild_namespace)
             Token.model_rebuild(_types_namespace=rebuild_namespace)
@@ -136,7 +136,7 @@ class MongoDB:
                 document_models=[
                     User,
                     RegistryAccessRole,
-                    Group,
+                    ExtendedGroup,
                     RegistryAclEntry,
                     ExtendedMCPServer,
                     Token,

--- a/registry-pkgs/src/registry_pkgs/google/__init__.py
+++ b/registry-pkgs/src/registry_pkgs/google/__init__.py
@@ -1,0 +1,6 @@
+from .cloud_identity_client import CloudIdentityGroupsClient, GoogleWorkspaceGroupInfo
+
+__all__ = [
+    "CloudIdentityGroupsClient",
+    "GoogleWorkspaceGroupInfo",
+]

--- a/registry-pkgs/src/registry_pkgs/google/cloud_identity_client.py
+++ b/registry-pkgs/src/registry_pkgs/google/cloud_identity_client.py
@@ -1,0 +1,115 @@
+import json
+import logging
+import time
+
+import httpx
+from pydantic import BaseModel
+
+from registry_pkgs.core.jwt_utils import build_jwt_payload, encode_jwt
+
+logger = logging.getLogger(__name__)
+
+_CLOUD_IDENTITY_BASE_URL = "https://cloudidentity.googleapis.com/v1"
+_GROUPS_READONLY_SCOPE = "https://www.googleapis.com/auth/cloud-identity.groups.readonly"
+_JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+_ASSERTION_TTL_SECONDS = 3600
+_TOKEN_REFRESH_SKEW_SECONDS = 60
+
+
+class GoogleWorkspaceGroupInfo(BaseModel):
+    email: str  # groupKey.id
+    display_name: str
+    resource_name: str  # "groups/{id}"
+
+
+class CloudIdentityGroupsClient:
+    def __init__(self, service_account_key_json: str) -> None:
+        self._key_json = service_account_key_json
+        self._client_email: str | None = None
+        self._private_key: str | None = None
+        self._token_uri: str = "https://oauth2.googleapis.com/token"
+        self._access_token: str | None = None
+        self._token_expiry: float = 0.0
+        self._http = httpx.AsyncClient(timeout=30.0)
+
+    def _load_key(self) -> None:
+        if self._client_email is not None:
+            return
+        if not self._key_json:
+            raise ValueError("google_service_account_key_json is not configured")
+        key = json.loads(self._key_json)
+        self._client_email = key["client_email"]
+        self._private_key = key["private_key"]
+        self._token_uri = key.get("token_uri", self._token_uri)
+
+    async def _get_token(self) -> str:
+        if self._access_token and time.monotonic() < self._token_expiry - _TOKEN_REFRESH_SKEW_SECONDS:
+            return self._access_token
+        self._load_key()
+
+        payload = build_jwt_payload(
+            subject=self._client_email,
+            issuer=self._client_email,
+            audience=self._token_uri,
+            expires_in_seconds=_ASSERTION_TTL_SECONDS,
+            extra_claims={"scope": _GROUPS_READONLY_SCOPE},
+        )
+        assertion = encode_jwt(payload, self._private_key)
+
+        resp = await self._http.post(
+            self._token_uri,
+            data={"grant_type": _JWT_BEARER_GRANT, "assertion": assertion},
+        )
+        if resp.status_code != 200:
+            raise ValueError(f"Failed to acquire Cloud Identity token: {resp.status_code} {resp.text}")
+        data = resp.json()
+        self._access_token = data["access_token"]
+        self._token_expiry = time.monotonic() + data.get("expires_in", _ASSERTION_TTL_SECONDS)
+        return self._access_token
+
+    async def _search_memberships(self, url: str, params: dict) -> list[dict]:
+        """Loop `nextPageToken` until exhausted, returning all raw membership dicts."""
+        token = await self._get_token()
+        headers = {"Authorization": f"Bearer {token}"}
+        memberships: list[dict] = []
+        page_token: str | None = None
+
+        while True:
+            page_params = dict(params)
+            if page_token:
+                page_params["pageToken"] = page_token
+            resp = await self._http.get(url, params=page_params, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+            memberships.extend(data.get("memberships", []))
+            page_token = data.get("nextPageToken")
+            if not page_token:
+                return memberships
+
+    async def list_transitive_groups_for_member(self, member_email: str) -> list[GoogleWorkspaceGroupInfo]:
+        """Paginates groups.memberships.searchTransitiveGroups via nextPageToken."""
+        url = f"{_CLOUD_IDENTITY_BASE_URL}/groups/-/memberships:searchTransitiveGroups"
+        # member_email is a normalized Workspace address (EmailValue-validated upstream); it is
+        # interpolated into the CIG query DSL, so callers must not pass unsanitized input here.
+        params = {"query": f"member_key_id == '{member_email}'"}
+        memberships = await self._search_memberships(url, params)
+        return [
+            GoogleWorkspaceGroupInfo(
+                email=m["groupKey"]["id"],
+                display_name=m.get("displayName", ""),
+                resource_name=m["group"],
+            )
+            for m in memberships
+        ]
+
+    async def list_transitive_members_of_group(self, group_resource_name: str) -> list[str]:
+        """Paginates groups.memberships.searchTransitiveMemberships via nextPageToken."""
+        url = f"{_CLOUD_IDENTITY_BASE_URL}/{group_resource_name}/memberships:searchTransitiveMemberships"
+        memberships = await self._search_memberships(url, params={})
+        emails: list[str] = []
+        for m in memberships:
+            for key in m.get("preferredMemberKey", []):
+                member_id = key.get("id")
+                if member_id:
+                    emails.append(member_id)
+        return emails

--- a/registry-pkgs/src/registry_pkgs/google/cloud_identity_client.py
+++ b/registry-pkgs/src/registry_pkgs/google/cloud_identity_client.py
@@ -3,6 +3,7 @@ import logging
 import time
 
 import httpx
+from httpx import AsyncClient
 from pydantic import BaseModel
 
 from registry_pkgs.core.jwt_utils import build_jwt_payload, encode_jwt
@@ -31,7 +32,17 @@ class CloudIdentityGroupsClient:
         self._token_uri: str = "https://oauth2.googleapis.com/token"
         self._access_token: str | None = None
         self._token_expiry: float = 0.0
-        self._http = httpx.AsyncClient(timeout=30.0)
+        self._http: httpx.AsyncClient | None = None
+
+    def _client(self) -> AsyncClient | None:
+        if self._http is None:
+            self._http = httpx.AsyncClient(timeout=30.0)
+        return self._http
+
+    async def aclose(self) -> None:
+        if self._http is not None:
+            await self._http.aclose()
+            self._http = None
 
     def _load_key(self) -> None:
         if self._client_email is not None:
@@ -57,7 +68,7 @@ class CloudIdentityGroupsClient:
         )
         assertion = encode_jwt(payload, self._private_key)
 
-        resp = await self._http.post(
+        resp = await self._client().post(
             self._token_uri,
             data={"grant_type": _JWT_BEARER_GRANT, "assertion": assertion},
         )
@@ -79,7 +90,7 @@ class CloudIdentityGroupsClient:
             page_params = dict(params)
             if page_token:
                 page_params["pageToken"] = page_token
-            resp = await self._http.get(url, params=page_params, headers=headers)
+            resp = await self._client().get(url, params=page_params, headers=headers)
             resp.raise_for_status()
             data = resp.json()
             memberships.extend(data.get("memberships", []))
@@ -108,7 +119,7 @@ class CloudIdentityGroupsClient:
         """
         token = await self._get_token()
         headers = {"Authorization": f"Bearer {token}"}
-        resp = await self._http.get(f"{_CLOUD_IDENTITY_BASE_URL}/{group_resource_name}", headers=headers)
+        resp = await self._client().get(f"{_CLOUD_IDENTITY_BASE_URL}/{group_resource_name}", headers=headers)
         resp.raise_for_status()
         return resp.json()
 

--- a/registry-pkgs/src/registry_pkgs/google/cloud_identity_client.py
+++ b/registry-pkgs/src/registry_pkgs/google/cloud_identity_client.py
@@ -10,6 +10,7 @@ from registry_pkgs.core.jwt_utils import build_jwt_payload, encode_jwt
 logger = logging.getLogger(__name__)
 
 _CLOUD_IDENTITY_BASE_URL = "https://cloudidentity.googleapis.com/v1"
+_GROUPS_DISCUSSION_FORUM_LABEL = "cloudidentity.googleapis.com/groups.discussion_forum"
 _GROUPS_READONLY_SCOPE = "https://www.googleapis.com/auth/cloud-identity.groups.readonly"
 _JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 _ASSERTION_TTL_SECONDS = 3600
@@ -89,9 +90,7 @@ class CloudIdentityGroupsClient:
     async def list_transitive_groups_for_member(self, member_email: str) -> list[GoogleWorkspaceGroupInfo]:
         """Paginates groups.memberships.searchTransitiveGroups via nextPageToken."""
         url = f"{_CLOUD_IDENTITY_BASE_URL}/groups/-/memberships:searchTransitiveGroups"
-        # member_email is a normalized Workspace address (EmailValue-validated upstream); it is
-        # interpolated into the CIG query DSL, so callers must not pass unsanitized input here.
-        params = {"query": f"member_key_id == '{member_email}'"}
+        params = {"query": f"member_key_id == '{member_email}' && '{_GROUPS_DISCUSSION_FORUM_LABEL}' in labels"}
         memberships = await self._search_memberships(url, params)
         return [
             GoogleWorkspaceGroupInfo(
@@ -101,6 +100,17 @@ class CloudIdentityGroupsClient:
             )
             for m in memberships
         ]
+
+    async def get_group(self, group_resource_name: str) -> dict:
+        """groups.get — GET /v1/{name=groups/*}. Returns the raw group resource dict.
+
+        Unlike the transitive-membership responses, this exposes the group's `description`.
+        """
+        token = await self._get_token()
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = await self._http.get(f"{_CLOUD_IDENTITY_BASE_URL}/{group_resource_name}", headers=headers)
+        resp.raise_for_status()
+        return resp.json()
 
     async def list_transitive_members_of_group(self, group_resource_name: str) -> list[str]:
         """Paginates groups.memberships.searchTransitiveMemberships via nextPageToken."""

--- a/registry-pkgs/src/registry_pkgs/google/cloud_identity_client.py
+++ b/registry-pkgs/src/registry_pkgs/google/cloud_identity_client.py
@@ -34,7 +34,7 @@ class CloudIdentityGroupsClient:
         self._token_expiry: float = 0.0
         self._http: httpx.AsyncClient | None = None
 
-    def _client(self) -> AsyncClient | None:
+    def _client(self) -> AsyncClient:
         if self._http is None:
             self._http = httpx.AsyncClient(timeout=30.0)
         return self._http
@@ -101,7 +101,8 @@ class CloudIdentityGroupsClient:
     async def list_transitive_groups_for_member(self, member_email: str) -> list[GoogleWorkspaceGroupInfo]:
         """Paginates groups.memberships.searchTransitiveGroups via nextPageToken."""
         url = f"{_CLOUD_IDENTITY_BASE_URL}/groups/-/memberships:searchTransitiveGroups"
-        params = {"query": f"member_key_id == '{member_email}' && '{_GROUPS_DISCUSSION_FORUM_LABEL}' in labels"}
+        escaped_email = member_email.replace("\\", "\\\\").replace("'", "\\'")
+        params = {"query": f"member_key_id == '{escaped_email}' && '{_GROUPS_DISCUSSION_FORUM_LABEL}' in labels"}
         memberships = await self._search_memberships(url, params)
         return [
             GoogleWorkspaceGroupInfo(

--- a/registry-pkgs/src/registry_pkgs/models/__init__.py
+++ b/registry-pkgs/src/registry_pkgs/models/__init__.py
@@ -19,6 +19,7 @@ from ._generated import (
 from .a2a_agent import A2AAgent
 from .extended_access_role import RegistryAccessRole
 from .extended_acl_entry import RegistryAclEntry
+from .extended_group import ExtendedGroup
 from .extended_mcp_server import ExtendedMCPServer
 from .extended_skill import ExtendedSkill
 from .extended_skill_file import ExtendedSkillFile
@@ -59,6 +60,7 @@ __all__ = [
     "WorkflowRun",
     "WorkflowSchedule",
     "WorkflowVersion",
+    "ExtendedGroup",
     "Group",
     "User",
     "Key",

--- a/registry-pkgs/src/registry_pkgs/models/__init__.py
+++ b/registry-pkgs/src/registry_pkgs/models/__init__.py
@@ -19,7 +19,7 @@ from ._generated import (
 from .a2a_agent import A2AAgent
 from .extended_access_role import RegistryAccessRole
 from .extended_acl_entry import RegistryAclEntry
-from .extended_group import ExtendedGroup
+from .extended_group import ExtendedGroup, ExtendedGroupSource
 from .extended_mcp_server import ExtendedMCPServer
 from .extended_skill import ExtendedSkill
 from .extended_skill_file import ExtendedSkillFile
@@ -61,6 +61,7 @@ __all__ = [
     "WorkflowSchedule",
     "WorkflowVersion",
     "ExtendedGroup",
+    "ExtendedGroupSource",
     "Group",
     "User",
     "Key",

--- a/registry-pkgs/src/registry_pkgs/models/__init__.py
+++ b/registry-pkgs/src/registry_pkgs/models/__init__.py
@@ -8,7 +8,6 @@ Also exports two enum types `PrincipalType` and `ResourceType`, so that other mo
 """
 
 from ._generated import (
-    Group,
     Key,
     PrincipalType,
     ResourceType,
@@ -62,7 +61,6 @@ __all__ = [
     "WorkflowVersion",
     "ExtendedGroup",
     "ExtendedGroupSource",
-    "Group",
     "User",
     "Key",
     "Token",

--- a/registry-pkgs/src/registry_pkgs/models/extended_group.py
+++ b/registry-pkgs/src/registry_pkgs/models/extended_group.py
@@ -1,0 +1,15 @@
+from enum import StrEnum
+
+from pydantic import Field
+
+from ._generated import Group
+
+
+class ExtendedGroupSource(StrEnum):
+    LOCAL = "local"
+    ENTRA = "entra"
+    GOOGLE = "google"
+
+
+class ExtendedGroup(Group):
+    source: ExtendedGroupSource = Field(default=ExtendedGroupSource.LOCAL)

--- a/registry-pkgs/src/registry_pkgs/oauth/user_service.py
+++ b/registry-pkgs/src/registry_pkgs/oauth/user_service.py
@@ -8,6 +8,8 @@ from registry_pkgs.models import User
 
 logger = logging.getLogger(__name__)
 
+_GOOGLE_PROVIDER = "google"
+
 
 class UserService:
     async def find_by_source_id(self, source_id: str) -> User | None:
@@ -94,20 +96,36 @@ class UserService:
             user_id as string if created, None on error
         """
         try:
+            provider = user_claims.get("auth_provider", "")
+            idp_id = user_claims.get("idp_id")
+            email = user_claims.get("email")
+
+            if provider == _GOOGLE_PROVIDER:
+                # Google is a LibreChat-native provider (Chat's googleStrategy.js sets googleId).
+                # Must use the real email claim — Google's sub is an opaque numeric id.
+                provider_fields: dict = {"provider": _GOOGLE_PROVIDER, "googleId": idp_id}
+                id_on_source = email  # Cloud Identity Groups API is email-keyed — see AS-1826.
+            else:
+                # Entra/Cognito/Keycloak map to Chat's generic openid connect provider.
+                # Fall back to sub when the token omits an email claim, preserving the
+                # pre-existing behavior (sub is email-shaped for these IdPs).
+                email = email or user_claims.get("sub")
+                provider_fields = {"provider": "openid", "openidId": idp_id or ""}
+                id_on_source = idp_id
+
             new_user = User(
                 name=user_claims.get("name"),
                 username=user_claims.get("sub"),
-                email=user_claims.get("sub"),
+                email=email,
                 emailVerified=True,
                 role="USER",
-                provider="openid",
-                openidId="",
-                idOnTheSource=user_claims.get("idp_id"),
+                idOnTheSource=id_on_source,
                 plugins=[],
                 termsAccepted=False,
                 favorites=[],
                 createdAt=datetime.now(UTC),
                 updatedAt=datetime.now(UTC),
+                **provider_fields,
             )
 
             created_user = await new_user.create()

--- a/registry-pkgs/src/registry_pkgs/oauth/user_service.py
+++ b/registry-pkgs/src/registry_pkgs/oauth/user_service.py
@@ -98,18 +98,17 @@ class UserService:
         try:
             provider = user_claims.get("auth_provider", "")
             idp_id = user_claims.get("idp_id")
-            email = user_claims.get("email")
+            # The managed-agent access token never carries a bare "email" claim (see
+            # TokenGrantService._mint_response) — sub is the email-shaped username for every
+            # provider, including Google (GoogleProvider.get_user_info sets username=email;
+            # Google's own opaque numeric sub is carried separately as idp_id).
+            email = user_claims.get("email") or user_claims.get("sub")
 
             if provider == _GOOGLE_PROVIDER:
                 # Google is a LibreChat-native provider (Chat's googleStrategy.js sets googleId).
-                # Must use the real email claim — Google's sub is an opaque numeric id.
                 provider_fields: dict = {"provider": _GOOGLE_PROVIDER, "googleId": idp_id}
                 id_on_source = email  # Cloud Identity Groups API is email-keyed — see AS-1826.
             else:
-                # Entra/Cognito/Keycloak map to Chat's generic openid connect provider.
-                # Fall back to sub when the token omits an email claim, preserving the
-                # pre-existing behavior (sub is email-shaped for these IdPs).
-                email = email or user_claims.get("sub")
                 provider_fields = {"provider": "openid", "openidId": idp_id or ""}
                 id_on_source = idp_id
 

--- a/registry-pkgs/tests/unit/google/test_cloud_identity_client.py
+++ b/registry-pkgs/tests/unit/google/test_cloud_identity_client.py
@@ -57,7 +57,9 @@ async def test_list_groups_paginates_and_maps():
     assert groups[1].display_name == "G2"
     assert client._http.get.await_count == 2
     calls = client._http.get.await_args_list
-    assert calls[0].kwargs["params"]["query"] == "member_key_id == 'ada@x.com'"
+    assert calls[0].kwargs["params"]["query"] == (
+        "member_key_id == 'ada@x.com' && 'cloudidentity.googleapis.com/groups.discussion_forum' in labels"
+    )
     assert calls[1].kwargs["params"]["pageToken"] == "abc"
 
 

--- a/registry-pkgs/tests/unit/google/test_cloud_identity_client.py
+++ b/registry-pkgs/tests/unit/google/test_cloud_identity_client.py
@@ -1,0 +1,118 @@
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from registry_pkgs.google.cloud_identity_client import CloudIdentityGroupsClient
+
+pytestmark = pytest.mark.asyncio
+
+
+def _sa_key_json() -> str:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    return json.dumps(
+        {
+            "client_email": "sa@proj.iam.gserviceaccount.com",
+            "private_key": pem,
+            "token_uri": "https://oauth2.googleapis.com/token",
+        }
+    )
+
+
+def _resp(json_data: dict, status: int = 200):
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = json_data
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def _client_with_token() -> CloudIdentityGroupsClient:
+    client = CloudIdentityGroupsClient(_sa_key_json())
+    client._http = MagicMock()
+    client._http.post = AsyncMock(return_value=_resp({"access_token": "tok", "expires_in": 3600}))
+    return client
+
+
+async def test_list_groups_paginates_and_maps():
+    client = _client_with_token()
+    page1 = {
+        "memberships": [{"group": "groups/1", "groupKey": {"id": "g1@x.com"}, "displayName": "G1"}],
+        "nextPageToken": "abc",
+    }
+    page2 = {"memberships": [{"group": "groups/2", "groupKey": {"id": "g2@x.com"}, "displayName": "G2"}]}
+    client._http.get = AsyncMock(side_effect=[_resp(page1), _resp(page2)])
+
+    groups = await client.list_transitive_groups_for_member("ada@x.com")
+
+    assert [g.email for g in groups] == ["g1@x.com", "g2@x.com"]
+    assert groups[0].resource_name == "groups/1"
+    assert groups[1].display_name == "G2"
+    assert client._http.get.await_count == 2
+    calls = client._http.get.await_args_list
+    assert calls[0].kwargs["params"]["query"] == "member_key_id == 'ada@x.com'"
+    assert calls[1].kwargs["params"]["pageToken"] == "abc"
+
+
+async def test_list_members_extracts_emails():
+    client = _client_with_token()
+    page = {
+        "memberships": [
+            {"preferredMemberKey": [{"id": "a@x.com"}]},
+            {"preferredMemberKey": [{"id": "b@x.com"}]},
+        ]
+    }
+    client._http.get = AsyncMock(return_value=_resp(page))
+
+    members = await client.list_transitive_members_of_group("groups/1")
+
+    assert members == ["a@x.com", "b@x.com"]
+
+
+async def test_token_is_cached_across_calls():
+    client = _client_with_token()
+    client._http.get = AsyncMock(return_value=_resp({"memberships": []}))
+
+    await client.list_transitive_groups_for_member("a@x.com")
+    await client.list_transitive_members_of_group("groups/1")
+
+    assert client._http.post.await_count == 1  # minted once, reused
+
+
+async def test_token_refreshes_when_expired():
+    client = _client_with_token()
+    client._http.get = AsyncMock(return_value=_resp({"memberships": []}))
+
+    await client.list_transitive_groups_for_member("a@x.com")
+    client._token_expiry = 0.0  # force expiry
+    await client.list_transitive_groups_for_member("a@x.com")
+
+    assert client._http.post.await_count == 2
+
+
+async def test_empty_key_construction_does_not_raise():
+    # Entra-only/Cognito deployments construct the client with an empty key at startup.
+    client = CloudIdentityGroupsClient("")
+    assert client._client_email is None  # not parsed eagerly
+
+
+async def test_empty_key_raises_on_first_use():
+    client = CloudIdentityGroupsClient("")
+    with pytest.raises(ValueError):
+        await client.list_transitive_groups_for_member("a@x.com")
+
+
+async def test_token_failure_raises():
+    client = CloudIdentityGroupsClient(_sa_key_json())
+    client._http = MagicMock()
+    client._http.post = AsyncMock(return_value=_resp({"error": "bad"}, status=401))
+
+    with pytest.raises(ValueError):
+        await client.list_transitive_groups_for_member("a@x.com")

--- a/registry-pkgs/tests/unit/google/test_cloud_identity_client.py
+++ b/registry-pkgs/tests/unit/google/test_cloud_identity_client.py
@@ -118,3 +118,24 @@ async def test_token_failure_raises():
 
     with pytest.raises(ValueError):
         await client.list_transitive_groups_for_member("a@x.com")
+
+
+async def test_client_and_http_are_lazy():
+    client = CloudIdentityGroupsClient("")
+    assert client._http is None
+    assert client._client() is client._http is not None
+
+
+async def test_aclose_is_noop_when_never_used():
+    client = CloudIdentityGroupsClient("")
+    await client.aclose()  # must not raise
+    assert client._http is None
+
+
+async def test_aclose_closes_and_resets_http():
+    client = CloudIdentityGroupsClient("")
+    mock_http = AsyncMock()
+    client._http = mock_http
+    await client.aclose()
+    mock_http.aclose.assert_awaited_once()
+    assert client._http is None

--- a/registry-pkgs/tests/unit/models/test_extended_group.py
+++ b/registry-pkgs/tests/unit/models/test_extended_group.py
@@ -1,0 +1,29 @@
+import pytest
+from pydantic import ValidationError
+
+from registry_pkgs.models import ExtendedGroup
+from registry_pkgs.models.extended_group import ExtendedGroupSource
+
+
+@pytest.fixture(autouse=True)
+def _no_collection(monkeypatch):
+    monkeypatch.setattr(ExtendedGroup, "get_pymongo_collection", classmethod(lambda cls: None))
+
+
+@pytest.mark.parametrize("value", ["local", "entra", "google"])
+def test_source_accepts_supported_values(value):
+    group = ExtendedGroup.model_validate({"name": "g", "source": value})
+    assert group.source == ExtendedGroupSource(value)
+
+
+def test_source_defaults_to_local():
+    assert ExtendedGroup.model_validate({"name": "g"}).source == ExtendedGroupSource.LOCAL
+
+
+def test_source_rejects_unknown_value():
+    with pytest.raises(ValidationError):
+        ExtendedGroup.model_validate({"name": "g", "source": "okta"})
+
+
+def test_inherits_groups_collection():
+    assert ExtendedGroup.Settings.name == "groups"

--- a/registry-pkgs/tests/unit/oauth/test_user_service.py
+++ b/registry-pkgs/tests/unit/oauth/test_user_service.py
@@ -1,0 +1,76 @@
+import pytest
+
+from registry_pkgs.models import User
+from registry_pkgs.oauth.user_service import UserService
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _fake_create(self):
+    """Stand in for Beanie's DB-backed create(); returns the constructed document."""
+    return self
+
+
+@pytest.fixture(autouse=True)
+def _patch_user(monkeypatch):
+    # Construct User documents without Beanie init, and stub the DB write.
+    monkeypatch.setattr(User, "get_pymongo_collection", classmethod(lambda cls: None))
+    monkeypatch.setattr(User, "create", _fake_create)
+
+
+async def test_create_google_user_sets_native_fields():
+    claims = {
+        "auth_provider": "google",
+        "name": "Ada",
+        "sub": "108273456789",  # opaque numeric — must NOT be used as email
+        "idp_id": "108273456789",
+        "email": "ada@example.com",
+    }
+    user = await UserService().create_user(claims)
+    assert user is not None
+    assert user.provider == "google"
+    assert user.googleId == "108273456789"
+    assert user.openidId is None
+    assert user.email == "ada@example.com"
+    assert user.idOnTheSource == "ada@example.com"
+    assert user.username == "108273456789"
+
+
+async def test_create_openid_user_populates_openid_id():
+    claims = {
+        "auth_provider": "entra",
+        "name": "Bob",
+        "sub": "bob@example.com",
+        "idp_id": "entra-oid-123",
+        "email": "bob@example.com",
+    }
+    user = await UserService().create_user(claims)
+    assert user is not None
+    assert user.provider == "openid"
+    assert user.openidId == "entra-oid-123"  # regression: no longer hardcoded ""
+    assert user.googleId is None
+    assert user.email == "bob@example.com"
+    assert user.idOnTheSource == "entra-oid-123"
+
+
+async def test_openid_user_without_email_claim_falls_back_to_sub():
+    claims = {
+        "auth_provider": "entra",
+        "sub": "dave@example.com",
+        "idp_id": "entra-oid-456",
+    }
+    user = await UserService().create_user(claims)
+    assert user is not None
+    assert user.email == "dave@example.com"
+
+
+async def test_google_user_with_opaque_sub_uses_email_not_sub():
+    claims = {
+        "auth_provider": "google",
+        "sub": "1234567890",
+        "idp_id": "1234567890",
+        "email": "carol@example.com",
+    }
+    user = await UserService().create_user(claims)
+    assert user is not None
+    assert user.email == "carol@example.com"

--- a/registry-pkgs/tests/unit/oauth/test_user_service.py
+++ b/registry-pkgs/tests/unit/oauth/test_user_service.py
@@ -74,3 +74,19 @@ async def test_google_user_with_opaque_sub_uses_email_not_sub():
     user = await UserService().create_user(claims)
     assert user is not None
     assert user.email == "carol@example.com"
+
+
+async def test_google_user_without_email_claim_falls_back_to_sub():
+    """Regression test: the managed-agent access token never carries an "email" claim
+    (see TokenGrantService._mint_response), and GoogleProvider.get_user_info sets the
+    JWT's sub to the verified email — not Google's own opaque numeric sub (that's idp_id)."""
+    claims = {
+        "auth_provider": "google",
+        "sub": "kent.xue@famulei.us",
+        "idp_id": "100718105552674358884",
+    }
+    user = await UserService().create_user(claims)
+    assert user is not None
+    assert user.email == "kent.xue@famulei.us"
+    assert user.idOnTheSource == "kent.xue@famulei.us"
+    assert user.googleId == "100718105552674358884"

--- a/registry-pkgs/tests/unit/test_access_control.py
+++ b/registry-pkgs/tests/unit/test_access_control.py
@@ -1,0 +1,49 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from beanie import PydanticObjectId
+
+from registry_pkgs import access_control
+
+pytestmark = pytest.mark.asyncio
+
+
+def _group(gid, source):
+    g = MagicMock()
+    g.id = gid
+    g.source = source
+    return g
+
+
+async def test_returns_empty_when_user_missing():
+    with patch.object(access_control.User, "get", AsyncMock(return_value=None)):
+        result = await access_control.resolve_group_ids_for_user(PydanticObjectId())
+    assert result == []
+
+
+async def test_returns_empty_when_user_has_no_source_id():
+    user = MagicMock()
+    user.idOnTheSource = None
+    with patch.object(access_control.User, "get", AsyncMock(return_value=user)):
+        result = await access_control.resolve_group_ids_for_user(PydanticObjectId())
+    assert result == []
+
+
+async def test_resolves_group_ids_including_google_source():
+    user = MagicMock()
+    user.id = PydanticObjectId()
+    user.idOnTheSource = "ada@example.com"
+    g1, g2 = PydanticObjectId(), PydanticObjectId()
+    groups = [_group(g1, "google"), _group(g2, "entra")]
+
+    query = MagicMock()
+    query.to_list = AsyncMock(return_value=groups)
+    with (
+        patch.object(access_control.User, "get", AsyncMock(return_value=user)),
+        patch.object(access_control.ExtendedGroup, "find", MagicMock(return_value=query)) as find,
+    ):
+        result = await access_control.resolve_group_ids_for_user(user.id)
+
+    assert result == [g1, g2]
+    find.assert_called_once()
+    assert find.call_args.args[0] == {"memberIds": "ada@example.com"}

--- a/registry-pkgs/tests/unit/test_mongodb.py
+++ b/registry-pkgs/tests/unit/test_mongodb.py
@@ -115,7 +115,7 @@ class TestMongoDBConnection:
 
             assert "User" in model_names
             assert "RegistryAccessRole" in model_names
-            assert "Group" in model_names
+            assert "ExtendedGroup" in model_names
             assert "RegistryAclEntry" in model_names
             assert "ExtendedMCPServer" in model_names
             assert "Token" in model_names

--- a/registry-pkgs/tests/unit/test_scopes.py
+++ b/registry-pkgs/tests/unit/test_scopes.py
@@ -8,8 +8,7 @@ import pytest
 import yaml
 
 from registry_pkgs.core import scopes
-from registry_pkgs.core.config import ScopesConfig
-from registry_pkgs.core.scopes import filter_known_groups, get_scope_description
+from registry_pkgs.core.scopes import filter_known_groups, get_scope_description, map_groups_to_scopes
 
 
 @pytest.fixture
@@ -38,16 +37,6 @@ def valid_scopes_config():
 
 
 @pytest.fixture
-def invalid_scopes_config_no_group_mappings():
-    """Invalid scopes configuration missing group_mappings."""
-    return {
-        "servers-read": [
-            {"action": "list_servers", "method": "GET", "endpoint": "/servers"},
-        ],
-    }
-
-
-@pytest.fixture
 def temp_scopes_file(valid_scopes_config):
     """Create a temporary scopes.yml file for testing."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
@@ -65,38 +54,26 @@ def temp_scopes_file(valid_scopes_config):
 def reset_scopes_cache():
     """Reset the module-level scopes cache before and after each test."""
     original_cache = scopes._SCOPES_CONFIG_CACHE
-    scopes._SCOPES_CONFIG_CACHE = {}
+    scopes._SCOPES_CONFIG_CACHE = None
 
     yield
 
     scopes._SCOPES_CONFIG_CACHE = original_cache
 
 
-def _scopes_config(path: str = "") -> ScopesConfig:
-    return ScopesConfig(scopes_config_path=path)
+@pytest.fixture
+def use_temp_scopes_file(temp_scopes_file, reset_scopes_cache):
+    """Point the module at a temp scopes.yml instead of the package-bundled one."""
+    with patch("registry_pkgs.core.scopes.get_scopes_file_path", return_value=temp_scopes_file):
+        yield temp_scopes_file
 
 
 class TestGetScopesFilePath:
     """Tests for get_scopes_file_path() function."""
 
-    def test_uses_scopes_config_path_from_settings_when_set(self, temp_scopes_file, reset_scopes_cache):
-        """Test that SCOPES_CONFIG_PATH from settings is used when set and file exists."""
-        result = scopes.get_scopes_file_path(_scopes_config(str(temp_scopes_file)))
-        assert result == temp_scopes_file
-        assert result.exists()
-
-    def test_warns_when_scopes_config_path_set_but_file_not_found(self, reset_scopes_cache):
-        """Test that a warning is logged when SCOPES_CONFIG_PATH is set but file doesn't exist."""
-        with patch("registry_pkgs.core.scopes.logger") as mock_logger:
-            with patch.object(Path, "exists", return_value=False):
-                with pytest.raises(FileNotFoundError):
-                    scopes.get_scopes_file_path(_scopes_config("/nonexistent/path/scopes.yml"))
-                mock_logger.warning.assert_called_once()
-                assert "/nonexistent/path/scopes.yml" in str(mock_logger.warning.call_args)
-
-    def test_uses_package_bundled_file_when_env_var_not_set(self, reset_scopes_cache):
-        """Test that package-bundled scopes.yml is used when SCOPES_CONFIG_PATH is not set."""
-        result = scopes.get_scopes_file_path(_scopes_config())
+    def test_returns_package_bundled_path(self, reset_scopes_cache):
+        """The package-bundled scopes.yml is always used — there is no override."""
+        result = scopes.get_scopes_file_path()
         expected_path = Path(scopes.__file__).parent.parent / "scopes.yml"
         assert result == expected_path
         assert result.exists()
@@ -105,26 +82,25 @@ class TestGetScopesFilePath:
         """Test that FileNotFoundError is raised when scopes.yml cannot be found."""
         with patch.object(Path, "exists", return_value=False):
             with pytest.raises(FileNotFoundError) as exc_info:
-                scopes.get_scopes_file_path(_scopes_config())
+                scopes.get_scopes_file_path()
             assert "scopes.yml not found" in str(exc_info.value)
 
 
 class TestLoadScopesConfig:
     """Tests for load_scopes_config() function."""
 
-    def test_loads_valid_scopes_config_successfully(self, temp_scopes_file, valid_scopes_config, reset_scopes_cache):
+    def test_loads_valid_scopes_config_successfully(self, use_temp_scopes_file, valid_scopes_config):
         """Test that a valid scopes configuration is loaded successfully."""
-        result = scopes.load_scopes_config(_scopes_config(str(temp_scopes_file)))
+        result = scopes.load_scopes_config()
         assert result == valid_scopes_config
         assert "group_mappings" in result
         assert "servers-read" in result
         assert "servers-write" in result
 
-    def test_caches_loaded_config(self, temp_scopes_file, reset_scopes_cache):
+    def test_caches_loaded_config(self, use_temp_scopes_file):
         """Test that configuration is cached after first load."""
-        config = _scopes_config(str(temp_scopes_file))
-        result1 = scopes.load_scopes_config(config)
-        result2 = scopes.load_scopes_config(config)
+        result1 = scopes.load_scopes_config()
+        result2 = scopes.load_scopes_config()
 
         assert result1 is result2
         assert scopes._SCOPES_CONFIG_CACHE
@@ -137,8 +113,9 @@ class TestLoadScopesConfig:
             temp_path = Path(f.name)
 
         try:
-            with pytest.raises(RuntimeError) as exc_info:
-                scopes.load_scopes_config(_scopes_config(str(temp_path)))
+            with patch("registry_pkgs.core.scopes.get_scopes_file_path", return_value=temp_path):
+                with pytest.raises(RuntimeError) as exc_info:
+                    scopes.load_scopes_config()
             assert "Invalid scopes configuration" in str(exc_info.value)
             assert "expected dict" in str(exc_info.value)
         finally:
@@ -152,8 +129,9 @@ class TestLoadScopesConfig:
             temp_path = Path(f.name)
 
         try:
-            with pytest.raises(RuntimeError) as exc_info:
-                scopes.load_scopes_config(_scopes_config(str(temp_path)))
+            with patch("registry_pkgs.core.scopes.get_scopes_file_path", return_value=temp_path):
+                with pytest.raises(RuntimeError) as exc_info:
+                    scopes.load_scopes_config()
             assert "missing required 'group_mappings' section" in str(exc_info.value)
         finally:
             temp_path.unlink()
@@ -166,8 +144,9 @@ class TestLoadScopesConfig:
             temp_path = Path(f.name)
 
         try:
-            with pytest.raises(RuntimeError) as exc_info:
-                scopes.load_scopes_config(_scopes_config(str(temp_path)))
+            with patch("registry_pkgs.core.scopes.get_scopes_file_path", return_value=temp_path):
+                with pytest.raises(RuntimeError) as exc_info:
+                    scopes.load_scopes_config()
             assert "Invalid YAML" in str(exc_info.value)
         finally:
             temp_path.unlink()
@@ -177,12 +156,12 @@ class TestLoadScopesConfig:
         with patch("registry_pkgs.core.scopes.get_scopes_file_path") as mock_get_path:
             mock_get_path.side_effect = FileNotFoundError("scopes.yml not found")
             with pytest.raises(FileNotFoundError):
-                scopes.load_scopes_config(_scopes_config())
+                scopes.load_scopes_config()
 
-    def test_logs_successful_load_with_group_count(self, temp_scopes_file, reset_scopes_cache):
+    def test_logs_successful_load_with_group_count(self, use_temp_scopes_file):
         """Test that successful load is logged with group mapping count."""
         with patch("registry_pkgs.core.scopes.logger") as mock_logger:
-            scopes.load_scopes_config(_scopes_config(str(temp_scopes_file)))
+            scopes.load_scopes_config()
             info_calls = [str(call) for call in mock_logger.info.call_args_list]
             assert any("2 group mappings" in call for call in info_calls)
 
@@ -190,18 +169,18 @@ class TestLoadScopesConfig:
 class TestScopesConfigStructure:
     """Tests for scopes configuration structure validation."""
 
-    def test_validates_group_mappings_structure(self, temp_scopes_file, reset_scopes_cache):
+    def test_validates_group_mappings_structure(self, use_temp_scopes_file):
         """Test that group_mappings has expected structure."""
-        config = scopes.load_scopes_config(_scopes_config(str(temp_scopes_file)))
+        config = scopes.load_scopes_config()
         assert "group_mappings" in config
         assert isinstance(config["group_mappings"], dict)
         for group_name, group_scopes in config["group_mappings"].items():
             assert isinstance(group_name, str)
             assert isinstance(group_scopes, list)
 
-    def test_validates_scope_definitions_structure(self, temp_scopes_file, reset_scopes_cache):
+    def test_validates_scope_definitions_structure(self, use_temp_scopes_file):
         """Test that scope definitions have expected structure."""
-        config = scopes.load_scopes_config(_scopes_config(str(temp_scopes_file)))
+        config = scopes.load_scopes_config()
         for key, value in config.items():
             if key != "group_mappings":
                 assert isinstance(value, dict)
@@ -214,29 +193,6 @@ class TestScopesConfigStructure:
                     assert "endpoint" in action
 
 
-class TestModuleImportPreloading:
-    """Tests for module-level preloading behavior."""
-
-    def test_preloads_config_on_module_import(self):
-        """Test that configuration is preloaded when module is imported.
-
-        Note: This test is more of a documentation of expected behavior.
-        The actual preloading happens at module import time, which is before tests run.
-        """
-        # If we got here, the module imported successfully, meaning preload didn't fail
-        assert True  # Cache may or may not be populated depending on test order
-
-    def test_module_import_fails_if_scopes_not_found(self):
-        """Test that module import should fail if scopes.yml cannot be found.
-
-        Note: This is tested implicitly - if scopes.yml is missing during actual import,
-        the module will fail to import and tests won't run.
-        """
-        # This test documents expected behavior
-        # In production, if scopes.yml is missing, the service won't start (fail-fast)
-        pass
-
-
 class TestEdgeCases:
     """Tests for edge cases and error conditions."""
 
@@ -247,7 +203,8 @@ class TestEdgeCases:
             temp_path = Path(f.name)
 
         try:
-            result = scopes.load_scopes_config(_scopes_config(str(temp_path)))
+            with patch("registry_pkgs.core.scopes.get_scopes_file_path", return_value=temp_path):
+                result = scopes.load_scopes_config()
             assert result["group_mappings"] == {}
         finally:
             temp_path.unlink()
@@ -259,37 +216,17 @@ class TestEdgeCases:
             temp_path = Path(f.name)
 
         try:
-            result = scopes.load_scopes_config(_scopes_config(str(temp_path)))
+            with patch("registry_pkgs.core.scopes.get_scopes_file_path", return_value=temp_path):
+                result = scopes.load_scopes_config()
             assert result["servers-read"] == []
         finally:
             temp_path.unlink()
 
-    def test_handles_relative_scopes_config_path(self, valid_scopes_config, reset_scopes_cache, tmp_path):
-        """Test that relative paths in SCOPES_CONFIG_PATH are resolved correctly."""
-        # Create a temp file in a subdirectory of tmp_path (which is under project)
-        temp_dir = tmp_path / "config"
-        temp_dir.mkdir()
-        temp_file = temp_dir / "test_scopes.yml"
-        with open(temp_file, "w") as f:
-            yaml.dump(valid_scopes_config, f)
-
-        # Create a relative path from current directory
-        try:
-            relative_path = temp_file.relative_to(Path.cwd())
-        except ValueError:
-            # If tmp_path is not under cwd, just use the absolute path for this test
-            relative_path = temp_file
-
-        result = scopes.get_scopes_file_path(_scopes_config(str(relative_path)))
-        assert result == Path(relative_path)
-        assert result.exists()
-
-    def test_cache_persists_across_calls(self, temp_scopes_file, reset_scopes_cache):
-        """Test that cache persists and prevents re-reading file."""
-        config = _scopes_config(str(temp_scopes_file))
-        result1 = scopes.load_scopes_config(config)
-        temp_scopes_file.unlink()
-        result2 = scopes.load_scopes_config(config)
+    def test_cache_persists_after_file_deleted(self, use_temp_scopes_file):
+        """Test that cache persists and prevents re-reading the file."""
+        result1 = scopes.load_scopes_config()
+        use_temp_scopes_file.unlink()
+        result2 = scopes.load_scopes_config()
         assert result1 is result2
         assert result2 is not None
 
@@ -297,19 +234,15 @@ class TestEdgeCases:
 class TestMapGroupsToScopes:
     """Tests for map_groups_to_scopes function."""
 
-    def test_maps_known_group(self, temp_scopes_file, reset_scopes_cache):
+    def test_maps_known_group(self, use_temp_scopes_file):
         """Known groups are resolved to their configured scopes."""
-        config = _scopes_config(str(temp_scopes_file))
-        scopes.load_scopes_config(config)
-        result = scopes.map_groups_to_scopes(["admin"], config)
+        result = map_groups_to_scopes(["admin"])
 
         assert result == ["servers-read", "servers-write"]
 
-    def test_unknown_group_returns_empty(self, temp_scopes_file, reset_scopes_cache):
+    def test_unknown_group_returns_empty(self, use_temp_scopes_file):
         """Unknown groups produce no scopes."""
-        config = _scopes_config(str(temp_scopes_file))
-        scopes.load_scopes_config(config)
-        result = scopes.map_groups_to_scopes(["unknown-group"], config)
+        result = map_groups_to_scopes(["unknown-group"])
 
         assert result == []
 
@@ -327,27 +260,22 @@ class TestMapGroupsToScopes:
             temp_path = Path(f.name)
 
         try:
-            config_obj = _scopes_config(str(temp_path))
-            scopes.load_scopes_config(config_obj)
-            result = scopes.map_groups_to_scopes(["group-a", "group-b"], config_obj)
+            with patch("registry_pkgs.core.scopes.get_scopes_file_path", return_value=temp_path):
+                result = map_groups_to_scopes(["group-a", "group-b"])
 
             assert result == ["scope1", "scope2", "scope3"]
         finally:
             temp_path.unlink()
 
-    def test_empty_groups_list(self, temp_scopes_file, reset_scopes_cache):
+    def test_empty_groups_list(self, use_temp_scopes_file):
         """Empty groups list returns empty scopes list."""
-        config = _scopes_config(str(temp_scopes_file))
-        scopes.load_scopes_config(config)
-        result = scopes.map_groups_to_scopes([], config)
+        result = map_groups_to_scopes([])
 
         assert result == []
 
-    def test_partial_group_match(self, temp_scopes_file, reset_scopes_cache):
+    def test_partial_group_match(self, use_temp_scopes_file):
         """Mix of known and unknown groups returns only known scopes."""
-        config = _scopes_config(str(temp_scopes_file))
-        scopes.load_scopes_config(config)
-        result = scopes.map_groups_to_scopes(["admin", "unknown-group", "user"], config)
+        result = map_groups_to_scopes(["admin", "unknown-group", "user"])
 
         # Should get scopes from admin and user, ignoring unknown-group
         assert set(result) == {"servers-read", "servers-write"}
@@ -366,9 +294,8 @@ class TestMapGroupsToScopes:
             temp_path = Path(f.name)
 
         try:
-            config_obj = _scopes_config(str(temp_path))
-            scopes.load_scopes_config(config_obj)
-            result = scopes.map_groups_to_scopes(["group-a", "group-b"], config_obj)
+            with patch("registry_pkgs.core.scopes.get_scopes_file_path", return_value=temp_path):
+                result = map_groups_to_scopes(["group-a", "group-b"])
 
             # First occurrence order is preserved: scope1, scope2, scope3 from group-a,
             # then scope4 from group-b (scope3 and scope2 already seen)
@@ -380,57 +307,47 @@ class TestMapGroupsToScopes:
 class TestFilterKnownGroups:
     """Tests for filter_known_groups function."""
 
-    def test_known_group_is_kept(self, temp_scopes_file, reset_scopes_cache):
+    def test_known_group_is_kept(self, use_temp_scopes_file):
         """A group present in group_mappings is kept in the output."""
-        config = _scopes_config(str(temp_scopes_file))
-        result = filter_known_groups(["admin"], config)
+        result = filter_known_groups(["admin"])
         assert result == ["admin"]
 
-    def test_unknown_group_is_removed(self, temp_scopes_file, reset_scopes_cache):
+    def test_unknown_group_is_removed(self, use_temp_scopes_file):
         """A group absent from group_mappings is removed."""
-        config = _scopes_config(str(temp_scopes_file))
-        result = filter_known_groups(["All-Company-Employees"], config)
+        result = filter_known_groups(["All-Company-Employees"])
         assert result == []
 
-    def test_mixed_groups_keeps_only_known(self, temp_scopes_file, reset_scopes_cache):
+    def test_mixed_groups_keeps_only_known(self, use_temp_scopes_file):
         """Mix of known and unknown groups returns only the known subset."""
-        config = _scopes_config(str(temp_scopes_file))
-        result = filter_known_groups(["admin", "All-Company-Employees", "user"], config)
+        result = filter_known_groups(["admin", "All-Company-Employees", "user"])
         assert result == ["admin", "user"]
 
-    def test_empty_input_returns_empty(self, temp_scopes_file, reset_scopes_cache):
+    def test_empty_input_returns_empty(self, use_temp_scopes_file):
         """Empty input list returns empty output."""
-        config = _scopes_config(str(temp_scopes_file))
-        result = filter_known_groups([], config)
+        result = filter_known_groups([])
         assert result == []
 
-    def test_preserves_input_order(self, temp_scopes_file, reset_scopes_cache):
+    def test_preserves_input_order(self, use_temp_scopes_file):
         """Output preserves the original order of known groups."""
-        config = _scopes_config(str(temp_scopes_file))
-        result = filter_known_groups(["user", "admin"], config)
+        result = filter_known_groups(["user", "admin"])
         assert result == ["user", "admin"]
 
-    def test_does_not_deduplicate(self, temp_scopes_file, reset_scopes_cache):
+    def test_does_not_deduplicate(self, use_temp_scopes_file):
         """Duplicate known groups are not removed — mirrors map_groups_to_scopes input convention."""
-        config = _scopes_config(str(temp_scopes_file))
-        result = filter_known_groups(["admin", "admin"], config)
+        result = filter_known_groups(["admin", "admin"])
         assert result == ["admin", "admin"]
 
 
 class TestGetScopeDescription:
     """Tests for get_scope_description function."""
 
-    def test_returns_description_for_nested_scope(self, temp_scopes_file, reset_scopes_cache):
-        config = _scopes_config(str(temp_scopes_file))
-
-        result = get_scope_description("servers-read", config)
+    def test_returns_description_for_nested_scope(self, use_temp_scopes_file):
+        result = get_scope_description("servers-read")
 
         assert result == "View registered MCP servers."
 
-    def test_returns_none_for_unknown_scope(self, temp_scopes_file, reset_scopes_cache):
-        config = _scopes_config(str(temp_scopes_file))
-
-        result = get_scope_description("unknown-scope", config)
+    def test_returns_none_for_unknown_scope(self, use_temp_scopes_file):
+        result = get_scope_description("unknown-scope")
 
         assert result is None
 
@@ -445,11 +362,12 @@ class TestGetScopeDescription:
             )
         )
 
-        result = get_scope_description("servers-read", _scopes_config(str(temp_path)))
+        with patch("registry_pkgs.core.scopes.get_scopes_file_path", return_value=temp_path):
+            result = get_scope_description("servers-read")
 
         assert result is None
 
     def test_returns_description_from_packaged_scopes_config(self, reset_scopes_cache):
-        result = get_scope_description("servers-read", _scopes_config())
+        result = get_scope_description("servers-read")
 
         assert result == "View registered MCP servers, their tools, and connection status."

--- a/registry/src/registry/api/redirect_routes.py
+++ b/registry/src/registry/api/redirect_routes.py
@@ -347,10 +347,7 @@ async def oauth2_callback(
             )
 
         try:
-            await group_service.sync_user_group_memberships(
-                user_obj,
-                enabled=settings.entra_group_sync_enabled,
-            )
+            await group_service.sync_user_group_memberships(user_obj)
         except Exception:
             logger.warning(
                 "Group sync failed for user %s; login will proceed.",

--- a/registry/src/registry/api/redirect_routes.py
+++ b/registry/src/registry/api/redirect_routes.py
@@ -362,7 +362,7 @@ async def oauth2_callback(
             "user_id": str(user_obj.id),
             "username": user_obj.username,
             "email": user_obj.email or user_claims.get("email", ""),
-            "groups": filter_known_groups(groups, settings.scopes_file_config),
+            "groups": filter_known_groups(groups),
             "scopes": user_claims.get("scope", []),
             "role": user_obj.role,
             "auth_method": "oauth2",
@@ -491,7 +491,7 @@ async def refresh_token(
 
         # If no scopes but has groups, map groups to scopes
         if not scopes and groups:
-            scopes = map_groups_to_scopes(groups, settings.scopes_file_config)
+            scopes = map_groups_to_scopes(groups)
             logger.info(f"Mapped refresh token groups {groups} to scopes: {scopes}")
 
         role = refresh_claims.get("role", "user")

--- a/registry/src/registry/api/v1/acl_routes.py
+++ b/registry/src/registry/api/v1/acl_routes.py
@@ -16,7 +16,6 @@ from registry_pkgs.models import PrincipalType
 from registry_pkgs.models.enums import PermissionBits
 
 from ...auth.dependencies import CurrentUser
-from ...core.config import settings
 from ...deps import get_acl_service, get_group_service
 from ...schemas.acl_schema import (
     GetResourcePermissionsResponse,
@@ -89,10 +88,7 @@ async def _snapshot_entra_groups(
     """
     for principal in data.updated:
         if principal.principalType == PrincipalType.GROUP:
-            await group_service.ensure_group_principal_exists(
-                str(principal.principalId),
-                enabled=settings.entra_group_sync_enabled,
-            )
+            await group_service.ensure_group_principal_exists(str(principal.principalId))
 
 
 async def _apply_permissions_in_transaction(

--- a/registry/src/registry/api/v1/mcp/consent_routes.py
+++ b/registry/src/registry/api/v1/mcp/consent_routes.py
@@ -14,7 +14,6 @@ from registry_pkgs.oauth.schemas import ConsentScopeDisplay, DownstreamConsentCo
 
 from ....auth.dependencies import CurrentUser
 from ....constants import DownstreamOAuthConstants
-from ....core.config import settings
 from ....core.session_store import SessionStore
 from ....deps import (
     get_a2a_agent_service,
@@ -121,10 +120,7 @@ async def get_downstream_consent_context(
             scopes=[
                 ConsentScopeDisplay(
                     name=DownstreamOAuthConstants.PROXY_OPS_SCOPE,
-                    description=get_scope_description(
-                        DownstreamOAuthConstants.PROXY_OPS_SCOPE,
-                        settings.scopes_file_config,
-                    ),
+                    description=get_scope_description(DownstreamOAuthConstants.PROXY_OPS_SCOPE),
                 )
             ],
         )

--- a/registry/src/registry/auth/dependencies.py
+++ b/registry/src/registry/auth/dependencies.py
@@ -4,6 +4,7 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, Request, status
 from itsdangerous import URLSafeTimedSerializer
 
+from registry_pkgs.core.scopes import map_groups_to_scopes
 from registry_pkgs.types import UserContextDict
 
 from ..core.config import settings
@@ -43,39 +44,6 @@ def build_signer():
     return URLSafeTimedSerializer(settings.secret_key)
 
 
-def map_cognito_groups_to_scopes(groups: list[str]) -> list[str]:
-    """
-    Map Cognito groups to MCP scopes using the scopes.yml configuration.
-
-    Args:
-        groups: List of Cognito group names
-
-    Returns:
-        List of MCP scopes
-    """
-    scopes = []
-    group_mappings = settings.scopes_config.get("group_mappings", {})
-
-    for group in groups:
-        if group in group_mappings:
-            group_scopes = group_mappings[group]
-            scopes.extend(group_scopes)
-            logger.debug(f"Mapped group '{group}' to scopes: {group_scopes}")
-        else:
-            logger.debug(f"No scope mapping found for group: {group}")
-
-    # Remove duplicates while preserving order
-    seen = set()
-    unique_scopes = []
-    for scope in scopes:
-        if scope not in seen:
-            seen.add(scope)
-            unique_scopes.append(scope)
-
-    logger.info(f"Final mapped scopes: {unique_scopes}")
-    return unique_scopes
-
-
 def effective_scopes_from_context(user_context: UserContextDict) -> list[str]:
     """
     Determine the effective scopes for a user based on the authentication context.
@@ -100,4 +68,4 @@ def effective_scopes_from_context(user_context: UserContextDict) -> list[str]:
     if not groups:
         return []
 
-    return map_cognito_groups_to_scopes(groups)
+    return map_groups_to_scopes(groups, settings.scopes_file_config)

--- a/registry/src/registry/auth/dependencies.py
+++ b/registry/src/registry/auth/dependencies.py
@@ -68,4 +68,4 @@ def effective_scopes_from_context(user_context: UserContextDict) -> list[str]:
     if not groups:
         return []
 
-    return map_groups_to_scopes(groups, settings.scopes_file_config)
+    return map_groups_to_scopes(groups)

--- a/registry/src/registry/container.py
+++ b/registry/src/registry/container.py
@@ -13,6 +13,8 @@ from registry_pkgs.core.consent_store import ConsentStore, PendingConsentStore
 from registry_pkgs.core.oauth_state_store import DownstreamOAuthStateStore, OAuthClientStore, OAuthStateStore
 from registry_pkgs.database.mongodb import MongoDB
 from registry_pkgs.federation.azure_foundry_client_cache import AzureFoundryClientCache
+from registry_pkgs.google.cloud_identity_client import CloudIdentityGroupsClient
+from registry_pkgs.models import ExtendedGroupSource
 from registry_pkgs.oauth.flow_state_manager import FlowStateManager
 from registry_pkgs.oauth.oauth_service import MCPOAuthService
 from registry_pkgs.oauth.token_service import TokenService
@@ -43,6 +45,7 @@ from .services.federation_sync_service import FederationSyncService
 from .services.group_directory_client import (
     CognitoGroupDirectoryClient,
     EntraIdGroupDirectoryClient,
+    GoogleGroupDirectoryClient,
     IdPGroupDirectoryClient,
     KeycloakGroupDirectoryClient,
 )
@@ -154,6 +157,7 @@ class RegistryContainer:
 
     @cached_property
     def group_directory_client(self) -> IdPGroupDirectoryClient:
+        """Supplies the "entra" slot of GroupService (Cognito/Keycloak stay no-op)."""
         provider = self.settings.auth_provider
         if provider == "entra":
             return EntraIdGroupDirectoryClient(
@@ -167,8 +171,21 @@ class RegistryContainer:
         return KeycloakGroupDirectoryClient()
 
     @cached_property
+    def cloud_identity_client(self) -> CloudIdentityGroupsClient:
+        return CloudIdentityGroupsClient(self.settings.google_service_account_key_json)
+
+    @cached_property
+    def google_group_directory_client(self) -> GoogleGroupDirectoryClient:
+        return GoogleGroupDirectoryClient(self.cloud_identity_client)
+
+    @cached_property
     def group_service(self) -> GroupService:
-        return GroupService(group_directory_client=self.group_directory_client)
+        clients: dict[ExtendedGroupSource, IdPGroupDirectoryClient] = {}
+        if self.settings.entra_group_sync_enabled:
+            clients[ExtendedGroupSource.ENTRA] = self.group_directory_client
+        if self.settings.google_group_sync_enabled:
+            clients[ExtendedGroupSource.GOOGLE] = self.google_group_directory_client
+        return GroupService(directory_clients=clients)
 
     @cached_property
     def acl_service(self) -> ACLService:

--- a/registry/src/registry/container.py
+++ b/registry/src/registry/container.py
@@ -560,6 +560,7 @@ class RegistryContainer:
         await self.mcp_proxy_client.aclose()
         await self.a2a_httpx_client.aclose()
         await self.a2a_client_registry.close()
+        await self.cloud_identity_client.aclose()
 
     def _initialize_federation(self) -> None:
         """Run optional federation sync on startup without failing the whole application."""

--- a/registry/src/registry/core/config.py
+++ b/registry/src/registry/core/config.py
@@ -162,6 +162,9 @@ class Settings(JarvisBaseSettings):
     entra_group_sync_enabled: bool = False
     entra_graph_url: str = "https://graph.microsoft.com"
 
+    # ==================== Google Group Sync ====================
+    google_group_sync_enabled: bool = True
+
     # ==================== Keycloak Integration ====================
     keycloak_url: str = "http://keycloak:8080"
     keycloak_realm: str = "mcp-gateway"

--- a/registry/src/registry/middleware/auth.py
+++ b/registry/src/registry/middleware/auth.py
@@ -325,7 +325,7 @@ class UnifiedAuthMiddleware:
         scopes = scope_string.split() if scope_string else []
 
         if not scopes and groups:
-            scopes = map_groups_to_scopes(groups, settings.scopes_file_config)
+            scopes = map_groups_to_scopes(groups)
             logger.info(f"Mapped JWT groups {groups} to scopes: {scopes}")
 
         if not scopes:
@@ -390,7 +390,7 @@ class UnifiedAuthMiddleware:
 
             # If no scopes but has groups, map groups to scopes
             if not scopes and groups:
-                scopes = map_groups_to_scopes(groups, settings.scopes_file_config)
+                scopes = map_groups_to_scopes(groups)
                 logger.info(f"Mapped session groups {groups} to scopes: {scopes}")
 
             logger.debug(f"JWT access token valid for user {username} (user_id: {user_id})")

--- a/registry/src/registry/services/access_control_service.py
+++ b/registry/src/registry/services/access_control_service.py
@@ -9,7 +9,7 @@ from pymongo.asynchronous.client_session import AsyncClientSession
 
 from registry_pkgs.access_control import build_acl_principal_or_clause, resolve_group_ids_for_user
 from registry_pkgs.models import (
-    Group,
+    ExtendedGroup,
     PrincipalType,
     RegistryAccessRole,
     User,
@@ -360,7 +360,7 @@ class ACLService:
             groups_by_id = {}
             if group_principal_ids:
                 group_ids = [principal_id for principal_id, _ in group_principal_ids]
-                fetched_groups = await Group.find({"_id": {"$in": group_ids}}, session=session).to_list()
+                fetched_groups = await ExtendedGroup.find({"_id": {"$in": group_ids}}, session=session).to_list()
                 groups_by_id = {group.id: group for group in fetched_groups}
 
             for principal_id, role_id in user_principal_ids:

--- a/registry/src/registry/services/group_directory_client.py
+++ b/registry/src/registry/services/group_directory_client.py
@@ -7,7 +7,11 @@ from abc import ABC, abstractmethod
 
 import httpx
 
+from registry_pkgs.google.cloud_identity_client import CloudIdentityGroupsClient
+
 logger = logging.getLogger(__name__)
+
+_GOOGLE_GROUP_DETAIL_CONCURRENCY = 10
 
 
 class IdPGroupDirectoryClient(ABC):
@@ -56,6 +60,44 @@ class KeycloakGroupDirectoryClient(IdPGroupDirectoryClient):
             "IdP group sync is not supported for keycloak; group-based ACLs will not reflect IdP membership."
         )
         return []
+
+
+class GoogleGroupDirectoryClient(IdPGroupDirectoryClient):
+    """Wraps the shared CloudIdentityGroupsClient. Group identity is the Cloud Identity
+    resource name (``groups/{id}``) throughout — stable, and directly usable by every endpoint.
+    """
+
+    def __init__(self, client: CloudIdentityGroupsClient) -> None:
+        self._client = client
+
+    async def get_user_group_ids(self, user_oid: str) -> list[str]:
+        # user_oid is the Workspace member email for a Google-authenticated user.
+        groups = await self._client.list_transitive_groups_for_member(user_oid)
+        return [g.resource_name for g in groups]
+
+    async def get_group_members(self, group_oid: str) -> list[str]:
+        # group_oid is a "groups/{id}" resource name.
+        return await self._client.list_transitive_members_of_group(group_oid)
+
+    async def get_group_details_batch(self, group_ids: list[str]) -> list[dict]:
+        semaphore = asyncio.Semaphore(_GOOGLE_GROUP_DETAIL_CONCURRENCY)
+
+        async def _one(resource_name: str) -> dict | None:
+            async with semaphore:
+                try:
+                    data = await self._client.get_group(resource_name)
+                except Exception:
+                    logger.warning("Cloud Identity groups.get failed for %s; skipping.", resource_name, exc_info=True)
+                    return None
+            return {
+                "id": data.get("name"),
+                "name": data.get("displayName"),
+                "email": (data.get("groupKey") or {}).get("id"),
+                "description": data.get("description"),
+            }
+
+        results = await asyncio.gather(*(_one(gid) for gid in group_ids))
+        return [r for r in results if r is not None]
 
 
 class EntraIdGroupDirectoryClient(IdPGroupDirectoryClient):

--- a/registry/src/registry/services/group_service.py
+++ b/registry/src/registry/services/group_service.py
@@ -1,10 +1,10 @@
-"""Group management service: search and Entra group membership sync."""
+"""Group management service: search and per-provider IdP group membership sync."""
 
 import logging
 
 from beanie import BulkWriter, PydanticObjectId
 
-from registry_pkgs.models._generated.group import Group, GroupSource
+from registry_pkgs.models import ExtendedGroup, ExtendedGroupSource
 from registry_pkgs.models._generated.user import User
 
 from .group_directory_client import IdPGroupDirectoryClient
@@ -13,10 +13,10 @@ logger = logging.getLogger(__name__)
 
 
 class GroupService:
-    def __init__(self, group_directory_client: IdPGroupDirectoryClient) -> None:
-        self._directory_client = group_directory_client
+    def __init__(self, directory_clients: dict[ExtendedGroupSource, IdPGroupDirectoryClient]) -> None:
+        self._clients = directory_clients
 
-    async def search_groups(self, query: str, limit: int = 30) -> list[Group]:
+    async def search_groups(self, query: str, limit: int = 30) -> list[ExtendedGroup]:
         """Search groups by name or email (case-insensitive substring match)."""
         search_query = {
             "$or": [
@@ -25,50 +25,53 @@ class GroupService:
             ]
         }
         try:
-            return await Group.find(search_query).limit(limit).to_list()
+            return await ExtendedGroup.find(search_query, projection_model=ExtendedGroup).limit(limit).to_list()
         except Exception as e:
             logger.error("Error searching groups with query '%s': %s", query, e)
             return []
 
-    async def sync_user_group_memberships(self, user: User, *, enabled: bool) -> None:
-        """Sync Entra group membership for the given user into MongoDB Group documents.
+    async def sync_user_group_memberships(self, user: User) -> None:
+        """Sync IdP group membership for the given user into MongoDB ExtendedGroup documents.
 
+        The directory client and enablement are resolved per-user from ``user.provider``.
         Port of PermissionService.syncUserEntraGroupMemberships from jarvis-api.
-        Non-destructive when Graph API returns an empty list (protects against transient failures).
+        Non-destructive when the directory returns an empty list (protects against transient failures).
         """
-        if not enabled:
-            return
-        if not user.idOnTheSource:
+        source = ExtendedGroupSource.GOOGLE if user.provider == "google" else ExtendedGroupSource.ENTRA
+        client = self._clients.get(source)
+        if client is None or not user.idOnTheSource:
             return
 
         user_oid: str = user.idOnTheSource
-        group_ids = await self._directory_client.get_user_group_ids(user_oid)
+        group_ids = await client.get_user_group_ids(user_oid)
         if not group_ids:
             return
 
-        await self._add_user_to_known_groups(user_oid, group_ids)
-        await self._upsert_new_groups_and_enroll_user(user_oid, group_ids)
-        await self._remove_user_from_stale_groups(user_oid, group_ids)
+        await self._add_user_to_known_groups(source, user_oid, group_ids)
+        await self._upsert_new_groups_and_enroll_user(source, client, user_oid, group_ids)
+        await self._remove_user_from_stale_groups(source, user_oid, group_ids)
 
-    async def _add_user_to_known_groups(self, user_oid: str, group_ids: list[str]) -> None:
-        """$addToSet the user into Entra groups that already exist in the DB."""
-        await Group.find(
+    async def _add_user_to_known_groups(self, source: ExtendedGroupSource, user_oid: str, group_ids: list[str]) -> None:
+        """$addToSet the user into groups that already exist in the DB."""
+        await ExtendedGroup.find(
             {
                 "idOnTheSource": {"$in": group_ids},
-                "source": GroupSource.ENTRA,
+                "source": source,
                 "memberIds": {"$ne": user_oid},
             }
         ).update_many({"$addToSet": {"memberIds": user_oid}})
 
-    async def _upsert_new_groups_and_enroll_user(self, user_oid: str, group_ids: list[str]) -> None:
+    async def _upsert_new_groups_and_enroll_user(
+        self, source: ExtendedGroupSource, client: IdPGroupDirectoryClient, user_oid: str, group_ids: list[str]
+    ) -> None:
         """Fetch details for groups absent from the DB, upsert them, then enroll the user."""
-        existing = await Group.find({"idOnTheSource": {"$in": group_ids}, "source": GroupSource.ENTRA}).to_list()
+        existing = await ExtendedGroup.find({"idOnTheSource": {"$in": group_ids}, "source": source}).to_list()
         existing_source_ids = {g.idOnTheSource for g in existing}
         missing_ids = [gid for gid in group_ids if gid not in existing_source_ids]
         if not missing_ids:
             return
 
-        details = await self._directory_client.get_group_details_batch(missing_ids)
+        details = await client.get_group_details_batch(missing_ids)
         if len(details) < len(missing_ids):
             logger.warning(
                 "get_group_details_batch resolved %d/%d groups; remaining will retry on next login.",
@@ -80,13 +83,13 @@ class GroupService:
         async with BulkWriter() as bulk_writer:
             for detail in details:
                 detail_ids.append(detail["id"])
-                await Group.find({"idOnTheSource": detail["id"], "source": GroupSource.ENTRA}).update_many(
+                await ExtendedGroup.find({"idOnTheSource": detail["id"], "source": source}).update_many(
                     {
                         "$setOnInsert": {
                             "name": detail["name"],
                             "email": detail.get("email"),
                             "description": detail.get("description"),
-                            "source": GroupSource.ENTRA,
+                            "source": source,
                             "idOnTheSource": detail["id"],
                             "memberIds": [],
                         }
@@ -96,39 +99,38 @@ class GroupService:
                 )
 
         if detail_ids:
-            await Group.find({"idOnTheSource": {"$in": detail_ids}, "source": GroupSource.ENTRA}).update_many(
+            await ExtendedGroup.find({"idOnTheSource": {"$in": detail_ids}, "source": source}).update_many(
                 {"$addToSet": {"memberIds": user_oid}}
             )
 
-    async def _remove_user_from_stale_groups(self, user_oid: str, group_ids: list[str]) -> None:
-        """$pullAll the user from Entra groups they no longer belong to."""
-        await Group.find(
+    async def _remove_user_from_stale_groups(
+        self, source: ExtendedGroupSource, user_oid: str, group_ids: list[str]
+    ) -> None:
+        """$pullAll the user from groups they no longer belong to."""
+        await ExtendedGroup.find(
             {
-                "source": GroupSource.ENTRA,
+                "source": source,
                 "memberIds": user_oid,
                 "idOnTheSource": {"$nin": group_ids},
             }
         ).update_many({"$pullAll": {"memberIds": [user_oid]}})
 
-    async def ensure_group_principal_exists(self, group_id: str, *, enabled: bool) -> None:
-        """Snapshot all transitive Entra group members into Group.memberIds before ACL grant.
+    async def ensure_group_principal_exists(self, group_id: str) -> None:
+        """Snapshot all transitive group members into ExtendedGroup.memberIds before ACL grant.
 
-        Port of PermissionService.ensureGroupPrincipalExists from jarvis-api (Entra branch only).
+        Dispatch is based on the group's own ``source`` field. LOCAL (or any source without a
+        configured/enabled client) is a no-op. Port of PermissionService.ensureGroupPrincipalExists.
         Errors from the directory client are re-raised so the ACL grant route returns 500.
         """
-        if not enabled:
-            return
-
-        group = await Group.get(PydanticObjectId(group_id))
+        group = await ExtendedGroup.get(PydanticObjectId(group_id))
         if group is None:
             return
-        if group.source != GroupSource.ENTRA:
-            return
-        if not group.idOnTheSource:
+        client = self._clients.get(group.source)
+        if client is None or not group.idOnTheSource:
             return
 
         try:
-            member_oids = await self._directory_client.get_group_members(group.idOnTheSource)
+            member_oids = await client.get_group_members(group.idOnTheSource)
         except Exception:
             logger.error(
                 "Failed to fetch group members for group %s (idOnTheSource=%s); ACL grant aborted.",

--- a/registry/src/registry/services/workflow_control_service.py
+++ b/registry/src/registry/services/workflow_control_service.py
@@ -26,9 +26,11 @@ from agno.run.cancel import acancel_run as agno_acancel_run
 from beanie import PydanticObjectId
 from fastapi import HTTPException
 
-from registry.auth.dependencies import UserContextDict, effective_scopes_from_context, map_cognito_groups_to_scopes
+from registry.auth.dependencies import UserContextDict, effective_scopes_from_context
+from registry.core.config import settings
+from registry_pkgs.core.scopes import map_groups_to_scopes
 from registry_pkgs.database.mongodb import MongoDB
-from registry_pkgs.models import Group, User
+from registry_pkgs.models import ExtendedGroup, User
 from registry_pkgs.models.enums import (
     NodeRunStatus,
     RequirementResolution,
@@ -860,7 +862,7 @@ async def _atomic_write_decision(
 async def _refresh_triggering_auth_context(
     run: WorkflowRun,
     current_auth_context: UserContextDict | None = None,
-) -> UserContextDict | None:
+):
     """Rebuild auth context from current user/group state before HITL resume.
 
     Returns ``None`` when no ``triggering_user_id`` was captured (e.g. script-driven
@@ -880,7 +882,7 @@ async def _refresh_triggering_auth_context(
 
     groups: list[str] = []
     if user.idOnTheSource:
-        current_groups = await Group.find({"memberIds": user.idOnTheSource}).to_list()
+        current_groups = await ExtendedGroup.find({"memberIds": user.idOnTheSource}).to_list()
         groups = [group.name for group in current_groups]
 
     return {
@@ -888,7 +890,7 @@ async def _refresh_triggering_auth_context(
         "client_id": run.triggering_client_id or "",
         "username": user.username or run.triggering_username,
         "groups": groups,
-        "scopes": map_cognito_groups_to_scopes(groups),
+        "scopes": map_groups_to_scopes(groups, settings.scopes_file_config),
         "auth_method": "service",
         "provider": "workflow",
         "auth_source": "workflow_resume",

--- a/registry/src/registry/services/workflow_control_service.py
+++ b/registry/src/registry/services/workflow_control_service.py
@@ -862,7 +862,7 @@ async def _atomic_write_decision(
 async def _refresh_triggering_auth_context(
     run: WorkflowRun,
     current_auth_context: UserContextDict | None = None,
-):
+) -> UserContextDict | None:
     """Rebuild auth context from current user/group state before HITL resume.
 
     Returns ``None`` when no ``triggering_user_id`` was captured (e.g. script-driven

--- a/registry/src/registry/services/workflow_control_service.py
+++ b/registry/src/registry/services/workflow_control_service.py
@@ -27,7 +27,6 @@ from beanie import PydanticObjectId
 from fastapi import HTTPException
 
 from registry.auth.dependencies import UserContextDict, effective_scopes_from_context
-from registry.core.config import settings
 from registry_pkgs.core.scopes import map_groups_to_scopes
 from registry_pkgs.database.mongodb import MongoDB
 from registry_pkgs.models import ExtendedGroup, User
@@ -890,7 +889,7 @@ async def _refresh_triggering_auth_context(
         "client_id": run.triggering_client_id or "",
         "username": user.username or run.triggering_username,
         "groups": groups,
-        "scopes": map_groups_to_scopes(groups, settings.scopes_file_config),
+        "scopes": map_groups_to_scopes(groups),
         "auth_method": "service",
         "provider": "workflow",
         "auth_source": "workflow_resume",

--- a/registry/tests/conftest.py
+++ b/registry/tests/conftest.py
@@ -191,14 +191,13 @@ def create_test_jwt_token(
     Returns:
         JWT access token string
     """
-    from registry.core.config import Settings
     from registry.utils.crypto_utils import generate_access_token
     from registry_pkgs.core.scopes import map_groups_to_scopes
 
     if user_id is None:
         user_id = f"test-{username}-id"
 
-    scopes = map_groups_to_scopes(groups, Settings(_env_file=None).scopes_file_config) or groups
+    scopes = map_groups_to_scopes(groups) or groups
 
     return generate_access_token(
         user_id=user_id,

--- a/registry/tests/unit/api/test_redirect_routes.py
+++ b/registry/tests/unit/api/test_redirect_routes.py
@@ -159,6 +159,7 @@ async def _successful_callback(
     mock_user: Mock,
     state: str | None,
     state_nonce: str | None = "state-nonce",
+    sync_side_effect: Exception | None = None,
 ) -> RedirectResponse:
     token_response = Mock()
     token_response.status_code = 200
@@ -168,7 +169,7 @@ async def _successful_callback(
     user_service.get_user_by_user_id = AsyncMock(return_value=mock_user)
 
     group_service = Mock()
-    group_service.sync_user_group_memberships = AsyncMock()
+    group_service.sync_user_group_memberships = AsyncMock(side_effect=sync_side_effect)
 
     with (
         patch("registry.api.redirect_routes.httpx.AsyncClient") as mock_client,
@@ -200,6 +201,22 @@ async def test_oauth2_callback_redirects_to_safe_next_path(mock_request, mock_se
     state = _encode_state({"nonce": "state-nonce", "next": "/consent/server?nonce=abc"})
 
     response = await _successful_callback(mock_request=mock_request, mock_user=mock_user, state=state)
+
+    assert response.headers["location"] == f"{mock_settings.registry_client_url}/consent/server?nonce=abc"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_oauth2_callback_login_completes_when_group_sync_fails(mock_request, mock_settings, mock_user) -> None:
+    """Fail-open: a Cloud Identity / Graph failure during group sync must not block login."""
+    state = _encode_state({"nonce": "state-nonce", "next": "/consent/server?nonce=abc"})
+
+    response = await _successful_callback(
+        mock_request=mock_request,
+        mock_user=mock_user,
+        state=state,
+        sync_side_effect=RuntimeError("cloud identity 500"),
+    )
 
     assert response.headers["location"] == f"{mock_settings.registry_client_url}/consent/server?nonce=abc"
 

--- a/registry/tests/unit/api/test_redirect_routes.py
+++ b/registry/tests/unit/api/test_redirect_routes.py
@@ -61,7 +61,6 @@ def mock_settings():
         settings.registry_client_url = "http://localhost:80/gateway"
         settings.registry_redirect_uri = "http://localhost:7860/redirect"
         settings.registry_url = "http://localhost:7860"
-        settings.scopes_file_config = {}
         settings.session_cookie_name = "session"
         settings.session_cookie_secure = False
         yield settings

--- a/registry/tests/unit/auth/test_auth_routes.py
+++ b/registry/tests/unit/auth/test_auth_routes.py
@@ -999,4 +999,4 @@ class TestAuthRoutes:
             )
 
         assert response.status_code == 302
-        mock_filter.assert_called_once_with(expected_groups, mock_settings.scopes_file_config)
+        mock_filter.assert_called_once_with(expected_groups)

--- a/registry/tests/unit/auth/test_dependencies.py
+++ b/registry/tests/unit/auth/test_dependencies.py
@@ -6,26 +6,26 @@ from registry.auth import dependencies as deps
 @pytest.mark.unit
 def test_effective_scopes_explicit_only(monkeypatch):
     user_context = {"scopes": ["a", "b", "a"], "groups": ["g1"]}
-    monkeypatch.setattr(deps, "map_cognito_groups_to_scopes", lambda _groups: ["x", "y"])
+    monkeypatch.setattr(deps, "map_groups_to_scopes", lambda _groups, _config: ["x", "y"])
     assert deps.effective_scopes_from_context(user_context) == ["a", "b"]
 
 
 @pytest.mark.unit
 def test_effective_scopes_groups_only(monkeypatch):
     user_context = {"scopes": [], "groups": ["g1"]}
-    monkeypatch.setattr(deps, "map_cognito_groups_to_scopes", lambda _groups: ["x", "y"])
+    monkeypatch.setattr(deps, "map_groups_to_scopes", lambda _groups, _config: ["x", "y"])
     assert deps.effective_scopes_from_context(user_context) == ["x", "y"]
 
 
 @pytest.mark.unit
 def test_effective_scopes_no_scopes_no_groups(monkeypatch):
     user_context = {"scopes": [], "groups": []}
-    monkeypatch.setattr(deps, "map_cognito_groups_to_scopes", lambda _groups: ["x"])
+    monkeypatch.setattr(deps, "map_groups_to_scopes", lambda _groups, _config: ["x"])
     assert deps.effective_scopes_from_context(user_context) == []
 
 
 @pytest.mark.unit
 def test_effective_scopes_explicit_takes_precedence(monkeypatch):
     user_context = {"scopes": ["explicit"], "groups": ["g1"]}
-    monkeypatch.setattr(deps, "map_cognito_groups_to_scopes", lambda _groups: ["group-scope"])
+    monkeypatch.setattr(deps, "map_groups_to_scopes", lambda _groups, _config: ["group-scope"])
     assert deps.effective_scopes_from_context(user_context) == ["explicit"]

--- a/registry/tests/unit/auth/test_dependencies.py
+++ b/registry/tests/unit/auth/test_dependencies.py
@@ -6,26 +6,26 @@ from registry.auth import dependencies as deps
 @pytest.mark.unit
 def test_effective_scopes_explicit_only(monkeypatch):
     user_context = {"scopes": ["a", "b", "a"], "groups": ["g1"]}
-    monkeypatch.setattr(deps, "map_groups_to_scopes", lambda _groups, _config: ["x", "y"])
+    monkeypatch.setattr(deps, "map_groups_to_scopes", lambda _groups: ["x", "y"])
     assert deps.effective_scopes_from_context(user_context) == ["a", "b"]
 
 
 @pytest.mark.unit
 def test_effective_scopes_groups_only(monkeypatch):
     user_context = {"scopes": [], "groups": ["g1"]}
-    monkeypatch.setattr(deps, "map_groups_to_scopes", lambda _groups, _config: ["x", "y"])
+    monkeypatch.setattr(deps, "map_groups_to_scopes", lambda _groups: ["x", "y"])
     assert deps.effective_scopes_from_context(user_context) == ["x", "y"]
 
 
 @pytest.mark.unit
 def test_effective_scopes_no_scopes_no_groups(monkeypatch):
     user_context = {"scopes": [], "groups": []}
-    monkeypatch.setattr(deps, "map_groups_to_scopes", lambda _groups, _config: ["x"])
+    monkeypatch.setattr(deps, "map_groups_to_scopes", lambda _groups: ["x"])
     assert deps.effective_scopes_from_context(user_context) == []
 
 
 @pytest.mark.unit
 def test_effective_scopes_explicit_takes_precedence(monkeypatch):
     user_context = {"scopes": ["explicit"], "groups": ["g1"]}
-    monkeypatch.setattr(deps, "map_groups_to_scopes", lambda _groups, _config: ["group-scope"])
+    monkeypatch.setattr(deps, "map_groups_to_scopes", lambda _groups: ["group-scope"])
     assert deps.effective_scopes_from_context(user_context) == ["explicit"]

--- a/registry/tests/unit/middleware/test_rbac.py
+++ b/registry/tests/unit/middleware/test_rbac.py
@@ -747,14 +747,14 @@ class TestIntegrationScenarios:
         # Mock the group mapping function
         from registry.auth import dependencies as deps_module
 
-        def mock_map_groups(groups):
+        def mock_map_groups(groups, _config):
             mappings = mock_settings.scopes_config.get("group_mappings", {})
             scopes = []
             for group in groups:
                 scopes.extend(mappings.get(group, []))
             return scopes
 
-        monkeypatch.setattr(deps_module, "map_cognito_groups_to_scopes", mock_map_groups)
+        monkeypatch.setattr(deps_module, "map_groups_to_scopes", mock_map_groups)
 
         app = self._build_app()
         app.add_middleware(ScopePermissionMiddleware)

--- a/registry/tests/unit/middleware/test_rbac.py
+++ b/registry/tests/unit/middleware/test_rbac.py
@@ -747,7 +747,7 @@ class TestIntegrationScenarios:
         # Mock the group mapping function
         from registry.auth import dependencies as deps_module
 
-        def mock_map_groups(groups, _config):
+        def mock_map_groups(groups):
             mappings = mock_settings.scopes_config.get("group_mappings", {})
             scopes = []
             for group in groups:

--- a/registry/tests/unit/services/test_access_control_service.py
+++ b/registry/tests/unit/services/test_access_control_service.py
@@ -724,7 +724,7 @@ class TestACLService:
             )
 
     @pytest.mark.asyncio
-    @patch("registry.services.access_control_service.Group")
+    @patch("registry.services.access_control_service.ExtendedGroup")
     @patch("registry.services.access_control_service.RegistryAclEntry")
     async def test_get_resource_permissions_returns_group_principal(self, mock_acl_entry, mock_group):
         service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
@@ -793,11 +793,11 @@ class TestACLService:
         assert len(result["principals"]) == 3
 
     @pytest.mark.asyncio
-    @patch("registry.services.group_service.Group")
+    @patch("registry.services.group_service.ExtendedGroup")
     async def test_search_groups_applies_limit(self, mock_group):
         mock_group.find.return_value.limit.return_value.to_list = AsyncMock(return_value=[])
 
-        service = GroupService(group_directory_client=MagicMock())
+        service = GroupService(directory_clients={})
         result = await service.search_groups("alpha", limit=5)
 
         assert result == []

--- a/registry/tests/unit/services/test_access_control_service.py
+++ b/registry/tests/unit/services/test_access_control_service.py
@@ -150,7 +150,7 @@ class TestACLService:
         assert service.resolve_perm_bits_for_role(ResourceType.AGENT.value, role_id) is None
 
     @pytest.mark.asyncio
-    @patch("registry_pkgs.access_control.Group")
+    @patch("registry_pkgs.access_control.ExtendedGroup")
     @patch("registry_pkgs.access_control.User")
     async def test_resolve_group_ids_user_with_entra_id(self, mock_user, mock_group):
         user_id = PydanticObjectId()
@@ -172,7 +172,7 @@ class TestACLService:
         mock_group.find.assert_called_once_with({"memberIds": "entra-uuid-123"}, session=None)
 
     @pytest.mark.asyncio
-    @patch("registry_pkgs.access_control.Group")
+    @patch("registry_pkgs.access_control.ExtendedGroup")
     @patch("registry_pkgs.access_control.User")
     async def test_resolve_group_ids_local_user_returns_empty(self, mock_user, mock_group):
         service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})
@@ -184,7 +184,7 @@ class TestACLService:
         mock_group.find.assert_not_called()
 
     @pytest.mark.asyncio
-    @patch("registry_pkgs.access_control.Group")
+    @patch("registry_pkgs.access_control.ExtendedGroup")
     @patch("registry_pkgs.access_control.User")
     async def test_resolve_group_ids_user_not_found_returns_empty(self, mock_user, mock_group):
         service = ACLService(user_service=Mock(), group_service=Mock(), role_cache={})

--- a/registry/tests/unit/services/test_group_directory_client.py
+++ b/registry/tests/unit/services/test_group_directory_client.py
@@ -8,8 +8,10 @@ import pytest
 from registry.services.group_directory_client import (
     CognitoGroupDirectoryClient,
     EntraIdGroupDirectoryClient,
+    GoogleGroupDirectoryClient,
     KeycloakGroupDirectoryClient,
 )
+from registry_pkgs.google.cloud_identity_client import GoogleWorkspaceGroupInfo
 
 
 async def test_cognito_get_user_group_ids_returns_empty():
@@ -46,6 +48,66 @@ async def test_keycloak_get_group_details_batch_returns_empty():
     client = KeycloakGroupDirectoryClient()
     result = await client.get_group_details_batch(["g1"])
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# GoogleGroupDirectoryClient
+# ---------------------------------------------------------------------------
+
+
+def _make_google_client() -> tuple[GoogleGroupDirectoryClient, AsyncMock]:
+    cig = AsyncMock()
+    return GoogleGroupDirectoryClient(cig), cig
+
+
+async def test_google_get_user_group_ids_returns_resource_names():
+    client, cig = _make_google_client()
+    cig.list_transitive_groups_for_member.return_value = [
+        GoogleWorkspaceGroupInfo(email="a@corp.com", display_name="A", resource_name="groups/1"),
+        GoogleWorkspaceGroupInfo(email="b@corp.com", display_name="B", resource_name="groups/2"),
+    ]
+
+    result = await client.get_user_group_ids("member@corp.com")
+
+    assert result == ["groups/1", "groups/2"]
+    cig.list_transitive_groups_for_member.assert_awaited_once_with("member@corp.com")
+
+
+async def test_google_get_group_members_delegates_to_transitive_members():
+    client, cig = _make_google_client()
+    cig.list_transitive_members_of_group.return_value = ["u1@corp.com", "u2@corp.com"]
+
+    result = await client.get_group_members("groups/42")
+
+    assert result == ["u1@corp.com", "u2@corp.com"]
+    cig.list_transitive_members_of_group.assert_awaited_once_with("groups/42")
+
+
+async def test_google_get_group_details_batch_maps_fields():
+    client, cig = _make_google_client()
+    cig.get_group.side_effect = [
+        {"name": "groups/1", "displayName": "Eng", "groupKey": {"id": "eng@corp.com"}, "description": "desc"},
+        {"name": "groups/2", "displayName": "Ops", "groupKey": {"id": "ops@corp.com"}, "description": None},
+    ]
+
+    result = await client.get_group_details_batch(["groups/1", "groups/2"])
+
+    assert {"id": "groups/1", "name": "Eng", "email": "eng@corp.com", "description": "desc"} in result
+    assert {"id": "groups/2", "name": "Ops", "email": "ops@corp.com", "description": None} in result
+    assert len(result) == 2
+
+
+async def test_google_get_group_details_batch_skips_failed_lookups():
+    """A single groups.get failure is skipped, not fatal for the whole batch."""
+    client, cig = _make_google_client()
+    cig.get_group.side_effect = [
+        {"name": "groups/1", "displayName": "Eng", "groupKey": {"id": "eng@corp.com"}, "description": None},
+        RuntimeError("boom"),
+    ]
+
+    result = await client.get_group_details_batch(["groups/1", "groups/2"])
+
+    assert result == [{"id": "groups/1", "name": "Eng", "email": "eng@corp.com", "description": None}]
 
 
 def _make_entra_client() -> EntraIdGroupDirectoryClient:

--- a/registry/tests/unit/services/test_group_service.py
+++ b/registry/tests/unit/services/test_group_service.py
@@ -1,4 +1,4 @@
-"""Unit tests for GroupService sync methods."""
+"""Unit tests for GroupService per-provider sync methods."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -7,19 +7,20 @@ from beanie import PydanticObjectId
 
 from registry.services.group_directory_client import IdPGroupDirectoryClient
 from registry.services.group_service import GroupService
-from registry_pkgs.models._generated.group import Group, GroupSource
+from registry_pkgs.models import ExtendedGroupSource
 from registry_pkgs.models._generated.user import User
 
 
-def _make_user(oid: str = "user-oid-1") -> MagicMock:
+def _make_user(oid: str = "user-oid-1", provider: str = "openid") -> MagicMock:
     user = MagicMock(spec=User)
     user.idOnTheSource = oid
     user.id = PydanticObjectId()
+    user.provider = provider
     return user
 
 
-def _make_group(source: GroupSource = GroupSource.ENTRA, id_on_source: str = "g1") -> MagicMock:
-    group = MagicMock(spec=Group)
+def _make_group(source: ExtendedGroupSource = ExtendedGroupSource.ENTRA, id_on_source: str = "g1") -> MagicMock:
+    group = MagicMock()
     group.id = PydanticObjectId()
     group.source = source
     group.idOnTheSource = id_on_source
@@ -28,54 +29,78 @@ def _make_group(source: GroupSource = GroupSource.ENTRA, id_on_source: str = "g1
     return group
 
 
+def _make_client(
+    group_ids: list | None = None,
+    members: list | None = None,
+    details: list | None = None,
+) -> MagicMock:
+    client = MagicMock(spec=IdPGroupDirectoryClient)
+    client.get_user_group_ids = AsyncMock(return_value=group_ids or [])
+    client.get_group_members = AsyncMock(return_value=members or [])
+    client.get_group_details_batch = AsyncMock(return_value=details or [])
+    return client
+
+
 def _make_service(
-    client_group_ids: list | None = None,
-    client_members: list | None = None,
-    client_details: list | None = None,
+    *,
+    entra_client: MagicMock | None = None,
+    google_client: MagicMock | None = None,
+    entra_enabled: bool = True,
+    google_enabled: bool = True,
 ) -> GroupService:
-    mock_client = MagicMock(spec=IdPGroupDirectoryClient)
-    mock_client.get_user_group_ids = AsyncMock(return_value=client_group_ids or [])
-    mock_client.get_group_members = AsyncMock(return_value=client_members or [])
-    mock_client.get_group_details_batch = AsyncMock(return_value=client_details or [])
-    return GroupService(group_directory_client=mock_client)
+    clients: dict[ExtendedGroupSource, MagicMock] = {}
+    if entra_enabled:
+        clients[ExtendedGroupSource.ENTRA] = entra_client or _make_client()
+    if google_enabled:
+        clients[ExtendedGroupSource.GOOGLE] = google_client or _make_client()
+    return GroupService(directory_clients=clients)
 
 
-async def test_sync_skips_when_disabled():
-    service = _make_service()
+def _entra_client(service: GroupService) -> MagicMock:
+    return service._clients[ExtendedGroupSource.ENTRA]
+
+
+def _google_client(service: GroupService) -> MagicMock:
+    return service._clients[ExtendedGroupSource.GOOGLE]
+
+
+async def test_sync_skips_when_source_disabled():
+    entra = _make_client(group_ids=["g1"])
+    service = _make_service(entra_client=entra, entra_enabled=False)
     user = _make_user()
-    await service.sync_user_group_memberships(user, enabled=False)
-    service._directory_client.get_user_group_ids.assert_not_called()
+    await service.sync_user_group_memberships(user)
+    entra.get_user_group_ids.assert_not_called()
 
 
 async def test_sync_skips_when_idOnTheSource_is_none():
     service = _make_service()
     user = _make_user()
     user.idOnTheSource = None
-    await service.sync_user_group_memberships(user, enabled=True)
-    service._directory_client.get_user_group_ids.assert_not_called()
+    await service.sync_user_group_memberships(user)
+    _entra_client(service).get_user_group_ids.assert_not_called()
 
 
 async def test_sync_skips_when_idOnTheSource_is_empty_string():
     service = _make_service()
     user = _make_user()
     user.idOnTheSource = ""
-    await service.sync_user_group_memberships(user, enabled=True)
-    service._directory_client.get_user_group_ids.assert_not_called()
+    await service.sync_user_group_memberships(user)
+    _entra_client(service).get_user_group_ids.assert_not_called()
 
 
-async def test_sync_skips_db_write_when_graph_returns_empty_list():
-    """Empty list from Graph must not touch DB (protects against transient failures)."""
-    service = _make_service(client_group_ids=[])
+async def test_sync_skips_db_write_when_directory_returns_empty_list():
+    """Empty list from the directory must not touch DB (protects against transient failures)."""
+    service = _make_service(entra_client=_make_client(group_ids=[]))
     user = _make_user()
 
-    with patch("registry.services.group_service.Group") as mock_group_cls:
-        await service.sync_user_group_memberships(user, enabled=True)
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
+        await service.sync_user_group_memberships(user)
         mock_group_cls.find.assert_not_called()
 
 
 async def test_sync_adds_user_to_existing_entra_group():
-    """User is bulk-added to Entra groups that already exist in DB."""
-    service = _make_service(client_group_ids=["g1"])
+    """User is bulk-added to groups that already exist in DB."""
+    service = _make_service(entra_client=_make_client(group_ids=["g1"]))
     user = _make_user(oid="oid-user")
 
     existing_group = MagicMock()
@@ -85,64 +110,100 @@ async def test_sync_adds_user_to_existing_entra_group():
     find_mock.update_many = AsyncMock()
     find_mock.to_list = AsyncMock(return_value=[existing_group])
 
-    with patch("registry.services.group_service.Group") as mock_group_cls:
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
         mock_group_cls.find.return_value = find_mock
-        await service.sync_user_group_memberships(user, enabled=True)
+        await service.sync_user_group_memberships(user)
 
-    # Group.find must have been called at least twice:
-    # once for $addToSet on existing groups, once to fetch existing list
     assert mock_group_cls.find.call_count >= 2
 
 
-async def test_sync_fetches_details_for_missing_groups():
-    """Groups not in DB trigger a get_group_details_batch call."""
-    service = _make_service(
-        client_group_ids=["g-new"],
-        client_details=[{"id": "g-new", "name": "New Group", "email": "ng@example.com", "description": "desc"}],
+async def test_sync_google_user_uses_google_client_not_entra():
+    """A provider='google' user must sync against the Google directory client only."""
+    entra = _make_client(group_ids=["entra-g"])
+    google = _make_client(group_ids=[])  # empty -> no DB writes, short-circuits after fetch
+    service = _make_service(entra_client=entra, google_client=google)
+    user = _make_user(provider="google")
+
+    await service.sync_user_group_memberships(user)
+
+    google.get_user_group_ids.assert_called_once_with(user.idOnTheSource)
+    entra.get_user_group_ids.assert_not_called()
+
+
+async def test_sync_google_upserts_with_google_source():
+    """New Google groups are upserted with source=GOOGLE."""
+    google = _make_client(
+        group_ids=["groups/1"],
+        details=[{"id": "groups/1", "name": "G", "email": "g@corp.com", "description": "d"}],
     )
-    user = _make_user()
+    service = _make_service(google_client=google)
+    user = _make_user(provider="google")
 
     find_mock = MagicMock()
     find_mock.update_many = AsyncMock()
     find_mock.to_list = AsyncMock(return_value=[])  # nothing in DB
 
-    with patch("registry.services.group_service.Group") as mock_group_cls:
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
         mock_group_cls.find.return_value = find_mock
-        await service.sync_user_group_memberships(user, enabled=True)
+        await service.sync_user_group_memberships(user)
 
-    service._directory_client.get_group_details_batch.assert_called_once_with(["g-new"])
+    google.get_group_details_batch.assert_called_once_with(["groups/1"])
+    # every find() query must be scoped to the GOOGLE source
+    assert all(ExtendedGroupSource.GOOGLE in str(c) for c in mock_group_cls.find.call_args_list)
 
 
-async def test_sync_partial_batch_logs_warning_and_skips_unresolved():
-    """Partial $batch result: resolved groups get $addToSet; unresolved ones are skipped with a warning."""
+async def test_sync_fetches_details_for_missing_groups():
+    """Groups not in DB trigger a get_group_details_batch call."""
     service = _make_service(
-        client_group_ids=["g-new-1", "g-new-2"],
-        client_details=[{"id": "g-new-1", "name": "G1", "email": None, "description": None}],
+        entra_client=_make_client(
+            group_ids=["g-new"],
+            details=[{"id": "g-new", "name": "New Group", "email": "ng@example.com", "description": "desc"}],
+        )
     )
     user = _make_user()
 
     find_mock = MagicMock()
     find_mock.update_many = AsyncMock()
-    find_mock.to_list = AsyncMock(return_value=[])  # both groups missing from DB
+    find_mock.to_list = AsyncMock(return_value=[])
 
-    with patch("registry.services.group_service.Group") as mock_group_cls:
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
+        mock_group_cls.find.return_value = find_mock
+        await service.sync_user_group_memberships(user)
+
+    _entra_client(service).get_group_details_batch.assert_called_once_with(["g-new"])
+
+
+async def test_sync_partial_batch_logs_warning_and_skips_unresolved():
+    """Partial batch result: resolved groups get $addToSet; unresolved ones are skipped with a warning."""
+    service = _make_service(
+        entra_client=_make_client(
+            group_ids=["g-new-1", "g-new-2"],
+            details=[{"id": "g-new-1", "name": "G1", "email": None, "description": None}],
+        )
+    )
+    user = _make_user()
+
+    find_mock = MagicMock()
+    find_mock.update_many = AsyncMock()
+    find_mock.to_list = AsyncMock(return_value=[])
+
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
         mock_group_cls.find.return_value = find_mock
         with patch("registry.services.group_service.logger") as mock_logger:
-            await service.sync_user_group_memberships(user, enabled=True)
+            await service.sync_user_group_memberships(user)
             mock_logger.warning.assert_called_once()
             warning_msg = mock_logger.warning.call_args[0][0]
             assert "get_group_details_batch" in warning_msg
 
-    # $addToSet must only reference the resolved group (g-new-1), not g-new-2
     addtoset_calls = [c for c in find_mock.update_many.call_args_list if "$addToSet" in str(c)]
     for call in addtoset_calls:
         query_str = str(call)
-        assert "g-new-2" not in query_str or "$nin" in query_str  # stale removal may mention it
+        assert "g-new-2" not in query_str or "$nin" in query_str
 
 
 async def test_sync_does_not_call_details_when_all_groups_exist():
-    """No details call needed when all Graph groups already exist in DB."""
-    service = _make_service(client_group_ids=["g1"])
+    """No details call needed when all directory groups already exist in DB."""
+    service = _make_service(entra_client=_make_client(group_ids=["g1"]))
     user = _make_user()
 
     existing_group = MagicMock()
@@ -152,16 +213,16 @@ async def test_sync_does_not_call_details_when_all_groups_exist():
     find_mock.update_many = AsyncMock()
     find_mock.to_list = AsyncMock(return_value=[existing_group])
 
-    with patch("registry.services.group_service.Group") as mock_group_cls:
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
         mock_group_cls.find.return_value = find_mock
-        await service.sync_user_group_memberships(user, enabled=True)
+        await service.sync_user_group_memberships(user)
 
-    service._directory_client.get_group_details_batch.assert_not_called()
+    _entra_client(service).get_group_details_batch.assert_not_called()
 
 
 async def test_sync_removes_user_from_stale_groups():
-    """stale removal: user must be $pullAll'd from groups no longer in Graph response."""
-    service = _make_service(client_group_ids=["g1"])
+    """stale removal: user must be $pullAll'd from groups no longer in the directory response."""
+    service = _make_service(entra_client=_make_client(group_ids=["g1"]))
     user = _make_user(oid="oid-user")
 
     existing_group = MagicMock()
@@ -171,74 +232,91 @@ async def test_sync_removes_user_from_stale_groups():
     find_mock.update_many = AsyncMock()
     find_mock.to_list = AsyncMock(return_value=[existing_group])
 
-    with patch("registry.services.group_service.Group") as mock_group_cls:
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
         mock_group_cls.find.return_value = find_mock
-        await service.sync_user_group_memberships(user, enabled=True)
+        await service.sync_user_group_memberships(user)
 
-    # The stale removal query uses {"$nin": group_ids} — verify it was called
     stale_removal_calls = [c for c in mock_group_cls.find.call_args_list if "$nin" in str(c)]
     assert len(stale_removal_calls) == 1
 
 
-async def test_ensure_skips_when_disabled():
-    service = _make_service()
-    with patch("registry.services.group_service.Group") as mock_group_cls:
-        mock_group_cls.get = AsyncMock()
-        await service.ensure_group_principal_exists("some-id", enabled=False)
-        mock_group_cls.get.assert_not_called()
+# ---------------------------------------------------------------------------
+# ensure_group_principal_exists
+# ---------------------------------------------------------------------------
 
 
 async def test_ensure_skips_when_group_not_found():
     service = _make_service()
-    with patch("registry.services.group_service.Group") as mock_group_cls:
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
         mock_group_cls.get = AsyncMock(return_value=None)
-        await service.ensure_group_principal_exists(str(PydanticObjectId()), enabled=True)
-    service._directory_client.get_group_members.assert_not_called()
+        await service.ensure_group_principal_exists(str(PydanticObjectId()))
+    _entra_client(service).get_group_members.assert_not_called()
 
 
 async def test_ensure_skips_for_local_source_group():
     service = _make_service()
-    local_group = _make_group(source=GroupSource.LOCAL)
-    with patch("registry.services.group_service.Group") as mock_group_cls:
+    local_group = _make_group(source=ExtendedGroupSource.LOCAL)
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
         mock_group_cls.get = AsyncMock(return_value=local_group)
-        await service.ensure_group_principal_exists(str(local_group.id), enabled=True)
-    service._directory_client.get_group_members.assert_not_called()
+        await service.ensure_group_principal_exists(str(local_group.id))
+    _entra_client(service).get_group_members.assert_not_called()
+    _google_client(service).get_group_members.assert_not_called()
+
+
+async def test_ensure_skips_when_source_disabled():
+    entra = _make_client(members=["u1"])
+    service = _make_service(entra_client=entra, entra_enabled=False)
+    group = _make_group(source=ExtendedGroupSource.ENTRA)
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
+        mock_group_cls.get = AsyncMock(return_value=group)
+        await service.ensure_group_principal_exists(str(group.id))
+    entra.get_group_members.assert_not_called()
 
 
 async def test_ensure_skips_when_idOnTheSource_is_none():
     service = _make_service()
-    group = _make_group(source=GroupSource.ENTRA)
+    group = _make_group(source=ExtendedGroupSource.ENTRA)
     group.idOnTheSource = None
-    with patch("registry.services.group_service.Group") as mock_group_cls:
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
         mock_group_cls.get = AsyncMock(return_value=group)
-        await service.ensure_group_principal_exists(str(group.id), enabled=True)
-    service._directory_client.get_group_members.assert_not_called()
+        await service.ensure_group_principal_exists(str(group.id))
+    _entra_client(service).get_group_members.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# ensure_group_principal_exists — happy path + error
-# ---------------------------------------------------------------------------
+async def test_ensure_replaces_member_ids_with_full_snapshot_entra():
+    entra = _make_client(members=["u1", "u2", "u3"])
+    service = _make_service(entra_client=entra)
+    group = _make_group(source=ExtendedGroupSource.ENTRA, id_on_source="g-entra")
 
-
-async def test_ensure_replaces_member_ids_with_full_snapshot():
-    service = _make_service(client_members=["u1", "u2", "u3"])
-    group = _make_group(source=GroupSource.ENTRA, id_on_source="g-entra")
-
-    with patch("registry.services.group_service.Group") as mock_group_cls:
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
         mock_group_cls.get = AsyncMock(return_value=group)
-        await service.ensure_group_principal_exists(str(group.id), enabled=True)
+        await service.ensure_group_principal_exists(str(group.id))
 
     group.set.assert_called_once_with({"memberIds": ["u1", "u2", "u3"]})
 
 
-async def test_ensure_propagates_directory_client_error():
-    service = _make_service()
-    service._directory_client.get_group_members = AsyncMock(side_effect=ValueError("graph error"))
-    group = _make_group(source=GroupSource.ENTRA, id_on_source="g-entra")
+async def test_ensure_replaces_member_ids_with_full_snapshot_google():
+    google = _make_client(members=["a@corp.com", "b@corp.com"])
+    service = _make_service(google_client=google)
+    group = _make_group(source=ExtendedGroupSource.GOOGLE, id_on_source="groups/42")
 
-    with patch("registry.services.group_service.Group") as mock_group_cls:
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
+        mock_group_cls.get = AsyncMock(return_value=group)
+        await service.ensure_group_principal_exists(str(group.id))
+
+    google.get_group_members.assert_called_once_with("groups/42")
+    group.set.assert_called_once_with({"memberIds": ["a@corp.com", "b@corp.com"]})
+
+
+async def test_ensure_propagates_directory_client_error():
+    entra = _make_client()
+    entra.get_group_members = AsyncMock(side_effect=ValueError("graph error"))
+    service = _make_service(entra_client=entra)
+    group = _make_group(source=ExtendedGroupSource.ENTRA, id_on_source="g-entra")
+
+    with patch("registry.services.group_service.ExtendedGroup") as mock_group_cls:
         mock_group_cls.get = AsyncMock(return_value=group)
         with patch("registry.services.group_service.logger") as mock_logger:
             with pytest.raises(ValueError, match="graph error"):
-                await service.ensure_group_principal_exists(str(group.id), enabled=True)
+                await service.ensure_group_principal_exists(str(group.id))
             mock_logger.error.assert_called_once()

--- a/registry/tests/unit/services/test_workflow_control_service.py
+++ b/registry/tests/unit/services/test_workflow_control_service.py
@@ -144,11 +144,11 @@ async def test_refresh_triggering_auth_context_uses_current_groups_not_persisted
         AsyncMock(return_value=SimpleNamespace(username="alice-current", idOnTheSource="source-user-1")),
     )
     monkeypatch.setattr(
-        wcs.Group,
+        wcs.ExtendedGroup,
         "find",
         lambda query: SimpleNamespace(to_list=AsyncMock(return_value=[SimpleNamespace(name="workflow-users")])),
     )
-    monkeypatch.setattr(wcs, "map_cognito_groups_to_scopes", MagicMock(return_value=["workflows-read"]))
+    monkeypatch.setattr(wcs, "map_groups_to_scopes", MagicMock(return_value=["workflows-read"]))
 
     ctx = await wcs._refresh_triggering_auth_context(run)
 

--- a/tartufo.toml
+++ b/tartufo.toml
@@ -134,4 +134,6 @@ exclude-signatures = [
     {signature = '53b54a4bcb801bb7e90592f9faca70126d06304d2b1b924a9df2c06d6784d2c9', reason = 'token service unit test moved to registry-pkgs (AS-1811) uses mock encrypted tokens, not credentials'},
     {signature = '42236bdc78f13898514f25cd3fa2e8dcde1112595a917e1e3207ae195fe63249', reason = 'crypto_utils unit test (AS-1811) auth-field fixtures use synthetic secrets, not credentials'},
     {signature = 'ebcee0c2ab0cc8f1b5fc75759f8531043f98a39d219813eaf847e3e3023fa87f', reason = 'crypto_utils unit test (AS-1811) auth-field fixtures use synthetic secrets, not credentials'},
+    {signature = 'f33e3ff36489aefc9922d5b5a4c03ab20301ba84758bc9dee38e8cae43e83cce', reason = 'removed config file path is not credential'},
+    {signature = '98a17f2f79343e964496ea55e7e52755d6f6c15ae9c855c2c6e11ed8f7cdd6ea', reason = 'removed config file path is not credential'},
 ]


### PR DESCRIPTION
## Deployment checklist
>Prerequisite: the login users, the OAuth app (A1), and the SA (A2) must all live in the same Workspace org, with the right permissions granted there. Mixing orgs won't work — a different-org login is blocked, and the SA can't read another org's groups.
### A. Google Cloud / Workspace

**A1. OAuth app (login)**
- Consent screen allows your Workspace users (Internal, or External + test users).
- Authorized redirect URIs:
  - prod: `https://<domain>/auth/oauth2/callback/google`
  - local: `http://localhost:8888/auth/oauth2/callback/google`
- Copy the `client_id` and `client_secret`.

**A2. Service Account (group sync · Cloud Identity)**
- Enable the **Cloud Identity API** on the SA's GCP project.
- In the Workspace, grant the SA **both Groups: Read and Users: Read** (both required — Groups Read alone returns 403 on the member→groups lookup).
- Workspace must be **Enterprise** or **Cloud Identity Premium**.
- Download the SA key JSON.

**A3. Permission groups + members**
- Reuse the same roles as Entra. Create Workspace groups whose **email local-part equals the `scopes.yml` key**:
  - `jarvis-registry-admin`
  - `jarvis-registry-power-user`
  - `jarvis-registry-user`
  - `jarvis-registry-read-only`
- Add each user to the group for their role (same as Entra).

### B. Config (.env / Secrets Manager)

```bash
GOOGLE_CLIENT_ID=<A1 client_id>
GOOGLE_CLIENT_SECRET=<A1 client_secret>
GOOGLE_ENABLED=true
GOOGLE_ALLOWED_HD=<domain>              # optional, restrict to this Workspace domain
GOOGLE_SERVICE_ACCOUNT_KEY_JSON={"type":"service_account",...}   # single line, unquoted
GOOGLE_GROUP_SYNC_ENABLED=true         # default true
AUTH_SERVER_API_PREFIX=/auth           # matches the registered /auth redirect
# AUTH_PROVIDER=google                 # makes Google the default provider (see notes)
```

### C. scopes.yml (group → scope)

Entra and Google **share the same keys**. Reuse the roles you already have — no per-domain keys, nothing to add beyond the existing roles:

```yaml
group_mappings:
  jarvis-registry-user:
    - servers-read
    - agents-read
    - workflows-read
    - mcp-proxy-ops        # only if the user needs the mcpgw proxy
```
