### PR TITLE
Fix:skill frontmatter rendering in frontend

### DIFF
--- a/frontend/src/pages/Skills/skillDraft.test.ts
+++ b/frontend/src/pages/Skills/skillDraft.test.ts
@@ -8,6 +8,7 @@ import {
   createEmptyDraft,
   createSkillMarkdownState,
   parseSkillMarkdown,
+  splitSkillMarkdown,
   toCreateRequest,
   toUpdateRequest,
   updateSkillMarkdownMetadata,
@@ -93,10 +94,41 @@ describe('composeSkillMarkdown', () => {
     expect(parseSkillMarkdown(markdown).frontmatter['allowed-tools']).toBe('');
   });
 
-  test('leaves a null allowedTools (no tool restriction) as YAML null, not an empty string', () => {
+  test('omits a null allowedTools (no tool restriction) entirely, rather than rendering it as null', () => {
     const markdown = composeSkillMarkdown(makeDetail({ allowedTools: null }));
 
-    expect(parseSkillMarkdown(markdown).frontmatter['allowed-tools']).toBeNull();
+    expect(markdown).not.toContain('allowed-tools');
+    expect(parseSkillMarkdown(markdown).frontmatter).not.toHaveProperty('allowed-tools');
+  });
+
+  test('omits any other explicitly-null frontmatter field entirely', () => {
+    const markdown = composeSkillMarkdown(
+      makeDetail({ frontmatter: { license: null, argumentHint: null, custom: 'kept' } }),
+    );
+
+    const parsed = parseSkillMarkdown(markdown);
+    expect(parsed.frontmatter).not.toHaveProperty('license');
+    expect(parsed.frontmatter).not.toHaveProperty('argument-hint');
+    expect(parsed.frontmatter.custom).toBe('kept');
+  });
+
+  test('always renders name first and description second, regardless of collection order', () => {
+    const markdown = composeSkillMarkdown(
+      makeDetail({
+        frontmatter: {
+          license: 'MIT',
+          allowedTools: ['Read'],
+          argumentHint: '[pull-request]',
+        },
+      }),
+    );
+
+    const frontmatterKeys = splitSkillMarkdown(markdown)
+      .frontmatterSource.split('\n')
+      .filter(line => /^[A-Za-z-]+:/.test(line))
+      .map(line => line.split(':')[0]);
+
+    expect(frontmatterKeys.slice(0, 2)).toEqual(['name', 'description']);
   });
 
   test('renders every other array-valued frontmatter field in YAML flow style', () => {

--- a/frontend/src/pages/Skills/skillDraft.ts
+++ b/frontend/src/pages/Skills/skillDraft.ts
@@ -133,6 +133,11 @@ const toKebabCaseFrontmatter = (frontmatter: { [key: string]: JsonValue }): { [k
     Object.entries(frontmatter).map(([key, value]) => [CLAUDE_CODE_FRONTMATTER_KEBAB_KEYS[key] ?? key, value]),
   );
 
+// A null field (e.g. allowedTools with no restriction) means "not set", matching the backend's
+// `exclude_none=True` dump and the CLI's `omitempty` — so it's dropped rather than rendered as `null`.
+const dropNullFrontmatterFields = (frontmatter: { [key: string]: JsonValue }): { [key: string]: JsonValue } =>
+  Object.fromEntries(Object.entries(frontmatter).filter(([, value]) => value !== null));
+
 // Renders `allowed-tools` as a plain space-joined string instead of a YAML list (Claude Code's own
 // preferred style for this field) and every other array-valued field in flow style (`[a, b]`) instead of
 // YAML's default block list style, without changing the parsed value of either.
@@ -203,24 +208,30 @@ export const composeSkillMarkdown = (detail: SkillDetail): string => {
   const inlineBody = parseInlineBodyFrontmatter(detail.body);
   const inlineFrontmatter = normalizeFrontmatterKeys(inlineBody.frontmatter);
   const storedFrontmatter = normalizeFrontmatterKeys(detail.frontmatter);
-  const frontmatter: { [key: string]: JsonValue } = {
+  const rest: { [key: string]: JsonValue } = {
     ...inlineFrontmatter,
     ...storedFrontmatter,
   };
 
-  for (const key of REGISTRY_BOOKKEEPING_FRONTMATTER_KEYS) delete frontmatter[key];
-  frontmatter.name = getSkillDisplayName(detail);
-  frontmatter.description = detail.description;
-  frontmatter.allowedTools =
+  for (const key of REGISTRY_BOOKKEEPING_FRONTMATTER_KEYS) delete rest[key];
+  rest.allowedTools =
     firstDefined(storedFrontmatter.allowedTools, detail.allowedTools, inlineFrontmatter.allowedTools) ?? null;
-  frontmatter.disableModelInvocation =
+  rest.disableModelInvocation =
     firstDefined(
       storedFrontmatter.disableModelInvocation,
       detail.disableModelInvocation,
       inlineFrontmatter.disableModelInvocation,
     ) ?? false;
-  frontmatter.userInvocable =
+  rest.userInvocable =
     firstDefined(storedFrontmatter.userInvocable, detail.userInvocable, inlineFrontmatter.userInvocable) ?? true;
+
+  // name and description always lead the rendered frontmatter; every other field follows in
+  // whatever order it was collected in.
+  const frontmatter: { [key: string]: JsonValue } = {
+    name: getSkillDisplayName(detail),
+    description: detail.description,
+    ...dropNullFrontmatterFields(rest),
+  };
 
   const yaml = stringifyFrontmatterYaml(toKebabCaseFrontmatter(frontmatter));
   const body = inlineBody.body ? `\n${inlineBody.body.replace(/^\n+/, '')}` : '';


### PR DESCRIPTION
  - Do NOT display `null`-valued fields. E.g. `allowed-tools: null` no longer shows up.
  - Make sure `name` is always first and `description` is always second. The rest are not explicitly ordered.