### PR TITLE
Feature: Claude Code CLI does support URL mode elicitation

### DIFF
--- a/registry/src/registry/mcpgw/tools/utils.py
+++ b/registry/src/registry/mcpgw/tools/utils.py
@@ -57,10 +57,25 @@ def _extract_authenticated_user_context(ctx: Context[ServerSession, McpAppContex
     return user_context
 
 
+def _is_claude_ai_client(client_params: InitializeRequestParams) -> bool:
+    """Return whether the client identifies itself as part of the Claude Desktop / Claude Code CLI family."""
+    return client_params.clientInfo.name.strip().lower().startswith("claude-ai")
+
+
 def _support_url_elicitation(client_params: InitializeRequestParams | None) -> bool:
-    """Return whether an MCP client supports URL-mode elicitation."""
+    """Return whether an MCP client supports URL-mode elicitation.
+
+    Claude Code CLI supports URL-mode elicitation but has a long-standing upstream bug where it
+    fails to declare the `elicitation.url` capability in its `initialize` request (reported, auto-closed
+    for inactivity, not scheduled to be fixed). Every "claude-ai*" client is either Claude Desktop
+    (which declares this capability correctly) or Claude Code CLI (which supports it regardless of the
+    declaration bug), so we treat the whole family as supporting it unconditionally.
+    """
     if client_params is None:
         return False
+
+    if _is_claude_ai_client(client_params):
+        return True
 
     elicitation = client_params.capabilities.elicitation
     if elicitation is None:
@@ -82,7 +97,7 @@ def _get_state_metadata(client_params: InitializeRequestParams | None) -> StateM
     name = client_params.clientInfo.name.strip().lower()
     if name == "visual studio code":
         branding = ClientBranding.VSCODE
-    elif name.startswith("claude-ai"):
+    elif _is_claude_ai_client(client_params):
         branding = ClientBranding.CLAUDE
     elif name.startswith("probe (via mcp-remote") or name.startswith("mcp-stdio-client (via mcp-remote"):
         branding = ClientBranding.CURSOR

--- a/registry/src/registry/mcpgw/tools/utils.py
+++ b/registry/src/registry/mcpgw/tools/utils.py
@@ -57,24 +57,19 @@ def _extract_authenticated_user_context(ctx: Context[ServerSession, McpAppContex
     return user_context
 
 
-def _is_claude_ai_client(client_params: InitializeRequestParams) -> bool:
-    """Return whether the client identifies itself as part of the Claude Desktop / Claude Code CLI family."""
-    return client_params.clientInfo.name.strip().lower().startswith("claude-ai")
-
-
 def _support_url_elicitation(client_params: InitializeRequestParams | None) -> bool:
     """Return whether an MCP client supports URL-mode elicitation.
 
-    Claude Code CLI supports URL-mode elicitation but has a long-standing upstream bug where it
-    fails to declare the `elicitation.url` capability in its `initialize` request (reported, auto-closed
-    for inactivity, not scheduled to be fixed). Every "claude-ai*" client is either Claude Desktop
-    (which declares this capability correctly) or Claude Code CLI (which supports it regardless of the
-    declaration bug), so we treat the whole family as supporting it unconditionally.
+    Claude Code CLI (clientInfo.name "claude-code") supports URL-mode elicitation but has a
+    long-standing upstream bug where it fails to declare the `elicitation.url` capability in its
+    `initialize` request (reported, auto-closed for inactivity, not scheduled to be fixed), so it's
+    trusted unconditionally. Claude Desktop ("claude-ai") declares this capability correctly and
+    needs no such override.
     """
     if client_params is None:
         return False
 
-    if _is_claude_ai_client(client_params):
+    if client_params.clientInfo.name.strip().lower().startswith("claude-code"):
         return True
 
     elicitation = client_params.capabilities.elicitation
@@ -97,7 +92,7 @@ def _get_state_metadata(client_params: InitializeRequestParams | None) -> StateM
     name = client_params.clientInfo.name.strip().lower()
     if name == "visual studio code":
         branding = ClientBranding.VSCODE
-    elif _is_claude_ai_client(client_params):
+    elif name.startswith("claude-ai"):
         branding = ClientBranding.CLAUDE
     elif name.startswith("probe (via mcp-remote") or name.startswith("mcp-stdio-client (via mcp-remote"):
         branding = ClientBranding.CURSOR

--- a/registry/tests/unit/mcpgw/test_server.py
+++ b/registry/tests/unit/mcpgw/test_server.py
@@ -336,26 +336,34 @@ def test_get_state_metadata_notify_flag_matches_url_elicitation_support(
 ):
     """notify_elicitation_complete must mirror _support_url_elicitation for every branding: a session
     is only ever registered in SessionStore (making a later notification possible) when the client
-    supports URL mode elicitation, regardless of which brand it's recognized as. The "claude-ai*" family
-    is always treated as supporting it (see utils._is_claude_ai_client), regardless of what it declares."""
+    supports URL mode elicitation, regardless of which brand it's recognized as. Claude Code CLI
+    ("claude-code") is always treated as supporting it regardless of what it declares."""
     client_params = _make_client_params(client_name, supports_url_elicitation=supports_url_elicitation)
 
     result = utils._get_state_metadata(client_params)
 
-    expected_notify = supports_url_elicitation or client_name.strip().lower().startswith("claude-ai")
+    expected_notify = supports_url_elicitation or client_name.strip().lower().startswith("claude-code")
     assert result["client_branding"] == expected_branding
     assert result["notify_elicitation_complete"] is expected_notify
 
 
 @pytest.mark.parametrize("supports_url_elicitation", [True, False])
-def test_support_url_elicitation_claude_ai_family_always_supported(supports_url_elicitation):
+def test_support_url_elicitation_claude_code_cli_always_supported(supports_url_elicitation):
     """Claude Code CLI supports URL-mode elicitation but has an upstream bug where it fails to declare
-    the capability in `initialize`. Any "claude-ai*" client is trusted regardless of the declared
-    capability, since the only real members of that family (Claude Desktop, Claude Code CLI) both
-    support it in practice."""
-    client_params = _make_client_params("claude-ai/1.0", supports_url_elicitation=supports_url_elicitation)
+    the capability in `initialize`. A "claude-code" client is trusted regardless of the declared
+    capability."""
+    client_params = _make_client_params("claude-code", supports_url_elicitation=supports_url_elicitation)
 
     assert utils._support_url_elicitation(client_params) is True
+
+
+@pytest.mark.parametrize("supports_url_elicitation", [True, False])
+def test_support_url_elicitation_claude_desktop_follows_declared_capability(supports_url_elicitation):
+    """Claude Desktop ("claude-ai") declares this capability correctly, so unlike Claude Code CLI it
+    gets no override and simply follows what it declares."""
+    client_params = _make_client_params("claude-ai/1.0", supports_url_elicitation=supports_url_elicitation)
+
+    assert utils._support_url_elicitation(client_params) is supports_url_elicitation
 
 
 def test_support_url_elicitation_non_claude_client_follows_declared_capability():

--- a/registry/tests/unit/mcpgw/test_server.py
+++ b/registry/tests/unit/mcpgw/test_server.py
@@ -336,13 +336,36 @@ def test_get_state_metadata_notify_flag_matches_url_elicitation_support(
 ):
     """notify_elicitation_complete must mirror _support_url_elicitation for every branding: a session
     is only ever registered in SessionStore (making a later notification possible) when the client
-    supports URL mode elicitation, regardless of which brand it's recognized as."""
+    supports URL mode elicitation, regardless of which brand it's recognized as. The "claude-ai*" family
+    is always treated as supporting it (see utils._is_claude_ai_client), regardless of what it declares."""
     client_params = _make_client_params(client_name, supports_url_elicitation=supports_url_elicitation)
 
     result = utils._get_state_metadata(client_params)
 
+    expected_notify = supports_url_elicitation or client_name.strip().lower().startswith("claude-ai")
     assert result["client_branding"] == expected_branding
-    assert result["notify_elicitation_complete"] is supports_url_elicitation
+    assert result["notify_elicitation_complete"] is expected_notify
+
+
+@pytest.mark.parametrize("supports_url_elicitation", [True, False])
+def test_support_url_elicitation_claude_ai_family_always_supported(supports_url_elicitation):
+    """Claude Code CLI supports URL-mode elicitation but has an upstream bug where it fails to declare
+    the capability in `initialize`. Any "claude-ai*" client is trusted regardless of the declared
+    capability, since the only real members of that family (Claude Desktop, Claude Code CLI) both
+    support it in practice."""
+    client_params = _make_client_params("claude-ai/1.0", supports_url_elicitation=supports_url_elicitation)
+
+    assert utils._support_url_elicitation(client_params) is True
+
+
+def test_support_url_elicitation_non_claude_client_follows_declared_capability():
+    client_params = _make_client_params("some-other-client", supports_url_elicitation=False)
+
+    assert utils._support_url_elicitation(client_params) is False
+
+
+def test_support_url_elicitation_returns_false_for_missing_client_params():
+    assert utils._support_url_elicitation(None) is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Claude Code CLI does support URL mode elicitation, but it declares this capability wrong in the `initialize` request. This is a reported, auto-closed bug and doesn't seem to get fixed in the near future. In this PR, we give the Claude Code MCP client a special treatment—our system considers it as supporting URL mode elicitation even though it declares otherwise according to the MCP spec, strictly speaking. This is a small UX win for Claude Code users, and is not a security loophole for dishonest MCP client software. The "direct connect" mode, which doesn't read `clientInfo`, already unconditionally returns a URL mode elicitation response anyway.