### PR TITLE
Fix(skills): derive name from display title on update, not just create

### DIFF
--- a/frontend/src/pages/Skills/skillDraft.test.ts
+++ b/frontend/src/pages/Skills/skillDraft.test.ts
@@ -12,6 +12,7 @@ import {
   toCreateRequest,
   toUpdateRequest,
   updateSkillMarkdownMetadata,
+  validateDraft,
 } from './skillDraft';
 
 const makeDetail = (overrides: Partial<SkillDetail> = {}): SkillDetail => ({
@@ -356,5 +357,42 @@ future-field:
   test('initializes alwaysApply from detail and defaults new drafts to false', () => {
     expect(createDraft(makeDetail({ alwaysApply: true })).alwaysApply).toBe(true);
     expect(createEmptyDraft('Author').alwaysApply).toBe(false);
+  });
+
+  test('derives an update request name from the display title, same as create', () => {
+    const draft = createDraft(makeDetail({ name: 'old-name', displayTitle: 'Old Name' }));
+    draft.markdown = updateSkillMarkdownMetadata(draft.markdown, { displayTitle: 'New Display Title' });
+
+    expect(toUpdateRequest(draft).name).toBe('new-display-title');
+    expect(toUpdateRequest(draft).name).toBe(toCreateRequest(draft).name);
+  });
+});
+
+describe('validateDraft', () => {
+  test('rejects a create draft whose display title has no usable identifier characters', () => {
+    const draft = createEmptyDraft('Author');
+    draft.markdown = updateSkillMarkdownMetadata(draft.markdown, { displayTitle: '!!!', description: 'A description' });
+
+    const result = validateDraft(draft);
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.message).toMatch(/skill identifier/);
+  });
+
+  test('rejects an update draft whose renamed display title has no usable identifier characters', () => {
+    const draft = createDraft(makeDetail());
+    draft.markdown = updateSkillMarkdownMetadata(draft.markdown, { displayTitle: '@@@' });
+
+    const result = validateDraft(draft);
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.message).toMatch(/skill identifier/);
+  });
+
+  test('accepts an update draft with a valid renamed display title', () => {
+    const draft = createDraft(makeDetail());
+    draft.markdown = updateSkillMarkdownMetadata(draft.markdown, { displayTitle: 'Renamed Skill' });
+
+    expect(validateDraft(draft).valid).toBe(true);
   });
 });

--- a/frontend/src/pages/Skills/skillDraft.ts
+++ b/frontend/src/pages/Skills/skillDraft.ts
@@ -319,7 +319,7 @@ export const validateDraft = (draft: SkillDraft): DraftValidation => {
   }
   if (parsed.body.length > 100_000) return { valid: false, message: 'Skill instructions are too long.' };
   if (!isSkillCategory(draft.category)) return { valid: false, message: 'Choose a valid category.' };
-  if (draft.id === null && !slugifySkillName(parsed.displayTitle)) {
+  if (!slugifySkillName(parsed.displayTitle)) {
     return { valid: false, message: 'Name must include letters or numbers that can form a skill identifier.' };
   }
 
@@ -343,6 +343,7 @@ export const toCreateRequest = (draft: SkillDraft): CreateSkillRequest => {
 export const toUpdateRequest = (draft: SkillDraft): UpdateSkillRequest => {
   const parsed = draft.markdown.parsed;
   return {
+    name: slugifySkillName(parsed.displayTitle),
     displayTitle: parsed.displayTitle,
     description: parsed.description,
     body: parsed.body,


### PR DESCRIPTION
## Summary

Renaming a skill's display title in the editor silently updated only `displayTitle` — the immutable `name`
(which drives the CLI sync-down folder path and SKILL.md identity) never changed, even though the editor's
preview implied it did. Root cause: `toUpdateRequest` never sent `name`, unlike `toCreateRequest`.

## Changes
- `toUpdateRequest` now derives `name: slugifySkillName(displayTitle)` on every save, matching create-time
behavior.
- `validateDraft`'s empty-slug guard now applies to updates too, not just creates.
- Backend rename path (duplicate-check, frontmatter rebuild) and the CLI's ID-based rename handling already
worked correctly — no changes needed there.

## Test plan
- Added 4 tests covering update-name derivation and validation of empty-slug rejection on both create and
update.
- `npx vitest run` — 41/41 passing.
- `npx biome check` — clean.